### PR TITLE
feat(widget): C1 Chainsaws of history (#32)

### DIFF
--- a/site/css/widgets/chainsaws.css
+++ b/site/css/widgets/chainsaws.css
@@ -1,0 +1,344 @@
+/* /widgets/chainsaws — scrollable showcase of "neutral" tools and the
+   wrong-on-purpose use that made each one matter. Mirrors the lineage
+   pattern: hero with anchor quote, scroll-revealed cards, refrain bands
+   between, an accent-block close. Theme tokens only. */
+
+.chainsaws {
+  --card-bg-on: rgba(225, 29, 46, 0.08);
+}
+
+/* ------------------------------------------------------------------
+   HERO — Anthony Joseph anchor quote + thesis
+   ------------------------------------------------------------------ */
+
+.chainsaws-hero {
+  padding-block: var(--space-7) var(--space-6);
+  border-bottom: 3px solid var(--accent);
+  position: relative;
+}
+
+.chainsaws-hero__eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  margin-bottom: var(--space-3);
+}
+
+.chainsaws-hero__quote {
+  margin: 0 0 var(--space-5);
+  padding: var(--space-3) var(--space-4);
+  border-left: 3px solid var(--accent);
+  background: var(--bg-elevated);
+  max-width: 60ch;
+}
+
+.chainsaws-hero__quote-text {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: clamp(1.4rem, 3.6vw, 2rem);
+  line-height: 1.2;
+  margin: 0 0 var(--space-3);
+  color: var(--fg);
+}
+
+.chainsaws-hero__quote-text::before {
+  content: "\201C";
+  color: var(--accent);
+  margin-right: 0.1em;
+}
+
+.chainsaws-hero__quote-text::after {
+  content: "\201D";
+  color: var(--accent);
+  margin-left: 0.05em;
+}
+
+.chainsaws-hero__quote-cite {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.1em;
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.chainsaws-hero__quote-cite cite {
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-style: normal;
+}
+
+.chainsaws-hero__quote-source {
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  letter-spacing: 0.08em;
+}
+
+.chainsaws-hero h1 {
+  font-size: var(--fs-2xl);
+  margin-bottom: var(--space-3);
+  max-width: 22ch;
+}
+
+.chainsaws-hero__sub {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 56ch;
+  color: var(--fg-soft);
+}
+
+.chainsaws-trail {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.chainsaws-trail a {
+  color: var(--muted);
+  text-decoration: none;
+  border: 1px solid var(--border-strong);
+  padding: 0.25rem 0.6rem;
+}
+
+.chainsaws-trail a:hover,
+.chainsaws-trail a:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent);
+  outline: none;
+}
+
+/* ------------------------------------------------------------------
+   LIST — six tool cards stacked vertically
+   ------------------------------------------------------------------ */
+
+.chainsaws-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.tool-card {
+  padding-block: var(--space-7);
+  border-bottom: 1px solid var(--border);
+  position: relative;
+  scroll-margin-top: var(--space-6);
+  transition: background 600ms var(--ease-snap);
+}
+
+.tool-card[data-on="true"] {
+  background: var(--card-bg-on);
+}
+
+.tool-card__inner {
+  opacity: 0;
+  transform: translateY(2rem);
+  transition: opacity 700ms var(--ease-snap), transform 700ms var(--ease-snap);
+}
+
+.tool-card[data-on="true"] .tool-card__inner {
+  opacity: 1;
+  transform: none;
+}
+
+.tool-card__head {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-4);
+  align-items: baseline;
+  margin-bottom: var(--space-5);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px dashed var(--border-strong);
+}
+
+.tool-card__index {
+  font-family: var(--font-mono);
+  font-size: clamp(2rem, 5vw, 3rem);
+  line-height: 1;
+  color: var(--accent);
+  letter-spacing: -0.02em;
+}
+
+.tool-card__name {
+  font-size: var(--fs-2xl);
+  margin: 0 0 var(--space-1);
+  line-height: 1.05;
+}
+
+.tool-card__era {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--fg-soft);
+  margin: 0;
+}
+
+.tool-card__split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-5);
+  align-items: start;
+}
+
+.tool-card__side {
+  padding: var(--space-3);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+}
+
+.tool-card__side--wrong {
+  border-color: var(--accent);
+  border-left-width: 3px;
+}
+
+.tool-card__label {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--muted);
+  margin: 0 0 var(--space-3);
+}
+
+.tool-card__label--accent {
+  color: var(--accent);
+}
+
+.tool-card__prose {
+  font-family: var(--font-display);
+  font-size: var(--fs-md);
+  line-height: 1.45;
+  color: var(--fg-soft);
+  max-width: 56ch;
+  margin: 0 0 var(--space-3);
+}
+
+.tool-card__side--wrong .tool-card__prose {
+  color: var(--fg);
+}
+
+.tool-card__source {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.tool-card__echo {
+  margin: var(--space-4) 0 0;
+  padding-top: var(--space-3);
+  border-top: 1px dashed var(--border-strong);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  .tool-card {
+    padding-block: var(--space-6);
+  }
+  .tool-card__head {
+    grid-template-columns: 1fr;
+    gap: var(--space-2);
+  }
+  .tool-card__split {
+    grid-template-columns: 1fr;
+    gap: var(--space-3);
+  }
+  .tool-card__name {
+    font-size: var(--fs-xl);
+  }
+}
+
+/* ------------------------------------------------------------------
+   REFRAIN — visible band of "the tool is never neutral" between cards
+   ------------------------------------------------------------------ */
+
+.chainsaws-refrain {
+  list-style: none;
+  padding-block: var(--space-5);
+  text-align: center;
+  border-top: 1px dashed var(--accent);
+  border-bottom: 1px dashed var(--accent);
+  background: var(--bg-elevated);
+}
+
+.chainsaws-refrain__text {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: clamp(1.2rem, 3vw, 1.6rem);
+  margin: 0;
+  color: var(--accent);
+  letter-spacing: -0.01em;
+}
+
+/* ------------------------------------------------------------------
+   FINAL — the turn from history to your problem
+   ------------------------------------------------------------------ */
+
+.chainsaws-final {
+  padding-block: var(--space-7);
+  text-align: center;
+  background: var(--accent);
+  color: var(--accent-ink);
+}
+
+.chainsaws-final h2 {
+  font-size: var(--fs-2xl);
+  margin: 0 auto var(--space-3);
+  max-width: 26ch;
+  color: var(--accent-ink);
+}
+
+.chainsaws-final p {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 48ch;
+  margin: 0 auto var(--space-4);
+}
+
+.chainsaws-final .btn {
+  background: var(--accent-ink);
+  color: var(--accent);
+  border-color: var(--accent-ink);
+}
+
+.chainsaws-final .btn + .btn {
+  margin-left: var(--space-2);
+}
+
+.chainsaws-final .btn:hover,
+.chainsaws-final .btn:focus-visible {
+  background: var(--bg);
+  color: var(--accent);
+  border-color: var(--bg);
+  box-shadow: 3px 3px 0 var(--accent-ink);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tool-card__inner {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+  .tool-card[data-on="true"] {
+    background: transparent;
+  }
+}

--- a/site/data/chainsaws.json
+++ b/site/data/chainsaws.json
@@ -1,0 +1,76 @@
+{
+  "source": "script/talk-framework-v6.md slide 19 + source-material/punk-rock-ai/vancouver-ai-meetup-23-transcript.md",
+  "generated": "hand-curated",
+  "anchor": {
+    "quote": "My ancestors didn't have chainsaws. But they would've used them if they were there.",
+    "speaker": "Anthony Joseph (Isiléyu)",
+    "context": "Squamish Nation Counselor, Indigenous welcome at Vancouver AI Community Meetup #23. The chainsaw is not the betrayal of the carving — it's the next chapter of it. The creative impulse is continuous; the tools change.",
+    "source_path": "source-material/punk-rock-ai/vancouver-ai-meetup-23-transcript.md",
+    "echo": "script/talk-framework-v6.md slide 19"
+  },
+  "thesis": "Every \"neutral\" tool was a corporate spectacle until somebody used it wrong on purpose.",
+  "subThesis": "The pamphlet, the camera, the transmitter, the photocopier, the timeline, the prompt. Each one shipped as a productivity machine. Each one became a weapon for the people who refused to ask permission.",
+  "refrain": "The tool is never neutral. But neither are we.",
+  "tools": [
+    {
+      "id": "printing-press",
+      "name": "Printing press",
+      "era": "1440s — 1500s",
+      "neutral_framing": "A faster scribe. Gutenberg's movable type was sold to the Church and to wealthy patrons as a way to mass-produce indulgences and Latin Bibles — a productivity upgrade for the existing clerical monopoly on the written word.",
+      "neutral_source": "Eisenstein, The Printing Press as an Agent of Change (1979); Wikipedia: Printing press / Gutenberg Bible",
+      "wrong_on_purpose": "Luther translated the Bible into German and printed it cheap. Pamphleteers cranked out vernacular tracts that ordinary people could actually read. Within a generation the Reformation, the scientific revolution, and the modern public sphere all rode on broken-rule presswork the licensors could not contain.",
+      "wrong_source": "Pettegree, Brand Luther (2015); Wikipedia: Reformation, Pamphlet wars",
+      "echo": "script/talk-framework-v6.md slide 5 — Dada lineage"
+    },
+    {
+      "id": "photography",
+      "name": "Photography",
+      "era": "1839 — 1910s",
+      "neutral_framing": "A society portrait machine. Daguerreotype studios sold the camera as a polite mirror for the merchant class — a way to keep a likeness, decorate a parlor, document a pose.",
+      "neutral_source": "Sontag, On Photography (1977); Wikipedia: History of photography",
+      "wrong_on_purpose": "Jacob Riis dragged a flash powder rig into the tenements of the Lower East Side and published How the Other Half Lives (1890). Lewis Hine put child laborers in front of his lens. The same camera that flattered the rich was used wrong on purpose to indict them — muckraking journalism is a photographic invention.",
+      "wrong_source": "Riis, How the Other Half Lives (1890); Hine, NCLC archives, Library of Congress; Wikipedia: Muckraker",
+      "echo": "script/talk-framework-v6.md (Cris's own photography origin, slide 3)"
+    },
+    {
+      "id": "radio",
+      "name": "Radio",
+      "era": "1920s — 1970s",
+      "neutral_framing": "A licensed broadcast utility. National regulators (FCC in the US, Marine Broadcasting Offences Act in the UK) carved the spectrum into commercial and state-run channels. Radio was sold as a one-to-many household appliance for sponsored music and the evening news.",
+      "neutral_source": "Hilmes, Radio Voices (1997); Wikipedia: History of radio, FCC",
+      "wrong_on_purpose": "Pirate stations like Radio Caroline broadcast rock 'n' roll from a ship in the North Sea in 1964. Free Radio Berkeley, Radio Alice in Bologna, the FM punk stations of the 1970s — operators jammed transmitters into attics and boats so the music the licensors wouldn't play could find an audience anyway.",
+      "wrong_source": "Chapman, Selling the Sixties: The Pirates and Pop Music Radio (1992); Wikipedia: Radio Caroline, Pirate radio",
+      "echo": "script/talk-framework-v6.md slide 5 — corporations build, weirdos figure out what it's for"
+    },
+    {
+      "id": "copy-machine",
+      "name": "Copy machine (Xerox)",
+      "era": "1959 — 1980s",
+      "neutral_framing": "An office productivity tool. Xerox sold the 914 as a way to duplicate memos faster — a corporate efficiency upgrade slotted in next to the typewriter and the filing cabinet.",
+      "neutral_source": "Owen, Copies in Seconds (2004); Wikipedia: Xerox 914",
+      "wrong_on_purpose": "Soviet dissidents passed banned literature hand-typed and photocopied as samizdat. Punks in London, New York, and San Francisco — Sniffin' Glue, Search & Destroy, Maximum Rocknroll — turned the office copier into a printing press they didn't have to ask permission to use. Cut-and-paste headlines, smudged toner, anyone could publish.",
+      "wrong_source": "Komaromi, Uncensored: Samizdat Novels and the Quest for Autonomy in Soviet Dissidence (2015); Triggs, Fanzines (2010); Wikipedia: Samizdat, Sniffin' Glue",
+      "echo": "script/talk-framework-v6.md slide 5 — Xerox punks beat"
+    },
+    {
+      "id": "social-media",
+      "name": "Social media",
+      "era": "2004 — present",
+      "neutral_framing": "A neutral connection layer. Facebook, Twitter, Instagram pitched themselves as productivity utilities for friendship and \"giving people the power to build community\" — engagement-optimized newsfeeds dressed up as civic infrastructure.",
+      "neutral_source": "Zuckerberg, Founder's Letter (2012); Zuboff, The Age of Surveillance Capitalism (2019); Wikipedia: Facebook, Twitter",
+      "wrong_on_purpose": "Tunisian and Egyptian organizers used Facebook events and Twitter hashtags to coordinate the 2010–2011 Arab Spring uprisings. Alicia Garza, Patrisse Cullors, and Opal Tometi turned #BlackLivesMatter from a Facebook post into a global movement. Hong Kong protesters used Telegram and AirDrop. The platform optimized for ad clicks; the weirdos used it to organize on the street.",
+      "wrong_source": "Tufekci, Twitter and Tear Gas (2017); Garza, The Purpose of Power (2020); Wikipedia: Arab Spring, Black Lives Matter",
+      "echo": "script/talk-framework-v6.md — \"corporations build the infrastructure, weirdos figure out what it's actually for\""
+    },
+    {
+      "id": "ai",
+      "name": "Generative AI",
+      "era": "2022 — present",
+      "neutral_framing": "An enterprise productivity tool. The model labs sell ChatGPT, Claude, Gemini as average-of-the-internet assistants — write the email faster, summarize the meeting, generate the marketing copy. Speed without judgment is a leaf blower.",
+      "neutral_source": "OpenAI / Anthropic / Google product marketing, 2022–2026; script/talk-framework-v6.md slide 9",
+      "wrong_on_purpose": "Use it wrong on purpose. Feed it your own corpus and ask what you sound like. Train tiny LoRAs on banned styles. Cut up your transcripts and generate against the grain. Pair AI with your three documents — policy, style, worldview — so the machine stops giving you the average of the internet and starts amplifying what makes you you. Build a posse. Pick up the tool. Use it wrong. Share what you learn.",
+      "wrong_source": "script/talk-framework-v6.md slides 17–20 (Three Documents, Posse, Release Day, Slide 19)",
+      "echo": "Slide 19 — Anthony Joseph: they would've used it if it were there"
+    }
+  ]
+}

--- a/site/js/widgets/chainsaws.js
+++ b/site/js/widgets/chainsaws.js
@@ -1,0 +1,163 @@
+// /widgets/chainsaws — load chainsaws.json, render the anchor quote and
+// six tool cards, attach IntersectionObserver so each card reveals once
+// as it enters the viewport. Mirrors the lineage.js pattern: no deps,
+// no inline handlers, escape every interpolation.
+
+const heroQuoteText = document.getElementById("anchor-quote-text");
+const heroQuoteSpeaker = document.getElementById("anchor-quote-speaker");
+const heroQuoteContext = document.getElementById("anchor-quote-context");
+const heroQuoteSource = document.getElementById("anchor-quote-source");
+const thesisEl = document.getElementById("chainsaws-thesis");
+const subEl = document.getElementById("chainsaws-sub");
+const trailEl = document.getElementById("chainsaws-trail");
+const listEl = document.getElementById("chainsaws-list");
+const refrainEl = document.getElementById("chainsaws-refrain");
+
+main();
+
+async function main() {
+  try {
+    const res = await fetch("/data/chainsaws.json");
+    if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
+    const data = await res.json();
+    renderAnchor(data.anchor);
+    if (thesisEl && data.thesis) thesisEl.textContent = data.thesis;
+    if (subEl && data.subThesis) subEl.textContent = data.subThesis;
+    if (refrainEl && data.refrain) refrainEl.textContent = data.refrain;
+    renderTrail(data.tools || []);
+    renderTools(data);
+    observeCards();
+  } catch (err) {
+    if (listEl) {
+      listEl.innerHTML = `<li class="kicker">chainsaws data unavailable.</li>`;
+    }
+    console.warn("[chainsaws]", err);
+  }
+}
+
+function renderAnchor(anchor) {
+  if (!anchor) return;
+  if (heroQuoteText) heroQuoteText.textContent = anchor.quote || "";
+  if (heroQuoteSpeaker) heroQuoteSpeaker.textContent = anchor.speaker || "";
+  if (heroQuoteContext) {
+    heroQuoteContext.textContent = anchor.context
+      ? ` — ${anchor.context}`
+      : "";
+  }
+  if (heroQuoteSource) {
+    const parts = [];
+    if (anchor.source_path) parts.push(anchor.source_path);
+    if (anchor.echo) parts.push(anchor.echo);
+    heroQuoteSource.textContent = parts.length ? `↳ ${parts.join(" · ")}` : "";
+  }
+}
+
+function renderTrail(tools) {
+  if (!trailEl) return;
+  trailEl.innerHTML = tools
+    .map(
+      (t) =>
+        `<a href="#tool-${escapeAttr(t.id)}">${escapeHTML(t.name)}</a>`
+    )
+    .join("");
+}
+
+function renderTools(data) {
+  if (!listEl) return;
+  const tools = data.tools || [];
+  const refrain = data.refrain || "";
+  const out = [];
+  tools.forEach((tool, i) => {
+    out.push(renderTool(tool, i + 1));
+    if (i < tools.length - 1 && refrain) {
+      out.push(refrainHTML(refrain));
+    }
+  });
+  listEl.innerHTML = out.join("");
+}
+
+function renderTool(t, index) {
+  return `
+    <li class="tool-card" id="tool-${escapeAttr(t.id)}" data-on="false">
+      <div class="wrap">
+        <article class="tool-card__inner">
+          <header class="tool-card__head">
+            <span class="tool-card__index">${escapeHTML(String(index).padStart(2, "0"))}</span>
+            <div>
+              <h2 class="tool-card__name">${escapeHTML(t.name)}</h2>
+              <p class="tool-card__era">${escapeHTML(t.era)}</p>
+            </div>
+          </header>
+
+          <div class="tool-card__split">
+            <section class="tool-card__side tool-card__side--neutral">
+              <p class="tool-card__label">The &ldquo;neutral&rdquo; framing</p>
+              <p class="tool-card__prose">${escapeHTML(t.neutral_framing)}</p>
+              ${
+                t.neutral_source
+                  ? `<p class="tool-card__source">↳ ${escapeHTML(t.neutral_source)}</p>`
+                  : ""
+              }
+            </section>
+
+            <section class="tool-card__side tool-card__side--wrong">
+              <p class="tool-card__label tool-card__label--accent">Wrong on purpose</p>
+              <p class="tool-card__prose">${escapeHTML(t.wrong_on_purpose)}</p>
+              ${
+                t.wrong_source
+                  ? `<p class="tool-card__source">↳ ${escapeHTML(t.wrong_source)}</p>`
+                  : ""
+              }
+            </section>
+          </div>
+
+          ${
+            t.echo
+              ? `<p class="tool-card__echo">${escapeHTML(t.echo)}</p>`
+              : ""
+          }
+        </article>
+      </div>
+    </li>
+  `;
+}
+
+function refrainHTML(text) {
+  return `
+    <li class="chainsaws-refrain" aria-hidden="true">
+      <p class="chainsaws-refrain__text">${escapeHTML(text)}</p>
+    </li>
+  `;
+}
+
+function observeCards() {
+  const cards = document.querySelectorAll(".tool-card");
+  if (!cards.length) return;
+  if (typeof IntersectionObserver === "undefined") {
+    cards.forEach((c) => c.setAttribute("data-on", "true"));
+    return;
+  }
+  const obs = new IntersectionObserver(
+    (entries) => {
+      for (const e of entries) {
+        if (e.isIntersecting) {
+          e.target.setAttribute("data-on", "true");
+          obs.unobserve(e.target);
+        }
+      }
+    },
+    { threshold: 0.18, rootMargin: "0px 0px -10% 0px" }
+  );
+  cards.forEach((c) => obs.observe(c));
+}
+
+function escapeHTML(s) {
+  return String(s ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function escapeAttr(s) {
+  return escapeHTML(s).replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+}

--- a/site/widgets/chainsaws.html
+++ b/site/widgets/chainsaws.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Chainsaws of history &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="Anthony Joseph's chainsaw line, mapped onto six &lsquo;neutral&rsquo; tools through history — printing press, photography, radio, copy machine, social media, AI — and the wrong-on-purpose use that made each one matter."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="Chainsaws of history — Punk Rock AI" />
+    <meta property="og:description" content="Every &lsquo;neutral&rsquo; tool was a corporate spectacle until somebody used it wrong on purpose. Six beats from Gutenberg to AI." />
+    <meta property="og:url" content="https://punkrockai.com/widgets/chainsaws.html" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/widgets/chainsaws.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main class="chainsaws">
+      <section class="chainsaws-hero grain scanlines">
+        <div class="wrap wrap--narrow">
+          <p class="chainsaws-hero__eyebrow">Slide 19 &middot; the tool is never neutral</p>
+          <blockquote class="chainsaws-hero__quote" id="anchor-quote">
+            <p class="chainsaws-hero__quote-text" id="anchor-quote-text"></p>
+            <footer class="chainsaws-hero__quote-cite">
+              <cite id="anchor-quote-speaker"></cite>
+              <span id="anchor-quote-context"></span>
+              <span class="chainsaws-hero__quote-source" id="anchor-quote-source"></span>
+            </footer>
+          </blockquote>
+          <h1 id="chainsaws-thesis"></h1>
+          <p class="chainsaws-hero__sub" id="chainsaws-sub"></p>
+          <nav class="chainsaws-trail" id="chainsaws-trail" aria-label="Tools"></nav>
+        </div>
+      </section>
+
+      <ol id="chainsaws-list" class="chainsaws-list" aria-live="polite"></ol>
+
+      <section class="chainsaws-final">
+        <div class="wrap wrap--narrow">
+          <h2>Pick up the tool. Use it wrong on purpose.</h2>
+          <p>
+            The chainsaw is not the betrayal of the carving. It is the next chapter
+            of it. The infrastructure is here. Your taste is the scarce resource.
+            Build a posse. Share what you learn.
+          </p>
+          <a class="btn" href="/widgets/three-documents.html">Write your three documents</a>
+          <a class="btn" href="/lineage.html">See the lineage</a>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <p class="sr-only" id="chainsaws-refrain"></p>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/chainsaws.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

C1 Chainsaws of history widget — Anthony Joseph's chainsaw line ("my ancestors didn't have chainsaws, but they would've used them if they were there") mapped onto six "neutral" tools through history and the wrong-on-purpose use that made each one matter.

- **Hero anchor quote** sourced to the Vancouver AI Meetup #23 transcript (`source-material/punk-rock-ai/vancouver-ai-meetup-23-transcript.md`) and echoed in `script/talk-framework-v6.md` slide 19
- **Six tool cards**, each with both a `neutral_framing` + source and a `wrong_on_purpose` + source:
  - Printing press → vernacular Bibles + Reformation pamphlets (Pettegree, *Brand Luther*)
  - Photography → Riis muckraking + Hine child-labor work (Riis, *How the Other Half Lives*)
  - Radio → pirate stations / Radio Caroline / Free Radio Berkeley (Chapman, *Selling the Sixties*)
  - Copy machine → samizdat + Sniffin' Glue / zines (Komaromi; Triggs, *Fanzines*)
  - Social media → Arab Spring + #BlackLivesMatter (Tufekci, *Twitter and Tear Gas*; Garza, *The Purpose of Power*)
  - Generative AI → use it wrong on purpose, three documents, posse (talk slides 17–20)
- **IntersectionObserver scroll-reveal** with `prefers-reduced-motion` opt-out, refrain bands between cards, accent-block close that bridges to `/widgets/three-documents.html` and `/lineage.html`

## Implementation

- 4 new files only — `site/widgets/chainsaws.html`, `site/css/widgets/chainsaws.css`, `site/js/widgets/chainsaws.js`, `site/data/chainsaws.json`
- Mirrors the `lineage.js` pattern: vanilla ES module, no external deps, local `escapeHTML` / `escapeAttr`, every `innerHTML` write escapes data
- Theme tokens only (`var(--accent)`, `var(--bg)`, `var(--fg)`, `var(--muted)`, etc.) — no new colors
- Mobile-first, `clamp()` typography, no horizontal scroll
- No inline scripts or handlers (CSP-clean)
- Header / footer via existing `data-include` partial system

## Test plan

- [ ] Page loads at `/widgets/chainsaws.html` end-to-end
- [ ] All six canonical tools render in order
- [ ] Anthony Joseph quote anchors the top with speaker + source citation
- [ ] Each tool card shows neutral framing + source AND wrong-on-purpose + source
- [ ] Scroll-reveal fires once per card (no jank on mobile / no re-trigger thrash — observer unobserves on intersect)
- [ ] `prefers-reduced-motion: reduce` disables the reveal transition
- [ ] Trail anchor links scroll to each tool
- [ ] Lighthouse perf ≥ 90 on mobile
- [ ] No console errors when `chainsaws.json` 404s — graceful fallback message

Closes #32

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4FVYexCNPKiQT5MS5byvv)_