### PR TITLE
chore(site): wire Wave 1 widgets into landing grid + clean URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ build/
 .env
 .env.local
 
+# Claude Code harness internals (worktrees, agent transcripts)
+.claude/
+
 # Generated assets bigger than git wants — drop in assets/generated/ to ignore
 assets/generated/
 assets/slides/

--- a/site/_redirects
+++ b/site/_redirects
@@ -12,6 +12,9 @@
 /widgets/name-what-you-see   /widgets/name-what-you-see.html   200
 /widgets/taste-audit         /widgets/taste-audit.html         200
 /widgets/pattern-finder      /widgets/pattern-finder.html      200
+/widgets/junior-pipeline     /widgets/junior-pipeline.html     200
+/widgets/pattern-graph       /widgets/pattern-graph.html       200
+/widgets/chainsaws           /widgets/chainsaws.html           200
 
 # If an old companion-site path leaks, route home.
 /companion-site/*           /                                  301

--- a/site/index.html
+++ b/site/index.html
@@ -249,6 +249,43 @@
                 <span class="card__cta">Scan &rarr;</span>
               </a>
             </li>
+            <li>
+              <a class="card" href="/widgets/junior-pipeline.html">
+                <span class="card__num">15</span>
+                <h3 class="card__title">Junior Pipeline</h3>
+                <p class="card__body">
+                  Two ladders side by side. The old career path. The new one
+                  with the bottom three rungs eaten by AI. Where the next
+                  masters come from is the open question of this decade.
+                </p>
+                <span class="card__cta">See the gap &rarr;</span>
+              </a>
+            </li>
+            <li>
+              <a class="card" href="/widgets/pattern-graph.html">
+                <span class="card__num">16</span>
+                <h3 class="card__title">Pattern cluster graph</h3>
+                <p class="card__body">
+                  Six eras as nodes. Six moves &mdash; cut-up, sampling,
+                  détournement, selection, reuse, refusal &mdash; as edges.
+                  Hover for citations. Click a move to see how the same
+                  gesture manifests across eras.
+                </p>
+                <span class="card__cta">Trace the through-line &rarr;</span>
+              </a>
+            </li>
+            <li>
+              <a class="card" href="/widgets/chainsaws.html">
+                <span class="card__num">17</span>
+                <h3 class="card__title">Chainsaws of history</h3>
+                <p class="card__body">
+                  Every &ldquo;neutral&rdquo; tool was a corporate spectacle
+                  until somebody used it wrong on purpose. Printing press to
+                  AI in six beats, anchored on Anthony Joseph&rsquo;s line.
+                </p>
+                <span class="card__cta">Pick up the tool &rarr;</span>
+              </a>
+            </li>
           </ul>
         </div>
       </section>


### PR DESCRIPTION
## Summary

Adds three landing-page cards under the existing Phase 4 row (#15 Junior Pipeline, #16 Pattern cluster graph, #17 Chainsaws of history) plus the matching clean-URL aliases in `_redirects`. Pure wiring — no widget logic.

Wave 1 widgets already merged via #72, #73, #74, #75. The punk-stack map (#74) is embedded inside `/recap.html` so no card or alias of its own.

## Test plan

- [ ] Visit `/` — three new cards render in the Phase 4 grid in order 15/16/17 with no layout shift.
- [ ] `/widgets/junior-pipeline`, `/widgets/pattern-graph`, `/widgets/chainsaws` all serve the widget HTML via Cloudflare Pages clean URL alias (`200` redirect).
- [ ] CSP and `_headers` unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4FVYexCNPKiQT5MS5byvv)_