### PR TITLE
feat(widget): C5 Punk-stack map embed (#36)

### DIFF
--- a/site/css/widgets/punk-stack-map.css
+++ b/site/css/widgets/punk-stack-map.css
@@ -1,0 +1,194 @@
+/* C5 — Map of the punk stack
+   A demonstrative SVG diagram embedded inside /recap.html #stack.
+   Theme tokens only — no new design language. */
+
+.punk-stack-map {
+  margin-block: var(--space-5) 0;
+  padding: var(--space-4);
+  border: 2px solid var(--accent);
+  background: var(--bg-elevated);
+  position: relative;
+}
+
+.punk-stack-map__head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2) var(--space-4);
+  margin-bottom: var(--space-3);
+}
+
+.punk-stack-map__eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  margin: 0;
+}
+
+.punk-stack-map__title {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  margin: 0;
+  color: var(--fg);
+  letter-spacing: -0.01em;
+}
+
+.punk-stack-map__hint {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  margin: 0;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.punk-stack-map__svg-wrap {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+}
+
+.punk-stack-map__svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  max-width: 100%;
+  font-family: var(--font-mono);
+}
+
+/* SVG primitives */
+.punk-stack-map__layer-bg {
+  fill: var(--bg);
+  stroke: var(--border);
+  stroke-width: 1;
+}
+
+.punk-stack-map__layer-label {
+  fill: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.punk-stack-map__node {
+  cursor: default;
+}
+
+.punk-stack-map__node-rect {
+  fill: var(--bg-elevated);
+  stroke: var(--border-strong);
+  stroke-width: 1.5;
+  transition: stroke 120ms var(--ease-snap), fill 120ms var(--ease-snap);
+}
+
+.punk-stack-map__node:hover .punk-stack-map__node-rect,
+.punk-stack-map__node:focus-visible .punk-stack-map__node-rect,
+.punk-stack-map__node[data-active="true"] .punk-stack-map__node-rect {
+  fill: var(--bg);
+  stroke: var(--accent);
+  stroke-width: 2;
+}
+
+.punk-stack-map__node-text {
+  fill: var(--fg);
+  font-size: 11px;
+  pointer-events: none;
+  font-family: var(--font-mono);
+}
+
+.punk-stack-map__node:focus-visible {
+  outline: none;
+}
+
+.punk-stack-map__arrow {
+  stroke: var(--accent);
+  stroke-width: 1.5;
+  fill: none;
+  opacity: 0.7;
+}
+
+.punk-stack-map__arrow-head {
+  fill: var(--accent);
+}
+
+/* Tooltip — absolutely positioned over the SVG, populated by JS. */
+.punk-stack-map__tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: var(--bg);
+  border: 1.5px solid var(--accent);
+  color: var(--fg);
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  line-height: 1.4;
+  max-width: min(28rem, 90%);
+  z-index: 2;
+  opacity: 0;
+  transform: translate(-50%, calc(-100% - 8px));
+  transition: opacity 120ms var(--ease-snap);
+  white-space: normal;
+  word-break: break-word;
+}
+
+.punk-stack-map__tooltip[data-visible="true"] {
+  opacity: 1;
+}
+
+.punk-stack-map__tooltip-path {
+  display: block;
+  color: var(--accent);
+  font-weight: 600;
+  margin-bottom: 2px;
+}
+
+.punk-stack-map__tooltip-meta {
+  display: block;
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.punk-stack-map__tooltip-label {
+  display: block;
+  color: var(--fg-soft);
+  margin-top: 2px;
+}
+
+.punk-stack-map__legend {
+  margin-top: var(--space-3);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.punk-stack-map__legend strong {
+  color: var(--fg);
+  font-weight: 600;
+}
+
+/* Mobile: SVG is responsive via viewBox; no horizontal scroll. */
+@media (max-width: 600px) {
+  .punk-stack-map {
+    padding: var(--space-3);
+  }
+  .punk-stack-map__hint {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .punk-stack-map__node-rect,
+  .punk-stack-map__tooltip {
+    transition: none;
+  }
+}

--- a/site/data/punk-stack.json
+++ b/site/data/punk-stack.json
@@ -1,0 +1,69 @@
+{
+  "generated": "2026-05-03",
+  "note": "Map of the punk stack: source markdown -> build scripts -> JSON manifests -> page widgets -> exports. Line counts captured at implementation time (see recap PR #36).",
+  "layers": [
+    {
+      "id": "markdown",
+      "title": "Source markdown",
+      "blurb": "Hand-edited prose lives in the repo as plain text.",
+      "items": [
+        { "path": "script/talk-framework-v6.md", "lines": 323, "label": "talk-framework-v6.md" },
+        { "path": "script/creativity-biography.md", "lines": 211, "label": "creativity-biography.md" },
+        { "path": "dress-rehearsal/elevenlabs-full-script.md", "lines": 278, "label": "elevenlabs-full-script.md" }
+      ]
+    },
+    {
+      "id": "scripts",
+      "title": "Build scripts",
+      "blurb": "Node ES modules in scripts/ — run by hand, never at request time.",
+      "items": [
+        { "path": "scripts/build-quotes.mjs", "lines": 198, "label": "build-quotes.mjs" },
+        { "path": "scripts/build-lineage.mjs", "lines": 51, "label": "build-lineage.mjs" },
+        { "path": "scripts/build-library-index.mjs", "lines": 153, "label": "build-library-index.mjs" },
+        { "path": "scripts/build-audio-cues.mjs", "lines": 160, "label": "build-audio-cues.mjs" },
+        { "path": "scripts/build-decisions.mjs", "lines": 210, "label": "build-decisions.mjs" },
+        { "path": "scripts/ingest-slides.mjs", "lines": 210, "label": "ingest-slides.mjs" }
+      ]
+    },
+    {
+      "id": "manifests",
+      "title": "JSON manifests",
+      "blurb": "Static contracts. Pages only read JSON; no runtime computation.",
+      "items": [
+        { "path": "site/data/quotes.json", "lines": 178, "label": "quotes.json" },
+        { "path": "site/data/slides.json", "lines": 249, "label": "slides.json" },
+        { "path": "site/data/lineage.json", "lines": 130, "label": "lineage.json" },
+        { "path": "site/data/library.json", "lines": 5672, "label": "library.json" },
+        { "path": "site/data/audio-cues.json", "lines": 223, "label": "audio-cues.json" },
+        { "path": "site/data/decisions.json", "lines": 216, "label": "decisions.json" }
+      ]
+    },
+    {
+      "id": "widgets",
+      "title": "Page widgets",
+      "blurb": "One HTML file per widget. Each ES module owns one job.",
+      "items": [
+        { "path": "site/widgets/three-documents.html", "lines": 164, "label": "three-documents.html" },
+        { "path": "site/widgets/both-hands.html", "lines": 88, "label": "both-hands.html" },
+        { "path": "site/widgets/name-what-you-see.html", "lines": 83, "label": "name-what-you-see.html" },
+        { "path": "site/widgets/taste-audit.html", "lines": 101, "label": "taste-audit.html" },
+        { "path": "site/widgets/pattern-finder.html", "lines": 95, "label": "pattern-finder.html" },
+        { "path": "site/widgets/selector.html", "lines": 85, "label": "selector.html" },
+        { "path": "site/widgets/cut-up.html", "lines": 105, "label": "cut-up.html" },
+        { "path": "site/widgets/word-ban.html", "lines": 100, "label": "word-ban.html" },
+        { "path": "site/widgets/bias-bingo.html", "lines": 76, "label": "bias-bingo.html" }
+      ]
+    },
+    {
+      "id": "exports",
+      "title": "Exports",
+      "blurb": "What leaves the browser: PNGs, share hashes, R2-hosted audio.",
+      "items": [
+        { "path": "html-to-image PNG", "lines": 0, "label": "Both Hands canvas -> PNG" },
+        { "path": "#s=<base64> share hash", "lines": 0, "label": "no-server share link" },
+        { "path": "R2 // per-slide.mp3", "lines": 0, "label": "ElevenLabs audio on R2" },
+        { "path": "Markdown export", "lines": 0, "label": "Three Documents .md" }
+      ]
+    }
+  ]
+}

--- a/site/js/widgets/punk-stack-map.js
+++ b/site/js/widgets/punk-stack-map.js
@@ -1,0 +1,282 @@
+// C5 — Map of the punk stack
+// Renders an inline SVG diagram embedded in /recap.html. Hover (or focus, or
+// tap) any node to see its real file path + line count from
+// /data/punk-stack.json. No build step. No D3. Pure DOM APIs.
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const VIEW_W = 960;
+const VIEW_H = 360;
+const COL_GAP = 36;
+const COLS = 5;
+const COL_W = (VIEW_W - COL_GAP * (COLS + 1)) / COLS; // ~165
+const NODE_H = 26;
+const NODE_GAP = 6;
+const HEADER_Y = 28;
+const NODES_TOP = 56;
+const MAX_NODES_PER_COL = 8;
+
+const root = document.getElementById("punk-stack-map");
+if (root) main();
+
+async function main() {
+  try {
+    const res = await fetch("/data/punk-stack.json");
+    if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
+    const data = await res.json();
+    render(root, data);
+  } catch (err) {
+    console.warn("[punk-stack-map]", err);
+    if (root) {
+      const note = document.createElement("p");
+      note.className = "punk-stack-map__hint";
+      note.textContent = "Stack map unavailable.";
+      root.appendChild(note);
+    }
+  }
+}
+
+function render(host, data) {
+  const layers = (data.layers || []).slice(0, COLS);
+  if (!layers.length) return;
+
+  const svgWrap = host.querySelector("[data-stack-svg-wrap]");
+  const tooltip = host.querySelector("[data-stack-tooltip]");
+  if (!svgWrap || !tooltip) return;
+
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("class", "punk-stack-map__svg");
+  svg.setAttribute("viewBox", `0 0 ${VIEW_W} ${VIEW_H}`);
+  svg.setAttribute("role", "img");
+  svg.setAttribute(
+    "aria-label",
+    "Diagram of the build pipeline: source markdown to build scripts to JSON manifests to page widgets to exports."
+  );
+  svg.setAttribute("preserveAspectRatio", "xMidYMid meet");
+
+  // arrow-head marker once
+  const defs = el("defs");
+  const marker = el("marker", {
+    id: "punk-stack-arrow",
+    viewBox: "0 0 10 10",
+    refX: "8",
+    refY: "5",
+    markerWidth: "7",
+    markerHeight: "7",
+    orient: "auto-start-reverse",
+  });
+  const arrowPath = el("path", {
+    d: "M0,0 L10,5 L0,10 z",
+    class: "punk-stack-map__arrow-head",
+  });
+  marker.appendChild(arrowPath);
+  defs.appendChild(marker);
+  svg.appendChild(defs);
+
+  // measure column heights so layer panels and arrows align
+  const cols = layers.map((layer, i) => {
+    const items = layer.items.slice(0, MAX_NODES_PER_COL);
+    const x = COL_GAP + i * (COL_W + COL_GAP);
+    const colHeight =
+      NODES_TOP + items.length * (NODE_H + NODE_GAP) - NODE_GAP + 14;
+    return { layer, items, x, colHeight, index: i };
+  });
+
+  // background panels per layer
+  cols.forEach((col) => {
+    const bg = el("rect", {
+      x: col.x - 8,
+      y: 12,
+      width: COL_W + 16,
+      height: col.colHeight,
+      rx: 2,
+      ry: 2,
+      class: "punk-stack-map__layer-bg",
+    });
+    svg.appendChild(bg);
+
+    const headerText = el("text", {
+      x: col.x + COL_W / 2,
+      y: HEADER_Y,
+      "text-anchor": "middle",
+      class: "punk-stack-map__layer-label",
+    });
+    headerText.textContent = `0${col.index + 1} · ${col.layer.title}`;
+    svg.appendChild(headerText);
+  });
+
+  // arrows between adjacent columns (drawn before nodes so nodes sit on top)
+  for (let i = 0; i < cols.length - 1; i++) {
+    const a = cols[i];
+    const b = cols[i + 1];
+    const midY = Math.max(a.colHeight, b.colHeight) / 2 + 6;
+    const x1 = a.x + COL_W + 4;
+    const x2 = b.x - 12;
+    const arrow = el("line", {
+      x1,
+      y1: midY,
+      x2,
+      y2: midY,
+      class: "punk-stack-map__arrow",
+      "marker-end": "url(#punk-stack-arrow)",
+    });
+    svg.appendChild(arrow);
+  }
+
+  // nodes — boxes per file
+  cols.forEach((col) => {
+    col.items.forEach((item, j) => {
+      const y = NODES_TOP + j * (NODE_H + NODE_GAP);
+      const node = el("g", {
+        class: "punk-stack-map__node",
+        tabindex: "0",
+        role: "button",
+      });
+      const lineLabel =
+        item.lines > 0 ? `${item.lines} lines` : "no line count";
+      node.setAttribute(
+        "aria-label",
+        `${col.layer.title}: ${item.path} — ${lineLabel}`
+      );
+
+      const rect = el("rect", {
+        x: col.x,
+        y,
+        width: COL_W,
+        height: NODE_H,
+        rx: 1,
+        ry: 1,
+        class: "punk-stack-map__node-rect",
+      });
+      const label = el("text", {
+        x: col.x + 8,
+        y: y + NODE_H / 2 + 4,
+        class: "punk-stack-map__node-text",
+      });
+      label.textContent = truncate(item.label || item.path, 22);
+
+      node.appendChild(rect);
+      node.appendChild(label);
+
+      // dataset for tooltip
+      node.dataset.path = item.path || "";
+      node.dataset.lines = String(item.lines ?? 0);
+      node.dataset.label = item.label || "";
+      node.dataset.layer = col.layer.title || "";
+
+      attachHandlers(node, host, tooltip);
+      svg.appendChild(node);
+    });
+  });
+
+  svgWrap.appendChild(svg);
+
+  // dismiss tooltip on outside click (touch)
+  document.addEventListener("click", (e) => {
+    if (!host.contains(e.target)) hideTooltip(tooltip, host);
+  });
+}
+
+function attachHandlers(node, host, tooltip) {
+  const show = () => {
+    showTooltip(tooltip, host, node);
+  };
+  const hide = () => {
+    hideTooltip(tooltip, host, node);
+  };
+  node.addEventListener("mouseenter", show);
+  node.addEventListener("mouseleave", hide);
+  node.addEventListener("focus", show);
+  node.addEventListener("blur", hide);
+  node.addEventListener("click", (e) => {
+    e.stopPropagation();
+    // toggle on touch
+    const wasActive = node.getAttribute("data-active") === "true";
+    // clear other active
+    host
+      .querySelectorAll('.punk-stack-map__node[data-active="true"]')
+      .forEach((n) => n.removeAttribute("data-active"));
+    if (wasActive) {
+      hide();
+    } else {
+      node.setAttribute("data-active", "true");
+      show();
+    }
+  });
+  node.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      show();
+    } else if (e.key === "Escape") {
+      hide();
+    }
+  });
+}
+
+function showTooltip(tooltip, host, node) {
+  const path = node.dataset.path || "";
+  const lines = Number(node.dataset.lines || 0);
+  const label = node.dataset.label || "";
+  const layer = node.dataset.layer || "";
+  // populate via textContent — XSS-safe
+  tooltip.replaceChildren();
+
+  const pathEl = document.createElement("span");
+  pathEl.className = "punk-stack-map__tooltip-path";
+  pathEl.textContent = path;
+  tooltip.appendChild(pathEl);
+
+  const meta = document.createElement("span");
+  meta.className = "punk-stack-map__tooltip-meta";
+  meta.textContent =
+    lines > 0 ? `${layer} · ${lines} lines` : `${layer} · artifact`;
+  tooltip.appendChild(meta);
+
+  if (label && label !== path) {
+    const lbl = document.createElement("span");
+    lbl.className = "punk-stack-map__tooltip-label";
+    lbl.textContent = label;
+    tooltip.appendChild(lbl);
+  }
+
+  // position: above the node, clamped to host bounds
+  const hostRect = host.getBoundingClientRect();
+  const nodeRect = node.getBoundingClientRect();
+  const cx = nodeRect.left + nodeRect.width / 2 - hostRect.left;
+  const cy = nodeRect.top - hostRect.top;
+  // clamp horizontally so the tooltip doesn't bleed off
+  const minX = 12;
+  const maxX = hostRect.width - 12;
+  const x = Math.max(minX, Math.min(maxX, cx));
+  tooltip.style.left = `${x}px`;
+  tooltip.style.top = `${cy}px`;
+  tooltip.setAttribute("data-visible", "true");
+}
+
+function hideTooltip(tooltip, host, node) {
+  // don't hide while an active (clicked) node still owns it
+  if (host && !node) {
+    tooltip.removeAttribute("data-visible");
+    return;
+  }
+  if (
+    host &&
+    host.querySelector('.punk-stack-map__node[data-active="true"]')
+  ) {
+    return;
+  }
+  tooltip.removeAttribute("data-visible");
+}
+
+function el(tag, attrs = {}) {
+  const node = document.createElementNS(SVG_NS, tag);
+  for (const [k, v] of Object.entries(attrs)) {
+    if (v == null) continue;
+    node.setAttribute(k, String(v));
+  }
+  return node;
+}
+
+function truncate(s, n) {
+  const str = String(s ?? "");
+  return str.length > n ? str.slice(0, n - 1) + "…" : str;
+}

