### PR TITLE
feat(widget): A3 Junior Pipeline diagram (#22)

### DIFF
--- a/site/css/widgets/junior-pipeline.css
+++ b/site/css/widgets/junior-pipeline.css
@@ -1,0 +1,392 @@
+/* /widgets/junior-pipeline — two parallel ladders, old + new.
+   Bottom three rungs of the new ladder are visibly "eaten". The whole
+   widget reveals on scroll so the gap registers physically as you read.
+   ------------------------------------------------------------------ */
+
+.pipeline-hero {
+  padding-block: var(--space-7) var(--space-5);
+  border-bottom: 3px solid var(--accent);
+  position: relative;
+}
+
+.pipeline-hero__eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  margin-bottom: var(--space-3);
+}
+
+.pipeline-hero h1 {
+  font-size: var(--fs-2xl);
+  margin-bottom: var(--space-3);
+  max-width: 32ch;
+}
+
+.pipeline-hero__sub {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 56ch;
+  color: var(--fg-soft);
+  margin-bottom: var(--space-3);
+}
+
+.pipeline-hero__warning {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  border-top: 1px dashed var(--accent);
+  border-bottom: 1px dashed var(--accent);
+  padding-block: var(--space-2);
+  margin-block: var(--space-4);
+  max-width: 56ch;
+}
+
+.pipeline-hero__hint {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  margin: 0;
+}
+
+/* ------------------------------------------------------------------
+   LADDERS — two columns side by side. Same trajectory, same number of
+   rungs. The new ladder gets the cracked-rung treatment at the bottom.
+   ------------------------------------------------------------------ */
+
+.pipeline-ladders {
+  padding-block: var(--space-6);
+}
+
+.pipeline-ladders > .wrap {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: clamp(1rem, 4vw, var(--space-5));
+  align-items: start;
+}
+
+.ladder {
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  padding: var(--space-4);
+  position: relative;
+}
+
+.ladder--new {
+  border-color: var(--accent);
+}
+
+.ladder__head {
+  border-bottom: 1px dashed var(--border-strong);
+  padding-bottom: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.ladder__tag {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--muted);
+  border: 1px solid var(--border-strong);
+  padding: 0.15rem 0.55rem;
+  margin-bottom: var(--space-2);
+}
+
+.ladder__tag--alarm {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.ladder__head h3 {
+  font-size: var(--fs-xl);
+  margin: 0 0 var(--space-2);
+}
+
+.ladder__lede {
+  font-family: var(--font-display);
+  font-size: var(--fs-md);
+  color: var(--fg-soft);
+  margin: 0;
+  max-width: 36ch;
+}
+
+/* ------------------------------------------------------------------
+   RUNGS — list. Top of list = master. Bottom = shoot-for-free.
+   Each rung is a button that toggles a detail panel.
+   ------------------------------------------------------------------ */
+
+.rungs {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.rung {
+  opacity: 0;
+  transform: translateY(0.75rem);
+  transition: opacity 600ms var(--ease-snap), transform 600ms var(--ease-snap);
+}
+
+.rung[data-on="true"] {
+  opacity: 1;
+  transform: none;
+}
+
+.rung__btn {
+  width: 100%;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  background: #0d0d0d;
+  border: 1px solid var(--border-strong);
+  color: var(--fg);
+  font: inherit;
+  font-family: var(--font-mono);
+  text-align: left;
+  cursor: pointer;
+  position: relative;
+  transition: border-color 160ms var(--ease-snap),
+    background 160ms var(--ease-snap),
+    transform 160ms var(--ease-snap);
+}
+
+.rung__btn:hover,
+.rung__btn:focus-visible,
+.rung__btn[aria-expanded="true"] {
+  outline: none;
+  border-color: var(--accent);
+  background: #131313;
+  transform: translate(-1px, -1px);
+  box-shadow: 3px 3px 0 var(--accent);
+}
+
+.rung__order {
+  font-size: var(--fs-xs);
+  letter-spacing: 0.18em;
+  color: var(--accent);
+}
+
+.rung__label {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  letter-spacing: -0.01em;
+  color: var(--fg);
+}
+
+.rung__mark {
+  font-size: var(--fs-xs);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.rung__mark--ok {
+  color: var(--fg-soft);
+}
+
+.rung__bar {
+  grid-column: 1 / -1;
+  height: 3px;
+  margin-top: var(--space-2);
+  background: var(--accent);
+  width: 100%;
+}
+
+.rung--old .rung__bar {
+  background: var(--accent);
+}
+
+.rung--new .rung__bar {
+  background: var(--accent);
+}
+
+/* ------------------------------------------------------------------
+   EATEN — bottom three rungs of the new ladder. Slashed, faded,
+   marked. The rung is still visible (so the gap is legible) but
+   visibly chewed.
+   ------------------------------------------------------------------ */
+
+.rung--eaten .rung__btn {
+  background: transparent;
+  border-style: dashed;
+  border-color: var(--rule);
+  color: var(--muted);
+}
+
+.rung--eaten .rung__label {
+  color: var(--muted);
+  text-decoration: line-through;
+  text-decoration-color: var(--accent);
+  text-decoration-thickness: 2px;
+}
+
+.rung--eaten .rung__mark {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.rung--eaten .rung__bar {
+  background: repeating-linear-gradient(
+    90deg,
+    var(--accent) 0 0.6rem,
+    transparent 0.6rem 1.1rem
+  );
+  opacity: 0.85;
+}
+
+.rung--eaten .rung__btn::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    -22deg,
+    transparent 0 0.6rem,
+    rgba(225, 29, 46, 0.18) 0.6rem 0.7rem
+  );
+  mix-blend-mode: screen;
+}
+
+/* ------------------------------------------------------------------
+   DETAIL — the example pulled from source-material/. Toggled via the
+   button's aria-expanded; we set [hidden] in JS so it stays
+   accessible to AT.
+   ------------------------------------------------------------------ */
+
+.rung__detail {
+  margin-top: var(--space-2);
+  padding: var(--space-3);
+  border-left: 3px solid var(--accent);
+  background: #0d0d0d;
+}
+
+.rung__detail[hidden] {
+  display: none;
+}
+
+.rung__summary {
+  font-family: var(--font-display);
+  font-size: var(--fs-md);
+  line-height: 1.4;
+  color: var(--fg);
+  margin: 0 0 var(--space-2);
+  max-width: none;
+}
+
+.rung__example {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  line-height: 1.55;
+  color: var(--fg-soft);
+  border: 0;
+  padding: var(--space-2) 0 0;
+  margin: 0 0 var(--space-2);
+  border-top: 1px dashed var(--border-strong);
+}
+
+.rung__source {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  margin: 0;
+  word-break: break-all;
+}
+
+.rung__source code {
+  font-family: inherit;
+  color: var(--accent);
+  background: transparent;
+  padding: 0;
+}
+
+/* ------------------------------------------------------------------
+   FINAL — the punchline that turns the diagram into a problem
+   ------------------------------------------------------------------ */
+
+.pipeline-final {
+  padding-block: var(--space-7);
+  text-align: center;
+  background: var(--accent);
+  color: var(--accent-ink);
+}
+
+.pipeline-final h2 {
+  font-size: var(--fs-2xl);
+  margin: 0 auto var(--space-3);
+  max-width: 24ch;
+  color: var(--accent-ink);
+}
+
+.pipeline-final p {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 50ch;
+  margin: 0 auto var(--space-4);
+}
+
+.pipeline-final .btn {
+  background: var(--accent-ink);
+  color: var(--accent);
+  border-color: var(--accent-ink);
+  margin: 0 var(--space-1) var(--space-2);
+}
+
+.pipeline-final .btn:hover,
+.pipeline-final .btn:focus-visible {
+  background: var(--bg);
+  color: var(--accent);
+  border-color: var(--bg);
+  box-shadow: 3px 3px 0 var(--accent-ink);
+}
+
+/* ------------------------------------------------------------------
+   RESPONSIVE — stack ladders on narrow viewports. The "new" ladder
+   ends up below the "old" one which preserves the bottom-of-the-page
+   = bottom-of-the-ladder visual logic.
+   ------------------------------------------------------------------ */
+
+@media (max-width: 860px) {
+  .pipeline-ladders > .wrap {
+    grid-template-columns: 1fr;
+    gap: var(--space-4);
+  }
+  .ladder {
+    padding: var(--space-3);
+  }
+  .rung__btn {
+    grid-template-columns: auto 1fr;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+  }
+  .rung__mark {
+    grid-column: 1 / -1;
+    font-size: 0.7rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rung {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+  .rung__btn:hover,
+  .rung__btn:focus-visible,
+  .rung__btn[aria-expanded="true"] {
+    transform: none;
+  }
+}

--- a/site/data/junior-pipeline.json
+++ b/site/data/junior-pipeline.json
@@ -1,0 +1,93 @@
+{
+  "source": "script/talk-framework-v6.md slide 13 + source-material/kevin-friel-pixel-wizard/kevin-friel-full-feature-kk.md",
+  "generated": "hand-curated",
+  "thesis": "How does a young creative learn if there's no market for the entry-level work that teaches you?",
+  "subThesis": "The old career path was a ladder. Each rung paid you to get better at the next one. AI is eating the bottom three. The top still exists — but the staircase to it doesn't.",
+  "warning": "The people who say they have this solved are not being honest with you.",
+  "rungs": [
+    {
+      "id": "shoot-for-free",
+      "label": "Shoot for free",
+      "order": 1,
+      "old": {
+        "summary": "You worked for credit, gas money, exposure. You learned by doing the work nobody would pay for yet.",
+        "example": "Kevin Friel spent years on the wrong side of the gate — long before anyone paid for his shots — earning the heavy version of the job in rooms where 'no' came from producers, legal, and physics, in about that order.",
+        "source": "source-material/kevin-friel-pixel-wizard/kevin-friel-full-feature-kk.md"
+      },
+      "new": {
+        "summary": "AI generates the speculative reel for free. The cost of 'making something to show' is a prompt and ten minutes.",
+        "eaten": true,
+        "example": "Same quality bar that used to ride a $100K budget now ships for $200 in 2.5 days. Who pays an unknown to shoot speculatively when the model does it before lunch?",
+        "source": "source-material/kevin-friel-pixel-wizard/kevin-friel-full-feature-kk.md"
+      }
+    },
+    {
+      "id": "assist",
+      "label": "Assist",
+      "order": 2,
+      "old": {
+        "summary": "You carried cable, loaded mags, ran the second monitor, watched the master work, took notes you didn't know were lessons.",
+        "example": "Kevin describes 'years inside facilities where real-time generative work meant $25K rigs and teams of specialists.' That's where assistants learned — not in classrooms, but in the rooms where the rigs ran.",
+        "source": "source-material/kevin-friel-pixel-wizard/kevin-friel-full-feature-kk.md"
+      },
+      "new": {
+        "summary": "The assistant role is the AI's first job. Roto, cleanup, slate logging, transcription, first-pass comp — gone.",
+        "eaten": true,
+        "example": "ComfyUI graphs, Runway Act 2 body performance, ElevenLabs voice cleanup, Topaz polish — Kevin's actual stack does the work an assistant used to do, with no one apprenticing in the room.",
+        "source": "source-material/kevin-friel-pixel-wizard/kevin-friel-full-feature-kk.md"
+      }
+    },
+    {
+      "id": "junior",
+      "label": "Junior",
+      "order": 3,
+      "old": {
+        "summary": "Your first credited shot. Your first real check. The rate was low, but the rung was real — and you climbed it on the back of the work.",
+        "example": "Twenty-five years deep — DNEG, BRON, MPC. The names on the back of your ticket stub. Kevin earned each rung the long way; that's what 'twenty-five years deep in the machine' actually buys you.",
+        "source": "source-material/kevin-friel-pixel-wizard/kevin-friel-full-feature-kk.md"
+      },
+      "new": {
+        "summary": "The junior tier is where the bottom collapses. The work that taught you, that paid you while you got better — that market is gone.",
+        "eaten": true,
+        "example": "'I spent 25 years learning the Hollywood way. Now I teach people to skip all that and just make things.' Skip the rungs. But the rungs were the school.",
+        "source": "source-material/kevin-friel-pixel-wizard/kevin-friel-full-feature-kk.md"
+      }
+    },
+    {
+      "id": "senior",
+      "label": "Senior",
+      "order": 4,
+      "old": {
+        "summary": "You owned shots, ran the room, mentored juniors, made the call when the model didn't render. Taste forged by ten thousand failed frames.",
+        "example": "Kevin's production brain — chain thinking across Midjourney, Runway, ElevenLabs, ComfyUI, Topaz — only matters because he learned comp on rigs that cost more than a house. Taste is the residue of the climb.",
+        "source": "source-material/kevin-friel-pixel-wizard/kevin-friel-full-feature-kk.md"
+      },
+      "new": {
+        "summary": "Senior survives — but only if you already have it. The path to becoming senior, for a 22-year-old today, is structurally missing.",
+        "eaten": false,
+        "example": "Kevin can teach 1,500+ Curious Refuge students the stack. He can't hand them the twenty-five years that taught him what a finished shot looks like.",
+        "source": "source-material/kevin-friel-pixel-wizard/kevin-friel-full-feature-kk.md"
+      }
+    },
+    {
+      "id": "master",
+      "label": "Master",
+      "order": 5,
+      "old": {
+        "summary": "Decades in. You've seen every tool come and go. Your taste is the work. Your name is on the back of the ticket.",
+        "example": "DNEG. BRON. MPC. The names on the back of your ticket stub. Mr. Pixel Wizard. Twenty-five years of VFX knowledge — 'and I'll tell you everything. That's the Film Club way.'",
+        "source": "source-material/kevin-friel-pixel-wizard/kevin-friel-full-feature-kk.md"
+      },
+      "new": {
+        "summary": "Masters still exist — but the pipeline that produced them is broken. Where the next Kevin comes from is the open question of this decade.",
+        "eaten": false,
+        "example": "'How does a young creative learn if there's no market for the entry-level work that teaches you? The people who say they have this solved are not being honest with you.'",
+        "source": "script/talk-framework-v6.md"
+      }
+    }
+  ],
+  "closing": {
+    "title": "The gap is the problem.",
+    "body": "Three rungs eaten. The senior and master tiers stand on air. The honest answer is: we don't know yet who pays to teach the next generation. Don't trust anyone who says they do."
+  }
+}

--- a/site/js/widgets/junior-pipeline.js
+++ b/site/js/widgets/junior-pipeline.js
@@ -1,0 +1,186 @@
+// /widgets/junior-pipeline — load junior-pipeline.json, render two parallel
+// ladders (old + new). Each rung holds a real example that surfaces on
+// hover/tap. The bottom three rungs of the new ladder are visibly "eaten" —
+// AI mark + cracked rung. IntersectionObserver staggers the reveal so the
+// gap registers physically as you scroll.
+
+const subThesisEl = document.getElementById("sub-thesis");
+const warningEl = document.getElementById("warning");
+const oldRungsEl = document.getElementById("rungs-old");
+const newRungsEl = document.getElementById("rungs-new");
+const closingTitleEl = document.getElementById("closing-title");
+const closingBodyEl = document.getElementById("closing-body");
+
+main();
+
+async function main() {
+  try {
+    const res = await fetch("/data/junior-pipeline.json");
+    if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
+    const data = await res.json();
+
+    if (subThesisEl && data.subThesis) {
+      subThesisEl.textContent = data.subThesis;
+    }
+    if (warningEl && data.warning) {
+      warningEl.textContent = data.warning;
+    }
+    if (closingTitleEl && data.closing && data.closing.title) {
+      closingTitleEl.textContent = data.closing.title;
+    }
+    if (closingBodyEl && data.closing && data.closing.body) {
+      closingBodyEl.textContent = data.closing.body;
+    }
+
+    renderLadder(oldRungsEl, data.rungs, "old");
+    renderLadder(newRungsEl, data.rungs, "new");
+    wireExpansion();
+    observeRungs();
+  } catch (err) {
+    if (oldRungsEl) {
+      oldRungsEl.innerHTML = `<li class="kicker">pipeline data unavailable.</li>`;
+    }
+    console.warn("[junior-pipeline]", err);
+  }
+}
+
+function renderLadder(host, rungs, side) {
+  if (!host || !Array.isArray(rungs)) return;
+  // The old ladder reads bottom-to-top (you climb up). To make the visual
+  // alignment between old/new identical we render top-to-bottom in DOM order
+  // (master at the top, shoot-for-free at the bottom) by reversing — that
+  // way the "eaten" rungs sit at the bottom of the new ladder, where the
+  // ground used to be.
+  const ordered = [...rungs].sort((a, b) => (b.order ?? 0) - (a.order ?? 0));
+  host.innerHTML = ordered
+    .map((rung) => renderRung(rung, side))
+    .join("");
+}
+
+function renderRung(rung, side) {
+  const variant = rung[side] || {};
+  const eaten = side === "new" && variant.eaten === true;
+  const id = `rung-${escapeAttr(side)}-${escapeAttr(rung.id)}`;
+  const order = rung.order ?? "";
+  const labelText = rung.label || rung.id || "";
+  const summary = variant.summary || "";
+  const example = variant.example || "";
+  const source = variant.source || "";
+
+  const stateClass = [
+    "rung",
+    `rung--${escapeAttr(side)}`,
+    eaten ? "rung--eaten" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return `
+    <li class="${stateClass}" data-on="false" data-eaten="${eaten ? "true" : "false"}">
+      <button
+        type="button"
+        class="rung__btn"
+        id="${id}"
+        aria-expanded="false"
+        aria-controls="${id}-detail"
+      >
+        <span class="rung__order">${escapeHTML(String(order).padStart(2, "0"))}</span>
+        <span class="rung__label">${escapeHTML(labelText)}</span>
+        ${
+          eaten
+            ? `<span class="rung__mark" aria-label="Eaten by AI">EATEN BY AI</span>`
+            : `<span class="rung__mark rung__mark--ok" aria-hidden="true">${escapeHTML(side === "new" ? "stands" : "rung")}</span>`
+        }
+        <span class="rung__bar" aria-hidden="true"></span>
+      </button>
+      <div
+        class="rung__detail"
+        id="${id}-detail"
+        role="region"
+        aria-labelledby="${id}"
+        hidden
+      >
+        <p class="rung__summary">${escapeHTML(summary)}</p>
+        ${
+          example
+            ? `<blockquote class="rung__example">${escapeHTML(example)}</blockquote>`
+            : ""
+        }
+        ${
+          source
+            ? `<p class="rung__source">&#x21B3; <code>${escapeHTML(source)}</code></p>`
+            : ""
+        }
+      </div>
+    </li>
+  `;
+}
+
+function wireExpansion() {
+  const buttons = document.querySelectorAll(".rung__btn");
+  buttons.forEach((btn) => {
+    btn.addEventListener("click", () => toggleRung(btn));
+    btn.addEventListener("mouseenter", () => openRung(btn));
+    btn.addEventListener("focus", () => openRung(btn));
+    // We deliberately don't auto-close on mouseleave — keeping it open
+    // makes tap parity easier and lets readers compare across columns.
+  });
+  // Close all when ESC is pressed inside a rung.
+  document.addEventListener("keydown", (ev) => {
+    if (ev.key !== "Escape") return;
+    document.querySelectorAll(".rung__btn[aria-expanded='true']").forEach((b) => {
+      closeRung(b);
+    });
+  });
+}
+
+function toggleRung(btn) {
+  const expanded = btn.getAttribute("aria-expanded") === "true";
+  if (expanded) closeRung(btn);
+  else openRung(btn);
+}
+
+function openRung(btn) {
+  if (btn.getAttribute("aria-expanded") === "true") return;
+  btn.setAttribute("aria-expanded", "true");
+  const detail = document.getElementById(btn.getAttribute("aria-controls"));
+  if (detail) detail.hidden = false;
+}
+
+function closeRung(btn) {
+  btn.setAttribute("aria-expanded", "false");
+  const detail = document.getElementById(btn.getAttribute("aria-controls"));
+  if (detail) detail.hidden = true;
+}
+
+function observeRungs() {
+  const rungs = document.querySelectorAll(".rung");
+  if (!rungs.length) return;
+  if (typeof IntersectionObserver === "undefined") {
+    rungs.forEach((r) => r.setAttribute("data-on", "true"));
+    return;
+  }
+  const obs = new IntersectionObserver(
+    (entries) => {
+      for (const e of entries) {
+        if (e.isIntersecting) {
+          e.target.setAttribute("data-on", "true");
+          obs.unobserve(e.target);
+        }
+      }
+    },
+    { threshold: 0.2, rootMargin: "0px 0px -8% 0px" }
+  );
+  rungs.forEach((r) => obs.observe(r));
+}
+
+function escapeHTML(s) {
+  return String(s ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function escapeAttr(s) {
+  return escapeHTML(s).replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+}

--- a/site/widgets/junior-pipeline.html
+++ b/site/widgets/junior-pipeline.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Junior Pipeline &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="Two ladders side by side. The old career path: shoot for free, assist, junior, senior, master. The new one with the bottom three rungs eaten by AI — and the gap where craft-formation used to live."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="Junior Pipeline — Punk Rock AI" />
+    <meta property="og:description" content="The bottom three rungs of the creative career ladder are getting eaten. Where do the next masters come from?" />
+    <meta property="og:url" content="https://punkrockai.com/widgets/junior-pipeline.html" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/widgets/junior-pipeline.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main class="pipeline">
+      <section class="pipeline-hero grain scanlines">
+        <div class="wrap wrap--narrow">
+          <p class="pipeline-hero__eyebrow">Slide 13 &middot; the missing staircase</p>
+          <h1 id="thesis">How does a young creative learn if there&rsquo;s no market for the entry-level work that teaches you?</h1>
+          <p class="pipeline-hero__sub" id="sub-thesis"></p>
+          <p class="pipeline-hero__warning" id="warning"></p>
+          <p class="pipeline-hero__hint" aria-hidden="true">Hover or tap any rung for a real example.</p>
+        </div>
+      </section>
+
+      <section class="pipeline-ladders" aria-labelledby="ladders-heading">
+        <div class="wrap">
+          <h2 id="ladders-heading" class="sr-only">Old path vs. new path</h2>
+
+          <div class="ladder ladder--old" aria-labelledby="old-ladder-title">
+            <header class="ladder__head">
+              <p class="ladder__tag">Then</p>
+              <h3 id="old-ladder-title">The old ladder</h3>
+              <p class="ladder__lede">Each rung paid you to get better at the next one.</p>
+            </header>
+            <ol class="rungs" id="rungs-old" aria-label="Old career path"></ol>
+          </div>
+
+          <div class="ladder ladder--new" aria-labelledby="new-ladder-title">
+            <header class="ladder__head">
+              <p class="ladder__tag ladder__tag--alarm">Now</p>
+              <h3 id="new-ladder-title">The new ladder</h3>
+              <p class="ladder__lede">AI eats the bottom three. The top stands on air.</p>
+            </header>
+            <ol class="rungs" id="rungs-new" aria-label="New career path"></ol>
+          </div>
+        </div>
+      </section>
+
+      <section class="pipeline-final">
+        <div class="wrap wrap--narrow">
+          <h2 id="closing-title">The gap is the problem.</h2>
+          <p id="closing-body"></p>
+          <a class="btn" href="/widgets/three-documents.html">Write your three documents</a>
+          <a class="btn" href="/lineage.html">Back to lineage</a>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/junior-pipeline.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Phase 4 widget A3 — animated diagram contrasting the old creative-career ladder (shoot-for-free → assist → junior → senior → master) with the new one where the bottom three rungs are visibly eaten by AI, leaving a structural gap where craft-formation used to live. Ties to slide 13.

- Two parallel ladders rendered from `site/data/junior-pipeline.json` (old on the left, new on the right; stacked on mobile).
- Bottom three rungs of the new ladder get a slashed label, dashed border, hatch overlay, and a broken/dotted accent bar so the gap reads at a glance.
- Each rung is a button — hover, focus, or tap surfaces a real example pulled from `source-material/kevin-friel-pixel-wizard/kevin-friel-full-feature-kk.md` (master rung also cites `script/talk-framework-v6.md` for the open-question framing).
- IntersectionObserver staggers the reveal as you scroll. `prefers-reduced-motion` disables the transitions.
- ES module JS, no build step, theme tokens only, escapeHTML/escapeAttr on every innerHTML write that touches data, no inline scripts/styles, no new external script origins (CSP-clean).

Files added:
- `site/widgets/junior-pipeline.html`
- `site/css/widgets/junior-pipeline.css`
- `site/js/widgets/junior-pipeline.js`
- `site/data/junior-pipeline.json`

## Test plan

- [ ] `npm run dev` then open `http://localhost:3000/widgets/junior-pipeline.html` — both ladders render with the same trajectory and the bottom-three gap on the new ladder is visually obvious
- [ ] Hover or focus any rung — example panel expands and cites a `source-material/...` (or `script/...`) path
- [ ] Tap a rung on a phone-sized viewport — same expand behaviour, no horizontal scroll
- [ ] Toggle `prefers-reduced-motion` — reveal animations disabled, layout unchanged
- [ ] Lighthouse perf ≥ 90 on the page
- [ ] CSP: no console violations (no inline scripts, no inline event handlers, no new origins)

Closes #22

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4FVYexCNPKiQT5MS5byvv)_