### PR TITLE
feat(widget): B1 Mastery Gym tracker (#25)

### DIFF
--- a/site/css/widgets/mastery-gym.css
+++ b/site/css/widgets/mastery-gym.css
@@ -1,0 +1,356 @@
+/* /widgets/mastery-gym.html — daily cycle log, streak, heatmap, .md export */
+
+.gym-intro {
+  padding-block: var(--space-6);
+  border-bottom: 1px solid var(--border);
+}
+
+.gym-intro h1 {
+  margin: 0 0 var(--space-3);
+}
+
+.gym-intro__lede {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 50ch;
+  color: var(--fg-soft);
+}
+
+.gym-intro__hint {
+  margin-top: var(--space-3);
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+/* ------------------------------------------------------------------
+   STATS — streak, total, last
+   ------------------------------------------------------------------ */
+
+.gym-stats {
+  padding-block: var(--space-5);
+  border-bottom: 1px solid var(--border);
+}
+
+.gym-stats__row {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.gym-stat {
+  display: grid;
+  gap: var(--space-1);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  padding: var(--space-3);
+}
+
+.gym-stat__num {
+  font-family: var(--font-display);
+  font-size: var(--fs-2xl);
+  line-height: 1;
+  color: var(--accent);
+  letter-spacing: -0.02em;
+}
+
+.gym-stat__label {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+@media (max-width: 540px) {
+  .gym-stats__row {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ------------------------------------------------------------------
+   CHECK-IN FORM
+   ------------------------------------------------------------------ */
+
+.gym-checkin {
+  padding-block: var(--space-5);
+}
+
+.gym-checkin__head {
+  margin-bottom: var(--space-4);
+}
+
+.gym-checkin__head h2 {
+  margin: var(--space-2) 0;
+}
+
+.gym-checkin__hint {
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  max-width: 60ch;
+  margin: 0;
+}
+
+.gym-form {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.gym-field {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.gym-field__label {
+  display: grid;
+  grid-template-columns: 2.4rem 1fr;
+  grid-template-rows: auto auto;
+  column-gap: var(--space-2);
+  align-items: baseline;
+}
+
+.gym-field__num {
+  grid-row: 1 / span 2;
+  font-family: var(--font-display);
+  font-size: var(--fs-xl);
+  color: var(--accent);
+  font-weight: 700;
+  text-align: right;
+  line-height: 1;
+}
+
+.gym-field__title {
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: var(--fs-sm);
+  color: var(--fg);
+}
+
+.gym-field__hint {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  letter-spacing: 0.04em;
+}
+
+.gym-field textarea,
+.gym-field input[type="text"] {
+  font-family: var(--font-mono);
+}
+
+.gym-tags {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+}
+
+.gym-field--keep .gym-field__num {
+  color: var(--accent);
+}
+
+.gym-field--refuse .gym-field__num {
+  color: var(--fg);
+}
+
+@media (max-width: 640px) {
+  .gym-tags {
+    grid-template-columns: 1fr;
+  }
+}
+
+.gym-form__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.gym-form__status {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  min-height: 1em;
+  margin: 0;
+}
+
+/* ------------------------------------------------------------------
+   HEATMAP — 16 weeks of cycles, today bottom-right
+   ------------------------------------------------------------------ */
+
+.gym-heatmap {
+  padding-block: var(--space-5);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.gym-heatmap__head {
+  margin-bottom: var(--space-4);
+}
+
+.gym-heatmap__head h2 {
+  margin: var(--space-2) 0;
+}
+
+.gym-heatmap__hint {
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  max-width: 60ch;
+  margin: 0;
+}
+
+.gym-heatmap__grid {
+  --cell: clamp(0.7rem, 2.4vw, 1.1rem);
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-rows: repeat(7, var(--cell));
+  grid-auto-columns: var(--cell);
+  gap: 3px;
+  padding: var(--space-2);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  overflow: hidden;
+  max-width: 100%;
+}
+
+.gym-cell {
+  width: var(--cell, 1rem);
+  height: var(--cell, 1rem);
+  display: inline-block;
+  background: #161616;
+  border: 1px solid var(--border);
+  padding: 0;
+  cursor: pointer;
+  transition: transform 120ms var(--ease-snap), outline 120ms var(--ease-snap);
+}
+
+.gym-cell:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  z-index: 2;
+}
+
+.gym-cell:hover {
+  transform: translate(-1px, -1px);
+}
+
+.gym-cell--empty {
+  cursor: default;
+  opacity: 0.35;
+}
+
+.gym-cell--future {
+  background: transparent;
+  border-color: transparent;
+  cursor: default;
+}
+
+.gym-cell--today {
+  outline: 1px dashed var(--accent);
+  outline-offset: 1px;
+}
+
+.gym-cell--l0 {
+  background: #161616;
+  border-color: var(--border);
+}
+
+.gym-cell--l1 {
+  background: color-mix(in srgb, var(--accent) 22%, #161616);
+  border-color: color-mix(in srgb, var(--accent) 30%, var(--border));
+}
+
+.gym-cell--l2 {
+  background: color-mix(in srgb, var(--accent) 55%, #161616);
+  border-color: color-mix(in srgb, var(--accent) 60%, var(--border));
+}
+
+.gym-cell--l3 {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.gym-heatmap__legend {
+  list-style: none;
+  margin: var(--space-3) 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+}
+
+.gym-heatmap__legend li {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.gym-heatmap__legend .gym-cell {
+  cursor: default;
+  width: 0.9rem;
+  height: 0.9rem;
+}
+
+/* ------------------------------------------------------------------
+   EXPORT
+   ------------------------------------------------------------------ */
+
+.gym-export {
+  padding-block: var(--space-5);
+}
+
+.gym-export h2 {
+  margin: 0 0 var(--space-3);
+}
+
+.gym-export__hint {
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  max-width: 60ch;
+  margin: 0 0 var(--space-3);
+}
+
+.gym-export__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.gym-export__preview {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  padding: var(--space-3);
+  max-height: 22rem;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--fg-soft);
+  margin: 0;
+}
+
+.gym-export__preview:empty {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gym-cell {
+    transition: none;
+  }
+  .gym-cell:hover {
+    transform: none;
+  }
+}

--- a/site/js/widgets/mastery-gym.js
+++ b/site/js/widgets/mastery-gym.js
@@ -1,0 +1,452 @@
+// /widgets/mastery-gym.html — daily one-cycle check-in. Streak counter,
+// 16-week heatmap, per-cycle "kept / refused" tags, Markdown export of the
+// last 30 cycles. Pure client-side, localStorage only, works offline.
+
+import { load, save, debounceSave, remove } from "/js/common/storage.js";
+
+const STORAGE_KEY = "gym:cycles";
+const HEATMAP_WEEKS = 16; // ~112 days, today anchors the bottom-right cell
+const EXPORT_LIMIT = 30;
+
+// Day-boundary rule: a streak counts consecutive days ending today OR
+// yesterday (24-hour grace). Missing two full calendar days breaks it.
+
+const els = {
+  form: document.getElementById("gym-form"),
+  tried: document.getElementById("gym-tried"),
+  feedback: document.getElementById("gym-feedback"),
+  iterated: document.getElementById("gym-iterated"),
+  kept: document.getElementById("gym-kept"),
+  refused: document.getElementById("gym-refused"),
+  status: document.getElementById("gym-status"),
+  today: document.querySelector("[data-today]"),
+  title: document.querySelector("[data-checkin-title]"),
+  hint: document.querySelector("[data-checkin-hint]"),
+  streak: document.querySelector('[data-stat="streak"]'),
+  total: document.querySelector('[data-stat="total"]'),
+  last: document.querySelector('[data-stat="last"]'),
+  heatmap: document.getElementById("gym-heatmap"),
+  preview: document.getElementById("gym-preview"),
+  exportBtn: document.querySelector('[data-action="export-md"]'),
+  copyBtn: document.querySelector('[data-action="copy-md"]'),
+  resetBtn: document.querySelector('[data-action="reset"]'),
+  saveBtn: document.querySelector('[data-action="save"]'),
+  clearBtn: document.querySelector('[data-action="clear"]'),
+};
+
+let cycles = []; // [{ date, tried, feedback, iterated, kept, refused, ts }]
+let editingDate = todayISO();
+
+hydrate();
+wireForm();
+wireActions();
+paintToday();
+hydrateFormForDate(editingDate);
+renderAll();
+
+// ---------------------------------------------------------------------------
+
+function hydrate() {
+  const { value } = load(STORAGE_KEY, []);
+  if (Array.isArray(value)) {
+    cycles = value
+      .filter((c) => c && typeof c.date === "string")
+      .map(normalizeCycle);
+  }
+}
+
+function persist() {
+  save(STORAGE_KEY, cycles);
+}
+
+const debouncedPersist = debounceSave(STORAGE_KEY, 350);
+
+function normalizeCycle(c) {
+  return {
+    date: c.date,
+    tried: typeof c.tried === "string" ? c.tried : "",
+    feedback: typeof c.feedback === "string" ? c.feedback : "",
+    iterated: typeof c.iterated === "string" ? c.iterated : "",
+    kept: typeof c.kept === "string" ? c.kept : "",
+    refused: typeof c.refused === "string" ? c.refused : "",
+    ts: typeof c.ts === "number" ? c.ts : Date.now(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// FORM
+
+function wireForm() {
+  if (!els.form) return;
+  els.form.addEventListener("submit", (e) => {
+    e.preventDefault();
+    saveCycle();
+  });
+  els.clearBtn?.addEventListener("click", () => {
+    setFormValues({ tried: "", feedback: "", iterated: "", kept: "", refused: "" });
+    flash("form cleared");
+  });
+
+  // Live-save while typing into today's check-in (so a reload mid-thought
+  // doesn't lose the draft). Only persist once at least one field has content,
+  // so an idle blur doesn't create an empty row.
+  for (const id of ["tried", "feedback", "iterated", "kept", "refused"]) {
+    els[id]?.addEventListener("input", () => {
+      if (editingDate !== todayISO()) return; // don't autosave when reviewing past
+      const entry = buildEntry(editingDate);
+      if (!hasContent(entry)) {
+        // If today's row exists but all fields are now empty, drop it.
+        const existed = cycles.some((c) => c.date === editingDate);
+        if (existed) {
+          cycles = cycles.filter((c) => c.date !== editingDate);
+          debouncedPersist(cycles);
+          paintStats();
+          paintHeatmap();
+        }
+        return;
+      }
+      cycles = upsertCycle(entry);
+      debouncedPersist(cycles);
+      paintStats();
+    });
+  }
+}
+
+function saveCycle() {
+  const entry = buildEntry(editingDate);
+  if (!hasContent(entry)) {
+    flash("nothing to save — write at least one field");
+    return;
+  }
+  cycles = upsertCycle(entry);
+  persist();
+  paintStats();
+  paintHeatmap();
+  flash(editingDate === todayISO() ? "today's cycle saved" : `cycle saved for ${editingDate}`);
+}
+
+function buildEntry(date) {
+  return {
+    date,
+    tried: (els.tried?.value || "").trim(),
+    feedback: (els.feedback?.value || "").trim(),
+    iterated: (els.iterated?.value || "").trim(),
+    kept: (els.kept?.value || "").trim(),
+    refused: (els.refused?.value || "").trim(),
+    ts: Date.now(),
+  };
+}
+
+function hasContent(entry) {
+  return Boolean(entry.tried || entry.feedback || entry.iterated || entry.kept || entry.refused);
+}
+
+function upsertCycle(entry) {
+  const next = cycles.slice();
+  const idx = next.findIndex((c) => c.date === entry.date);
+  if (idx >= 0) {
+    next[idx] = { ...next[idx], ...entry };
+  } else {
+    next.push(entry);
+  }
+  next.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+  return next;
+}
+
+function setFormValues(v) {
+  if (els.tried) els.tried.value = v.tried || "";
+  if (els.feedback) els.feedback.value = v.feedback || "";
+  if (els.iterated) els.iterated.value = v.iterated || "";
+  if (els.kept) els.kept.value = v.kept || "";
+  if (els.refused) els.refused.value = v.refused || "";
+}
+
+function hydrateFormForDate(date) {
+  editingDate = date;
+  const found = cycles.find((c) => c.date === date);
+  setFormValues(found || { tried: "", feedback: "", iterated: "", kept: "", refused: "" });
+  paintCheckinHeader();
+}
+
+function paintCheckinHeader() {
+  if (!els.title || !els.hint) return;
+  const isToday = editingDate === todayISO();
+  if (isToday) {
+    els.title.textContent = "Today's cycle";
+    els.hint.textContent = "Five quick fields. Save updates today's entry — one cycle per calendar day.";
+  } else {
+    els.title.textContent = `Editing ${editingDate}`;
+    els.hint.textContent = "You're reviewing a past day. Save to update that entry, or click today's cell to come back.";
+  }
+  if (els.saveBtn) {
+    els.saveBtn.textContent = isToday ? "Save today's cycle" : `Save ${editingDate}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// RENDER
+
+function renderAll() {
+  paintStats();
+  paintHeatmap();
+}
+
+function paintToday() {
+  if (els.today) els.today.textContent = formatHumanDate(new Date());
+}
+
+function paintStats() {
+  if (els.streak) els.streak.textContent = String(currentStreak(cycles));
+  if (els.total) els.total.textContent = String(cycles.length);
+  if (els.last) {
+    const last = cycles[cycles.length - 1];
+    els.last.textContent = last ? last.date : "—";
+  }
+}
+
+function paintHeatmap() {
+  const grid = els.heatmap;
+  if (!grid) return;
+  grid.innerHTML = "";
+
+  const today = startOfDay(new Date());
+  // Layout: 7 rows × HEATMAP_WEEKS cols, today is bottom-right.
+  // Bottom-right cell is today; we lay out column-by-column.
+  const totalCells = HEATMAP_WEEKS * 7;
+  const lastIdx = totalCells - 1; // bottom-right
+  const dayMs = 86400000;
+
+  const byDate = new Map(cycles.map((c) => [c.date, c]));
+  const todayStr = isoDate(today);
+
+  for (let i = 0; i < totalCells; i++) {
+    const offset = lastIdx - i; // days before today
+    const cellDate = new Date(today.getTime() - offset * dayMs);
+    const dateStr = isoDate(cellDate);
+    const cycle = byDate.get(dateStr);
+    const intensity = intensityFor(cycle);
+    const isToday = dateStr === todayStr;
+
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = `gym-cell gym-cell--l${intensity}`;
+    if (!cycle) btn.classList.add("gym-cell--empty");
+    if (isToday) btn.classList.add("gym-cell--today");
+    btn.dataset.date = dateStr;
+    const labelStatus = cycle ? "checked in" : "no cycle";
+    btn.setAttribute("aria-label", `${dateStr} — ${labelStatus}`);
+    btn.title = cycle
+      ? `${dateStr} — ${summarize(cycle)}`
+      : `${dateStr} — no cycle`;
+    btn.addEventListener("click", () => {
+      hydrateFormForDate(dateStr);
+      els.tried?.focus();
+      flash(`loaded ${dateStr}`);
+    });
+    grid.appendChild(btn);
+  }
+}
+
+// 0–3 intensity buckets based on how many fields were filled.
+function intensityFor(cycle) {
+  if (!cycle) return 0;
+  const filled = ["tried", "feedback", "iterated", "kept", "refused"].filter(
+    (k) => (cycle[k] || "").trim().length > 0
+  ).length;
+  if (filled === 0) return 0;
+  if (filled <= 1) return 1;
+  if (filled <= 3) return 2;
+  return 3;
+}
+
+function summarize(cycle) {
+  const t = (cycle.tried || cycle.feedback || cycle.iterated || "").trim();
+  if (!t) return "checked in";
+  return t.length > 60 ? t.slice(0, 57) + "…" : t;
+}
+
+// ---------------------------------------------------------------------------
+// STREAK
+
+function currentStreak(list) {
+  if (!list.length) return 0;
+  const set = new Set(list.map((c) => c.date));
+  const today = startOfDay(new Date());
+  // Allow a 1-day grace: if today isn't logged but yesterday is, streak still
+  // counts (so the counter doesn't blink to zero each morning before check-in).
+  let cursor = new Date(today.getTime());
+  if (!set.has(isoDate(cursor))) {
+    cursor = new Date(cursor.getTime() - 86400000);
+    if (!set.has(isoDate(cursor))) return 0;
+  }
+  let n = 0;
+  while (set.has(isoDate(cursor))) {
+    n += 1;
+    cursor = new Date(cursor.getTime() - 86400000);
+  }
+  return n;
+}
+
+// ---------------------------------------------------------------------------
+// EXPORT
+
+function wireActions() {
+  els.exportBtn?.addEventListener("click", () => {
+    const md = buildMarkdown(cycles, EXPORT_LIMIT);
+    if (!md) {
+      flash("no cycles yet — log one first");
+      return;
+    }
+    downloadMarkdown(md);
+  });
+  els.copyBtn?.addEventListener("click", async () => {
+    const md = buildMarkdown(cycles, EXPORT_LIMIT);
+    if (!md) {
+      flash("no cycles yet — log one first");
+      return;
+    }
+    if (els.preview) els.preview.textContent = md;
+    try {
+      await navigator.clipboard.writeText(md);
+      flash("markdown copied to clipboard");
+    } catch {
+      flash("couldn't copy — preview shown below");
+    }
+  });
+  els.resetBtn?.addEventListener("click", () => {
+    if (!cycles.length) {
+      flash("nothing to wipe");
+      return;
+    }
+    const ok = window.confirm(
+      `Wipe all ${cycles.length} cycle${cycles.length === 1 ? "" : "s"}? This can't be undone.`
+    );
+    if (!ok) return;
+    cycles = [];
+    remove(STORAGE_KEY);
+    setFormValues({ tried: "", feedback: "", iterated: "", kept: "", refused: "" });
+    if (els.preview) els.preview.textContent = "";
+    renderAll();
+    flash("cycles wiped");
+  });
+}
+
+function buildMarkdown(list, limit) {
+  if (!list.length) return "";
+  // newest first, capped at `limit`
+  const recent = list.slice().sort((a, b) => (a.date < b.date ? 1 : -1)).slice(0, limit);
+  const today = todayISO();
+  const lines = [];
+  lines.push(`# Mastery Gym journal`);
+  lines.push("");
+  lines.push(`_Exported ${today} · ${recent.length} cycle${recent.length === 1 ? "" : "s"} · streak ${currentStreak(list)}_`);
+  lines.push("");
+  lines.push("> One cycle a day. Try. Feedback. Iterate. Speed isn't the point — judgment is.");
+  lines.push("");
+  for (const c of recent) {
+    lines.push(`## ${c.date}`);
+    lines.push("");
+    if (c.tried) {
+      lines.push(`**Tried.** ${stripMd(c.tried)}`);
+      lines.push("");
+    }
+    if (c.feedback) {
+      lines.push(`**Feedback.** ${stripMd(c.feedback)}`);
+      lines.push("");
+    }
+    if (c.iterated) {
+      lines.push(`**Iterated.** ${stripMd(c.iterated)}`);
+      lines.push("");
+    }
+    if (c.kept) {
+      lines.push(`- Kept: ${stripMd(c.kept)}`);
+    }
+    if (c.refused) {
+      lines.push(`- Refused: ${stripMd(c.refused)}`);
+    }
+    lines.push("");
+    lines.push("---");
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+function downloadMarkdown(md) {
+  const blob = new Blob([md], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `mastery-gym-${todayISO()}.md`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+  if (els.preview) els.preview.textContent = md;
+  flash("markdown downloaded");
+}
+
+function stripMd(s) {
+  // Keep markdown export clean: collapse whitespace, escape pipes, preserve content.
+  return String(s).replace(/\s+/g, " ").trim();
+}
+
+// ---------------------------------------------------------------------------
+// UTIL
+
+function todayISO() {
+  return isoDate(new Date());
+}
+
+function isoDate(d) {
+  // local-date ISO (YYYY-MM-DD), not UTC — a cycle "today" should match the
+  // user's wall clock, not the timezone shift.
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function startOfDay(d) {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+function formatHumanDate(d) {
+  try {
+    return d.toLocaleDateString(undefined, {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  } catch {
+    return isoDate(d);
+  }
+}
+
+function flash(msg) {
+  if (!els.status) return;
+  els.status.textContent = msg;
+  clearTimeout(flash._t);
+  flash._t = setTimeout(() => {
+    if (els.status) els.status.textContent = "";
+  }, 3000);
+}
+
+// Defensive helpers — kept for any future innerHTML write that touches stored
+// user input. Current renderers use textContent / dataset / setAttribute, so
+// nothing user-controlled is interpolated as HTML, but these stay available.
+// eslint-disable-next-line no-unused-vars
+function escapeHTML(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+// eslint-disable-next-line no-unused-vars
+function escapeAttr(s) {
+  return escapeHTML(s);
+}

--- a/site/widgets/mastery-gym.html
+++ b/site/widgets/mastery-gym.html
@@ -1,0 +1,192 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mastery Gym &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="Daily check-in for one taste cycle: try, feedback, iterate. Streak counter, heatmap, and per-cycle tags for what you kept and what you refused."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:title" content="Mastery Gym &mdash; Punk Rock AI" />
+    <meta property="og:description" content="One cycle a day. Try. Feedback. Iterate. Build the taste muscle." />
+    <meta property="og:url" content="https://punkrockai.com/widgets/mastery-gym.html" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/widgets/mastery-gym.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main>
+      <section class="gym-intro grain scanlines">
+        <div class="wrap wrap--narrow">
+          <p class="kicker kicker--accent">Slide 7 &middot; the feedback loop</p>
+          <h1>Mastery Gym.</h1>
+          <p class="gym-intro__lede">
+            One cycle a day. Try something. Get feedback. Iterate. You don&rsquo;t
+            get strong by going once. AI compresses the loop &mdash; speed is
+            not the point. Judgment is.
+          </p>
+          <p class="gym-intro__hint">
+            Log one cycle per day. Tag what you kept, name what you refused.
+            All on this device, no account, works offline.
+          </p>
+        </div>
+      </section>
+
+      <section class="gym-stats">
+        <div class="wrap wrap--narrow">
+          <ul class="gym-stats__row">
+            <li class="gym-stat">
+              <span class="gym-stat__num" data-stat="streak">0</span>
+              <span class="gym-stat__label">Day streak</span>
+            </li>
+            <li class="gym-stat">
+              <span class="gym-stat__num" data-stat="total">0</span>
+              <span class="gym-stat__label">Cycles logged</span>
+            </li>
+            <li class="gym-stat">
+              <span class="gym-stat__num" data-stat="last">&mdash;</span>
+              <span class="gym-stat__label">Last check-in</span>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="gym-checkin">
+        <div class="wrap wrap--narrow">
+          <header class="gym-checkin__head">
+            <p class="eyebrow">Today &middot; <span data-today>&mdash;</span></p>
+            <h2 data-checkin-title>Today&rsquo;s cycle</h2>
+            <p class="gym-checkin__hint" data-checkin-hint>
+              Five quick fields. Save updates today&rsquo;s entry &mdash; one cycle per calendar day.
+            </p>
+          </header>
+
+          <form class="gym-form" id="gym-form" autocomplete="off">
+            <div class="gym-field">
+              <label class="gym-field__label" for="gym-tried">
+                <span class="gym-field__num">01</span>
+                <span class="gym-field__title">Tried</span>
+                <span class="gym-field__hint">What did you actually attempt today?</span>
+              </label>
+              <textarea
+                id="gym-tried"
+                name="tried"
+                rows="2"
+                placeholder="A new opening sentence. A different mix bus. A risky crop."
+              ></textarea>
+            </div>
+
+            <div class="gym-field">
+              <label class="gym-field__label" for="gym-feedback">
+                <span class="gym-field__num">02</span>
+                <span class="gym-field__title">Feedback</span>
+                <span class="gym-field__hint">What did the room, the rough cut, the model, the reader say?</span>
+              </label>
+              <textarea
+                id="gym-feedback"
+                name="feedback"
+                rows="2"
+                placeholder="Pacing drags in the middle. Two friends asked the same question."
+              ></textarea>
+            </div>
+
+            <div class="gym-field">
+              <label class="gym-field__label" for="gym-iterated">
+                <span class="gym-field__num">03</span>
+                <span class="gym-field__title">Iterated</span>
+                <span class="gym-field__hint">What change did you make as a result?</span>
+              </label>
+              <textarea
+                id="gym-iterated"
+                name="iterated"
+                rows="2"
+                placeholder="Cut the second act in half. Re-recorded the bridge."
+              ></textarea>
+            </div>
+
+            <div class="gym-tags">
+              <div class="gym-field gym-field--tag gym-field--keep">
+                <label class="gym-field__label" for="gym-kept">
+                  <span class="gym-field__num">+</span>
+                  <span class="gym-field__title">What I kept</span>
+                  <span class="gym-field__hint">Comma-separate. The keepers go in the muscle.</span>
+                </label>
+                <input
+                  id="gym-kept"
+                  name="kept"
+                  type="text"
+                  placeholder="cold open, hand-held shot, the line about the leaf blower"
+                />
+              </div>
+              <div class="gym-field gym-field--tag gym-field--refuse">
+                <label class="gym-field__label" for="gym-refused">
+                  <span class="gym-field__num">&minus;</span>
+                  <span class="gym-field__title">What I refused</span>
+                  <span class="gym-field__hint">The cutting room floor. This is taste.</span>
+                </label>
+                <input
+                  id="gym-refused"
+                  name="refused"
+                  type="text"
+                  placeholder="five corporate adjectives, the safe ending, the b-roll filler"
+                />
+              </div>
+            </div>
+
+            <div class="gym-form__actions">
+              <button class="btn btn--primary" type="submit" data-action="save">Save today&rsquo;s cycle</button>
+              <button class="btn" type="button" data-action="clear">Clear form</button>
+              <p class="gym-form__status" id="gym-status" aria-live="polite"></p>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <section class="gym-heatmap">
+        <div class="wrap wrap--narrow">
+          <header class="gym-heatmap__head">
+            <p class="eyebrow">The reps</p>
+            <h2>Sixteen weeks of cycles.</h2>
+            <p class="gym-heatmap__hint">
+              Each cell is a day. Filled cells are days you ran the loop.
+              Today is the bottom-right corner. Click a cell to read or edit
+              that day&rsquo;s cycle.
+            </p>
+          </header>
+          <div class="gym-heatmap__grid" id="gym-heatmap" role="grid" aria-label="Mastery Gym cycle heatmap"></div>
+          <ul class="gym-heatmap__legend" aria-hidden="true">
+            <li><span class="gym-cell gym-cell--l0"></span> none</li>
+            <li><span class="gym-cell gym-cell--l1"></span> brief</li>
+            <li><span class="gym-cell gym-cell--l2"></span> solid</li>
+            <li><span class="gym-cell gym-cell--l3"></span> deep</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="gym-export">
+        <div class="wrap wrap--narrow">
+          <h2>Take the journal with you.</h2>
+          <p class="gym-export__hint">
+            Export the last 30 cycles as a Markdown journal &mdash; for your
+            repo, your notebook, your fridge. Works offline. No account.
+          </p>
+          <div class="gym-export__actions">
+            <button class="btn btn--primary" type="button" data-action="export-md">Download last 30 .md</button>
+            <button class="btn" type="button" data-action="copy-md">Copy as Markdown</button>
+            <button class="btn" type="button" data-action="reset">Wipe all cycles</button>
+          </div>
+          <pre class="gym-export__preview" id="gym-preview" aria-live="polite"></pre>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/mastery-gym.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Phase 4 widget B1 — turns slide 7's Mastery Gym idea (try / feedback / iterate, every day) into an actual habit-tracking artifact at `/widgets/mastery-gym.html`.

- Daily one-cycle check-in form — five fields (Tried / Feedback / Iterated, plus tag inputs for *what I kept* and *what I refused*). One cycle per calendar day; same-day save upserts.
- Streak counter with a 24-hour grace window (counts consecutive days ending today *or* yesterday so the count doesn't blink to zero before the morning check-in).
- 16-week heatmap (7×16 grid, today bottom-right). Each cell is a `<button>` with `aria-label="YYYY-MM-DD — checked in"`; clicking loads that day into the form for review/edit. Cell intensity reflects how many fields were filled. Cells size via `clamp()` for mobile.
- Markdown export — last 30 cycles as `mastery-gym-YYYY-MM-DD.md` via `Blob` + `<a download>`. Copy-to-clipboard button with on-page preview fallback.
- localStorage-only via `/js/common/storage.js` (`pra:v1:gym:cycles`). No network calls, works offline.
- No inline `<script>`/`<style>`/handlers; user input rendered via `textContent` / `setAttribute` / `dataset`; local `escapeHTML`/`escapeAttr` available for future renderers. Theme tokens only.

## Test plan

- [ ] Load `/widgets/mastery-gym.html`, fill the form, hit Save — entry appears in heatmap as today's bottom-right cell.
- [ ] Reload — form re-hydrates with today's entry, streak shows 1, total shows 1.
- [ ] Click a past cell — form loads that day, header switches to "Editing YYYY-MM-DD", saving updates that row.
- [ ] Cross a day boundary (or simulate by adding a yesterday entry) — streak counts consecutive days; missing two days breaks it.
- [ ] Click "Download last 30 .md" — `.md` file downloads with newest-first cycles, kept/refused as bullets.
- [ ] DevTools offline — every action still works.
- [ ] Phone width — no horizontal scroll, heatmap cells shrink, tag fields stack.

Closes #25

https://claude.ai/code/session_01S4FVYexCNPKiQT5MS5byvv

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4FVYexCNPKiQT5MS5byvv)_