--- a/site/recap.html
+++ b/site/recap.html
@@ -17,6 +17,7 @@
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/widgets/recap.css" />
+    <link rel="stylesheet" href="/css/widgets/punk-stack-map.css" />
   </head>
   <body class="shell recap">
     <header class="site-header" data-include="header"></header>
@@ -503,6 +504,21 @@
                 <a href="/talk.html#q-15-if-your-values-aren-t-in-text">Slide 18 &middot; Three Documents</a>
               </span>
             </aside>
+
+            <aside id="punk-stack-map" class="punk-stack-map" aria-labelledby="punk-stack-map-title">
+              <header class="punk-stack-map__head">
+                <p class="punk-stack-map__eyebrow">C5 &middot; map of the punk stack</p>
+                <h3 id="punk-stack-map-title" class="punk-stack-map__title">Markdown &rarr; scripts &rarr; manifests &rarr; widgets &rarr; exports.</h3>
+                <p class="punk-stack-map__hint">Hover any box for the file path + line count.</p>
+              </header>
+              <div class="punk-stack-map__svg-wrap" data-stack-svg-wrap>
+                <div class="punk-stack-map__tooltip" role="status" aria-live="polite" data-stack-tooltip></div>
+              </div>
+              <p class="punk-stack-map__legend">
+                <span><strong>Direction:</strong> left to right, build time to runtime.</span>
+                <span><strong>Counts:</strong> live <code>wc -l</code> snapshot at PR time.</span>
+              </p>
+            </aside>
           </div>
         </section>
 
@@ -643,5 +659,6 @@
 
     <script type="module" src="/js/common/header.js"></script>
     <script type="module" src="/js/widgets/recap.js"></script>
+    <script type="module" src="/js/widgets/punk-stack-map.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

C5 — Map of the punk stack. An inline SVG diagram embedded inside `/recap.html` (`#stack` section) showing the full build pipeline at a glance: source markdown → build scripts → JSON manifests → page widgets → exports. Hovering, focusing, or tapping any box reveals the real file path and live `wc -l` line count via an aria-live tooltip.

- **New** `site/css/widgets/punk-stack-map.css` — theme-token-only styling (`--accent`, `--bg`, `--bg-elevated`, `--fg`, `--muted`, `--border`). Tooltip is plain CSS. Mobile-friendly via `viewBox`; no horizontal scroll.
- **New** `site/js/widgets/punk-stack-map.js` — vanilla DOM SVG renderer using `document.createElementNS`. Reads `/data/punk-stack.json`, builds five layer columns and arrow-headed flow lines, wires `mouseenter`/`focus`/`click` handlers (so touch devices get a tap-to-reveal). Tooltip content set via `textContent` — XSS-safe. No D3, no CDN.
- **New** `site/data/punk-stack.json` — five layers, real repo paths with line-count snapshots taken at PR time.
- **Modified** `site/recap.html` — links the new CSS, embeds the `<aside id="punk-stack-map">` callout inside the `#stack` section right after the existing pull-quote, loads the new module with `defer`. No CSP / `_headers` / `_redirects` / `index.html` changes.

### Line-count snapshot (`wc -l`, captured 2026-05-03)

| Layer | Files |
|---|---|
| markdown | `script/talk-framework-v6.md` 323, `script/creativity-biography.md` 211, `dress-rehearsal/elevenlabs-full-script.md` 278 |
| scripts | `build-quotes.mjs` 198, `build-lineage.mjs` 51, `build-library-index.mjs` 153, `build-audio-cues.mjs` 160, `build-decisions.mjs` 210, `ingest-slides.mjs` 210 |
| manifests | `quotes.json` 178, `slides.json` 249, `lineage.json` 130, `library.json` 5672, `audio-cues.json` 223, `decisions.json` 216 |
| widgets | `three-documents.html` 164, `both-hands.html` 88, `name-what-you-see.html` 83, `taste-audit.html` 101, `pattern-finder.html` 95, `selector.html` 85, `cut-up.html` 105, `word-ban.html` 100, `bias-bingo.html` 76 |
| exports | html-to-image PNG, `#s=` share hash, R2 audio, Markdown export |

## Test plan

- [ ] `/recap.html` loads, the new C5 callout renders inside the "punk stack" section
- [ ] Hovering a box surfaces tooltip with path + line count
- [ ] Keyboard tab navigates the boxes; Enter/Space surfaces tooltip; Escape hides
- [ ] Tap-to-reveal works on touch
- [ ] No horizontal scroll at 375px width
- [ ] No console errors; no new network calls beyond `/data/punk-stack.json`

Closes #36.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4FVYexCNPKiQT5MS5byvv)_