### PR TITLE
feat(widget): B3 Open Source Receipt (#27)

### DIFF
--- a/site/css/widgets/receipt.css
+++ b/site/css/widgets/receipt.css
@@ -1,0 +1,429 @@
+/* /widgets/receipt.html — Open Source Receipt
+   Paper-receipt aesthetic. Monospace only inside the receipt.
+   ------------------------------------------------------------------ */
+
+.osr-intro {
+  padding-block: var(--space-6);
+  border-bottom: 1px solid var(--border);
+}
+
+.osr-intro h1 {
+  margin: 0 0 var(--space-3);
+}
+
+.osr-intro__lede {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 50ch;
+  color: var(--fg-soft);
+}
+
+.osr-intro__hint {
+  margin-top: var(--space-3);
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+.osr-intro__caveat {
+  margin-top: var(--space-4);
+  padding: var(--space-3) var(--space-3);
+  border: 1px dashed var(--accent);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  color: var(--fg-soft);
+  max-width: 60ch;
+}
+
+.osr-intro__caveat strong {
+  color: var(--accent);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+/* ------------------------------------------------------------------
+   FORM
+   ------------------------------------------------------------------ */
+
+.osr-form-wrap {
+  padding-block: var(--space-5);
+}
+
+.osr-form {
+  font-family: var(--font-mono);
+}
+
+.osr-fieldset {
+  border: 1px solid var(--border-strong);
+  padding: var(--space-4);
+  margin: 0;
+}
+
+.osr-legend {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  padding-inline: var(--space-2);
+}
+
+.osr-fieldset__hint {
+  margin: 0 0 var(--space-4);
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+.osr-questions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.osr-q {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+}
+
+@media (max-width: 560px) {
+  .osr-q {
+    grid-template-columns: auto 1fr;
+  }
+  .osr-q__control {
+    grid-column: 1 / -1;
+    justify-self: stretch;
+  }
+}
+
+.osr-q__num {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  letter-spacing: 0.1em;
+}
+
+.osr-q__label {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+  color: var(--fg);
+}
+
+.osr-q__hint {
+  display: block;
+  margin-top: var(--space-1);
+  font-size: var(--fs-xs);
+  color: var(--muted);
+}
+
+.osr-q__control {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.osr-q__yesno {
+  display: inline-flex;
+  border: 1px solid var(--border-strong);
+}
+
+.osr-q__yesno button {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  background: transparent;
+  border: 0;
+  color: var(--fg-soft);
+  padding: 0.45rem 0.9rem;
+  cursor: pointer;
+  transition: background 120ms var(--ease-snap), color 120ms var(--ease-snap);
+}
+
+.osr-q__yesno button + button {
+  border-left: 1px solid var(--border-strong);
+}
+
+.osr-q__yesno button[aria-pressed="true"] {
+  background: var(--accent);
+  color: var(--accent-ink);
+}
+
+.osr-q__yesno button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.osr-q__number {
+  width: 7rem;
+  padding: 0.45rem 0.6rem;
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  background: #0d0d0d;
+  color: var(--fg);
+  border: 1px solid var(--border-strong);
+  border-radius: 0;
+  text-align: right;
+}
+
+.osr-form__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+.osr-form__status {
+  margin-top: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  min-height: 1.2em;
+}
+
+/* ------------------------------------------------------------------
+   RECEIPT — paper, monospace, halftone print feel.
+   Captured by html-to-image as PNG.
+   ------------------------------------------------------------------ */
+
+.osr-receipt-wrap {
+  padding-block: var(--space-5);
+}
+
+.osr-receipt {
+  font-family: var(--font-mono);
+  color: var(--paper-ink);
+  background-color: var(--paper);
+  margin-inline: auto;
+  max-width: 28rem;
+  width: 100%;
+  padding: var(--space-4) var(--space-3);
+  position: relative;
+  isolation: isolate;
+  box-shadow:
+    0 1px 0 rgba(0, 0, 0, 0.4),
+    8px 12px 0 rgba(0, 0, 0, 0.45);
+  /* deckle / torn edge top + bottom */
+  clip-path: polygon(
+    0 4px,
+    3% 0,
+    9% 5px,
+    16% 1px,
+    24% 4px,
+    33% 0,
+    41% 5px,
+    50% 1px,
+    59% 4px,
+    68% 0,
+    77% 5px,
+    86% 1px,
+    94% 4px,
+    100% 0,
+    100% calc(100% - 4px),
+    96% 100%,
+    89% calc(100% - 5px),
+    80% calc(100% - 1px),
+    71% calc(100% - 4px),
+    62% 100%,
+    53% calc(100% - 5px),
+    44% calc(100% - 1px),
+    35% calc(100% - 4px),
+    26% 100%,
+    17% calc(100% - 5px),
+    8% calc(100% - 1px),
+    2% calc(100% - 4px),
+    0 100%
+  );
+}
+
+.osr-receipt p,
+.osr-receipt ul,
+.osr-receipt li {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-family: var(--font-mono);
+  color: var(--paper-ink);
+  font-size: var(--fs-xs);
+  line-height: 1.55;
+}
+
+.osr-receipt__head {
+  text-align: center;
+}
+
+.osr-receipt__brand {
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  font-size: var(--fs-sm);
+}
+
+.osr-receipt__addr {
+  letter-spacing: 0.08em;
+}
+
+.osr-receipt__rule {
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  user-select: none;
+  margin-block: var(--space-1);
+}
+
+.osr-receipt__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-2);
+  letter-spacing: 0.08em;
+}
+
+.osr-receipt__head .osr-receipt__meta {
+  justify-content: center;
+}
+
+.osr-receipt__body {
+  margin-top: var(--space-2);
+}
+
+.osr-receipt__line {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-3);
+  letter-spacing: 0.04em;
+}
+
+.osr-receipt__line--header {
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.osr-receipt__lines {
+  display: grid;
+  gap: 0.15rem;
+  margin-block: var(--space-2);
+}
+
+.osr-receipt__line--item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--space-2);
+  align-items: baseline;
+}
+
+.osr-receipt__item-name {
+  white-space: normal;
+  word-break: break-word;
+}
+
+.osr-receipt__item-math {
+  display: block;
+  margin-top: 0.1rem;
+  font-size: var(--fs-xs);
+  color: var(--paper-ink);
+  opacity: 0.7;
+  letter-spacing: 0.02em;
+}
+
+.osr-receipt__line--subtotal {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.osr-receipt__line--total {
+  font-weight: 700;
+  font-size: var(--fs-sm);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.osr-receipt__line--total-sub {
+  justify-content: flex-end;
+  font-size: var(--fs-xs);
+  color: var(--paper-ink);
+  opacity: 0.7;
+  font-style: italic;
+}
+
+.osr-receipt__foot {
+  margin-top: var(--space-3);
+  text-align: center;
+}
+
+.osr-receipt__caveat {
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.osr-receipt__caveat--body {
+  margin-top: var(--space-2);
+  font-weight: 400;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  text-align: left;
+  font-size: var(--fs-xs);
+  line-height: 1.5;
+}
+
+.osr-receipt__thanks {
+  margin-block: var(--space-3) var(--space-2);
+  letter-spacing: 0.16em;
+  font-weight: 700;
+}
+
+.osr-receipt__barcode {
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  letter-spacing: 0.2em;
+  margin-block: var(--space-1) var(--space-1);
+}
+
+.osr-receipt__sig {
+  letter-spacing: 0.06em;
+  opacity: 0.7;
+}
+
+/* ------------------------------------------------------------------
+   ACTIONS
+   ------------------------------------------------------------------ */
+
+.osr-actions {
+  padding-block: var(--space-5) var(--space-7);
+  border-top: 1px solid var(--border);
+}
+
+.osr-actions__hint {
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  max-width: 60ch;
+  margin: 0 0 var(--space-3);
+}
+
+.osr-actions__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.osr-actions__status {
+  margin-top: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  min-height: 1.2em;
+}

--- a/site/js/widgets/receipt.js
+++ b/site/js/widgets/receipt.js
@@ -1,0 +1,458 @@
+// /widgets/receipt.html — Open Source Receipt
+// Toy estimator. The user answers a short questionnaire about their
+// open-web footprint; we multiply through illustrative numbers and
+// render a paper-receipt-style estimate. Heuristic, not truth — see
+// the talk's "1,800 of mine" beat for the real-world anchor.
+
+import { load, save, remove } from "/js/common/storage.js";
+
+const STORAGE_KEY = "osr:state";
+
+// ---------------------------------------------------------------------------
+// Questionnaire — illustrative multipliers. Kept deliberately transparent:
+// every multiplier shows up in the receipt math so the user can see what we
+// did and disagree with it. The numbers are made up to feel honest, not to
+// be accurate.
+// ---------------------------------------------------------------------------
+
+const QUESTIONS = [
+  {
+    id: "cc_publishing",
+    type: "yesno",
+    label:
+      "Did you publish CC-licensed work on the open web before 2020?",
+    hint: "Photos, writing, code, design files, anything.",
+    receiptName: "CC-licensed publisher",
+    fixedArtifacts: 200,
+    multiplier: 1.0,
+    mathLabel: "fixed bundle x 1.0",
+  },
+  {
+    id: "flickr_photos",
+    type: "number",
+    label: "Public Flickr photos (approximate)",
+    hint: "Skip if zero. The 1,800 figure came from 145,000 here.",
+    placeholder: "e.g. 5000",
+    receiptName: "Flickr public photos",
+    multiplier: 0.7,
+    mathLabel: "x 0.7 likely indexed",
+  },
+  {
+    id: "github_repos",
+    type: "number",
+    label: "GitHub repos with code committed before 2022",
+    hint: "Public repos only. Forks count if you actually committed.",
+    placeholder: "e.g. 12",
+    receiptName: "GitHub repos",
+    multiplier: 18,
+    mathLabel: "x 18 files per repo",
+  },
+  {
+    id: "deviantart",
+    type: "yesno",
+    label: "Account on DeviantArt or similar art platform older than 5 years",
+    hint: "ArtStation, Behance, Newgrounds, FurAffinity, etc.",
+    receiptName: "Art platform footprint",
+    fixedArtifacts: 80,
+    multiplier: 1.0,
+    mathLabel: "fixed bundle x 1.0",
+  },
+  {
+    id: "old_blog",
+    type: "yesno",
+    label: "Personal blog older than 5 years (still indexable)",
+    hint: "WordPress, Tumblr, Blogger, Jekyll, anything self-hosted.",
+    receiptName: "Personal blog",
+    fixedArtifacts: 120,
+    multiplier: 1.0,
+    mathLabel: "fixed bundle x 1.0",
+  },
+  {
+    id: "longform_posts",
+    type: "number",
+    label: "Long-form public posts (Medium, Substack, personal site)",
+    hint: "Anything 500+ words you put on the open web.",
+    placeholder: "e.g. 40",
+    receiptName: "Long-form posts",
+    multiplier: 1.0,
+    mathLabel: "x 1.0 one artifact each",
+  },
+  {
+    id: "forum_participation",
+    type: "yesno",
+    label: "Public mailing list / forum / Stack Overflow participation",
+    hint: "Hundreds of public posts under a stable handle counts.",
+    receiptName: "Forum / list participation",
+    fixedArtifacts: 250,
+    multiplier: 1.0,
+    mathLabel: "fixed bundle x 1.0",
+  },
+  {
+    id: "wiki_edits",
+    type: "yesno",
+    label: "Edited Wikipedia or another public wiki under your name",
+    hint: "Even a small handful of edits — they get scraped.",
+    receiptName: "Public wiki edits",
+    fixedArtifacts: 30,
+    multiplier: 1.0,
+    mathLabel: "fixed bundle x 1.0",
+  },
+];
+
+// Global multipliers shown on the receipt after the subtotal. These exist
+// to make the widget feel less confidently large. Both are made up.
+const INDEXING_FACTOR = 0.62; // not everything public is actually indexed
+const CORPUS_OVERLAP = 0.18; // not every indexed thing made it into a corpus
+
+// ---------------------------------------------------------------------------
+// State + bootstrap
+// ---------------------------------------------------------------------------
+
+let state = freshState();
+let statusEl, actionsStatusEl;
+
+hydrate();
+renderQuestions();
+wireForm();
+wireActions();
+
+// ---------------------------------------------------------------------------
+
+function freshState() {
+  const out = {};
+  for (const q of QUESTIONS) {
+    out[q.id] = q.type === "yesno" ? null : "";
+  }
+  return out;
+}
+
+function hydrate() {
+  const { value } = load(STORAGE_KEY, null);
+  if (value && typeof value === "object") {
+    state = { ...freshState(), ...sanitize(value) };
+  }
+}
+
+function sanitize(value) {
+  const out = {};
+  for (const q of QUESTIONS) {
+    const v = value[q.id];
+    if (q.type === "yesno") {
+      out[q.id] = v === true || v === false ? v : null;
+    } else {
+      out[q.id] = typeof v === "string" ? v : "";
+    }
+  }
+  return out;
+}
+
+function persist() {
+  save(STORAGE_KEY, state);
+}
+
+// ---------------------------------------------------------------------------
+// Questionnaire render
+// ---------------------------------------------------------------------------
+
+function renderQuestions() {
+  const list = document.querySelector("[data-questions]");
+  if (!list) return;
+  list.innerHTML = "";
+  QUESTIONS.forEach((q, idx) => {
+    list.appendChild(renderQuestion(q, idx));
+  });
+}
+
+function renderQuestion(q, idx) {
+  const li = document.createElement("li");
+  li.className = "osr-q";
+  const num = String(idx + 1).padStart(2, "0");
+  const labelHtml = `
+    <span class="osr-q__num">${escapeHTML(num)}.</span>
+    <label class="osr-q__label" for="osr-q-${escapeAttr(q.id)}">
+      ${escapeHTML(q.label)}
+      <span class="osr-q__hint">${escapeHTML(q.hint || "")}</span>
+    </label>
+  `;
+  if (q.type === "yesno") {
+    li.innerHTML = `
+      ${labelHtml}
+      <span class="osr-q__control">
+        <span class="osr-q__yesno" role="group" aria-labelledby="osr-q-${escapeAttr(q.id)}-label">
+          <button type="button" data-q="${escapeAttr(q.id)}" data-val="yes" aria-pressed="false">Yes</button>
+          <button type="button" data-q="${escapeAttr(q.id)}" data-val="no" aria-pressed="false">No</button>
+        </span>
+      </span>
+    `;
+    const buttons = li.querySelectorAll(".osr-q__yesno button");
+    buttons.forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const next = btn.dataset.val === "yes";
+        // toggle off if pressing the active button again
+        state[q.id] = state[q.id] === next ? null : next;
+        paintYesNo(li, q.id);
+        persist();
+      });
+    });
+    paintYesNo(li, q.id);
+  } else {
+    li.innerHTML = `
+      ${labelHtml}
+      <span class="osr-q__control">
+        <input
+          type="number"
+          inputmode="numeric"
+          min="0"
+          step="1"
+          class="osr-q__number"
+          id="osr-q-${escapeAttr(q.id)}"
+          data-q="${escapeAttr(q.id)}"
+          placeholder="${escapeAttr(q.placeholder || "0")}"
+        />
+      </span>
+    `;
+    const input = li.querySelector("input");
+    input.value = state[q.id] || "";
+    input.addEventListener("input", () => {
+      const cleaned = input.value.replace(/[^0-9]/g, "");
+      if (cleaned !== input.value) input.value = cleaned;
+      state[q.id] = cleaned;
+      persist();
+    });
+  }
+  return li;
+}
+
+function paintYesNo(li, qId) {
+  const value = state[qId];
+  li.querySelectorAll(".osr-q__yesno button").forEach((btn) => {
+    const isYes = btn.dataset.val === "yes";
+    const pressed = value === true ? isYes : value === false ? !isYes : false;
+    btn.setAttribute("aria-pressed", pressed ? "true" : "false");
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Wire actions
+// ---------------------------------------------------------------------------
+
+function wireForm() {
+  statusEl = document.getElementById("osr-status");
+  actionsStatusEl = document.getElementById("osr-actions-status");
+  document
+    .querySelector('[data-action="compute"]')
+    ?.addEventListener("click", compute);
+  document
+    .querySelector('[data-action="reset"]')
+    ?.addEventListener("click", reset);
+}
+
+function wireActions() {
+  document
+    .querySelector('[data-action="png"]')
+    ?.addEventListener("click", exportPng);
+  document
+    .querySelector('[data-action="recompute"]')
+    ?.addEventListener("click", () => {
+      hideReceipt();
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Compute — deterministic math from current state.
+// ---------------------------------------------------------------------------
+
+function compute() {
+  const lines = buildLines();
+  if (!lines.length) {
+    flash(statusEl, "answer at least one question to print");
+    return;
+  }
+  renderReceipt(lines);
+  showReceipt();
+  flash(statusEl, "receipt printed below");
+  // bring the receipt into view
+  document
+    .getElementById("osr-receipt-wrap")
+    ?.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+function buildLines() {
+  const lines = [];
+  for (const q of QUESTIONS) {
+    const v = state[q.id];
+    if (q.type === "yesno") {
+      if (v === true) {
+        const artifacts = Math.round(q.fixedArtifacts * q.multiplier);
+        lines.push({
+          name: q.receiptName,
+          math: `yes - ${q.fixedArtifacts} ${q.mathLabel}`,
+          value: artifacts,
+        });
+      }
+    } else {
+      const n = Number.parseInt(v, 10);
+      if (Number.isFinite(n) && n > 0) {
+        const artifacts = Math.round(n * q.multiplier);
+        lines.push({
+          name: q.receiptName,
+          math: `${n} ${q.mathLabel}`,
+          value: artifacts,
+        });
+      }
+    }
+  }
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Receipt render
+// ---------------------------------------------------------------------------
+
+function renderReceipt(lines) {
+  const linesEl = document.querySelector("[data-lines]");
+  if (linesEl) {
+    linesEl.innerHTML = lines
+      .map(
+        (line) => `
+          <li class="osr-receipt__line osr-receipt__line--item">
+            <span class="osr-receipt__item-name">
+              ${escapeHTML(line.name)}
+              <span class="osr-receipt__item-math">${escapeHTML(line.math)}</span>
+            </span>
+            <span class="osr-receipt__item-value">${formatNum(line.value)}</span>
+          </li>
+        `,
+      )
+      .join("");
+  }
+
+  const subtotal = lines.reduce((sum, l) => sum + l.value, 0);
+  const indexed = Math.round(subtotal * INDEXING_FACTOR);
+  const overlap = Math.round(indexed * CORPUS_OVERLAP);
+
+  setText("[data-subtotal]", formatNum(subtotal));
+  setText("[data-indexed]", formatNum(indexed));
+  setText("[data-overlap]", formatNum(overlap));
+  setText("[data-total]", formatNum(overlap));
+
+  const now = new Date();
+  setText("[data-stamp]", isoDate(now));
+  setText("[data-time]", isoTime(now));
+  setText("[data-receipt-id]", receiptId(state));
+}
+
+function showReceipt() {
+  const wrap = document.getElementById("osr-receipt-wrap");
+  const actions = document.getElementById("osr-actions");
+  if (wrap) wrap.hidden = false;
+  if (actions) actions.hidden = false;
+}
+
+function hideReceipt() {
+  const wrap = document.getElementById("osr-receipt-wrap");
+  const actions = document.getElementById("osr-actions");
+  if (wrap) wrap.hidden = true;
+  if (actions) actions.hidden = true;
+}
+
+// ---------------------------------------------------------------------------
+// Reset
+// ---------------------------------------------------------------------------
+
+function reset() {
+  const ok = window.confirm("Clear all answers and the receipt?");
+  if (!ok) return;
+  state = freshState();
+  remove(STORAGE_KEY);
+  renderQuestions();
+  hideReceipt();
+  flash(statusEl, "answers cleared");
+}
+
+// ---------------------------------------------------------------------------
+// PNG export — mirrors both-hands.js
+// ---------------------------------------------------------------------------
+
+async function exportPng() {
+  const node = document.getElementById("osr-receipt");
+  if (!node) return;
+  if (!window.htmlToImage) {
+    flash(actionsStatusEl, "html-to-image still loading - try again in a sec.");
+    return;
+  }
+  try {
+    flash(actionsStatusEl, "rendering...");
+    const dataUrl = await window.htmlToImage.toPng(node, {
+      pixelRatio: 2,
+      backgroundColor: "#f4ede0",
+      cacheBust: true,
+    });
+    const a = document.createElement("a");
+    a.href = dataUrl;
+    a.download = `open-source-receipt-${isoDate(new Date())}.png`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    flash(actionsStatusEl, "PNG downloaded");
+  } catch (err) {
+    console.error(err);
+    flash(actionsStatusEl, "PNG export failed - see console");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function setText(selector, text) {
+  const el = document.querySelector(selector);
+  if (el) el.textContent = text;
+}
+
+function formatNum(n) {
+  return Number(n).toLocaleString("en-US");
+}
+
+function isoDate(d) {
+  return d.toISOString().slice(0, 10);
+}
+
+function isoTime(d) {
+  return d.toTimeString().slice(0, 5);
+}
+
+// Deterministic-ish receipt ID derived from state so the same answers print
+// the same number. djb2 hash, six digits.
+function receiptId(s) {
+  const str = JSON.stringify(s);
+  let h = 5381;
+  for (let i = 0; i < str.length; i++) {
+    h = (h * 33) ^ str.charCodeAt(i);
+  }
+  const id = Math.abs(h) % 1000000;
+  return String(id).padStart(6, "0");
+}
+
+function flash(target, msg) {
+  if (!target) return;
+  target.textContent = msg;
+  clearTimeout(target._t);
+  target._t = setTimeout(() => {
+    if (target) target.textContent = "";
+  }, 3000);
+}
+
+function escapeHTML(str) {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escapeAttr(str) {
+  return escapeHTML(str);
+}

--- a/site/widgets/receipt.html
+++ b/site/widgets/receipt.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Open Source Receipt &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="Toy estimator: how much of you is in the training data? Answer a few questions, get a paper-receipt-style heuristic. Heavily caveated."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:title" content="Open Source Receipt — Punk Rock AI" />
+    <meta property="og:description" content="A heuristic, not the truth. Tally your open-source footprint and feel the shape of the question." />
+    <meta property="og:url" content="https://punkrockai.com/widgets/receipt.html" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/widgets/receipt.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main>
+      <section class="osr-intro grain scanlines">
+        <div class="wrap wrap--narrow">
+          <p class="kicker kicker--accent">Slide 10 &middot; the confrontation</p>
+          <h1>Open Source Receipt.</h1>
+          <p class="osr-intro__lede">
+            How much of you is in the training data? Nobody can say
+            for sure &mdash; not even the people who scraped it. So we play
+            the question for shape, not for truth.
+          </p>
+          <p class="osr-intro__hint">
+            Answer a few yes/no and numeric questions about what you put
+            on the open web. The widget multiplies through illustrative
+            numbers and prints a paper-receipt-style estimate.
+          </p>
+          <p class="osr-intro__caveat">
+            <strong>Heuristic, not truth.</strong> The talk&rsquo;s
+            <em>1,800 of mine</em> figure is real and specific to one
+            person who checked one dataset search tool against 145,000
+            public Flickr photos. Use this widget to feel the shape of
+            the question. Do not use it to know the answer.
+          </p>
+        </div>
+      </section>
+
+      <section class="osr-form-wrap">
+        <div class="wrap wrap--narrow">
+          <form class="osr-form" id="osr-form" novalidate>
+            <fieldset class="osr-fieldset">
+              <legend class="osr-legend">The questionnaire</legend>
+              <p class="osr-fieldset__hint">
+                Answer for the years before ~2022 &mdash; that&rsquo;s
+                roughly when most public corpora stopped freshening.
+                Skip what doesn&rsquo;t apply. Inputs save as you type.
+              </p>
+              <ol class="osr-questions" data-questions></ol>
+            </fieldset>
+
+            <div class="osr-form__row">
+              <button class="btn btn--primary" type="button" data-action="compute">Print receipt</button>
+              <button class="btn" type="button" data-action="reset">Reset</button>
+            </div>
+            <p class="osr-form__status" id="osr-status" aria-live="polite"></p>
+          </form>
+        </div>
+      </section>
+
+      <section class="osr-receipt-wrap" id="osr-receipt-wrap" hidden>
+        <div class="wrap wrap--narrow">
+          <article class="osr-receipt halftone--paper" id="osr-receipt" aria-label="Open source receipt">
+            <header class="osr-receipt__head">
+              <p class="osr-receipt__brand">PUNK ROCK AI &middot; OPEN SOURCE RECEIPT</p>
+              <p class="osr-receipt__addr">punkrockai.com</p>
+              <p class="osr-receipt__addr">a heuristic, not the truth</p>
+              <p class="osr-receipt__rule" aria-hidden="true">================================</p>
+              <p class="osr-receipt__meta">
+                <span data-stamp>0000-00-00</span>
+                <span>&middot;</span>
+                <span data-time>00:00</span>
+              </p>
+              <p class="osr-receipt__meta">
+                <span>RECEIPT #</span>
+                <span data-receipt-id>000000</span>
+              </p>
+              <p class="osr-receipt__rule" aria-hidden="true">================================</p>
+            </header>
+
+            <div class="osr-receipt__body">
+              <p class="osr-receipt__line osr-receipt__line--header">
+                <span>ITEM</span>
+                <span>EST.</span>
+              </p>
+              <ul class="osr-receipt__lines" data-lines></ul>
+              <p class="osr-receipt__rule" aria-hidden="true">--------------------------------</p>
+              <p class="osr-receipt__line osr-receipt__line--subtotal">
+                <span>SUBTOTAL (artifacts)</span>
+                <span data-subtotal>0</span>
+              </p>
+              <p class="osr-receipt__line">
+                <span>x INDEXING FACTOR (0.62)</span>
+                <span data-indexed>0</span>
+              </p>
+              <p class="osr-receipt__line">
+                <span>x CORPUS OVERLAP (0.18)</span>
+                <span data-overlap>0</span>
+              </p>
+              <p class="osr-receipt__rule" aria-hidden="true">================================</p>
+              <p class="osr-receipt__line osr-receipt__line--total">
+                <span>TOTAL (illustrative)</span>
+                <span data-total>0</span>
+              </p>
+              <p class="osr-receipt__line osr-receipt__line--total-sub">
+                <span>artifacts plausibly in <em>some</em> corpus</span>
+              </p>
+            </div>
+
+            <footer class="osr-receipt__foot">
+              <p class="osr-receipt__rule" aria-hidden="true">================================</p>
+              <p class="osr-receipt__caveat">
+                ** HEURISTIC. THE NUMBERS ARE ILLUSTRATIVE. **
+              </p>
+              <p class="osr-receipt__caveat osr-receipt__caveat--body">
+                The talk&rsquo;s 1,800 figure belongs to one person who
+                checked one dataset search tool against 145,000 public
+                Flickr photos. Your number is a shape, not a fact.
+                Multipliers above are made up to feel honest, not to be
+                accurate. No corpus has been queried. No file has left
+                this page.
+              </p>
+              <p class="osr-receipt__rule" aria-hidden="true">================================</p>
+              <p class="osr-receipt__thanks">
+                THANK YOU FOR SHARING FREELY<br />
+                THE COVENANT WAS REAL
+              </p>
+              <p class="osr-receipt__barcode" aria-hidden="true">|||| |||| |||| || |||| ||||</p>
+              <p class="osr-receipt__sig">punkrockai.com / widgets / receipt</p>
+            </footer>
+          </article>
+        </div>
+      </section>
+
+      <section class="osr-actions" id="osr-actions" hidden>
+        <div class="wrap wrap--narrow">
+          <p class="osr-actions__hint">
+            The PNG is captured exactly as you see it &mdash; caveats and
+            all. Pin it on a wall. Send it to a posse member. It is
+            not evidence. It is a feeling, printed.
+          </p>
+          <div class="osr-actions__row">
+            <button class="btn btn--primary" type="button" data-action="png">Export PNG</button>
+            <button class="btn" type="button" data-action="recompute">Edit answers</button>
+          </div>
+          <p class="osr-actions__status" id="osr-actions-status" aria-live="polite"></p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.13/dist/html-to-image.min.js" defer></script>
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/receipt.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Phase 4 / B3 widget: a toy estimator that asks "how much of you is in the training data?" The user answers a short questionnaire (CC publishing, Flickr, GitHub, DeviantArt, blogs, longform, forums, wiki) and the widget multiplies through illustrative numbers and prints a paper-receipt-style estimate. Heuristic, not truth — anchored to the talk's "1,800 of mine" beat (slide 10).

- `site/widgets/receipt.html` — questionnaire + receipt + actions, halftone-paper receipt with deckle clip-path
- `site/css/widgets/receipt.css` — monospace receipt visual, theme tokens only, mobile-friendly max-width
- `site/js/widgets/receipt.js` — ES module, deterministic math, transparent multipliers shown inline on the receipt, INDEXING_FACTOR (0.62) + CORPUS_OVERLAP (0.18) applied at footer, deterministic receipt-id from djb2 hash of state, PNG export via `window.htmlToImage.toPng` (filename `open-source-receipt-YYYY-MM-DD.png`)
- Caveats inline on the page and on the receipt: heuristic, not truth; the 1,800 figure is one person checking one tool against 145k photos
- Local `escapeHTML` / `escapeAttr` on every `innerHTML` write; no inline `<script>` / `<style>` / handlers; html-to-image already in CSP
- localStorage via `/js/common/storage.js`
- `node --check site/js/widgets/receipt.js` passes

## Test plan

- [ ] Visit `/widgets/receipt.html`, answer a mix of yes/no and numeric questions, click "Print receipt"
- [ ] Confirm the receipt renders with each line's multiplier visible (e.g. `5000 x 0.7 likely indexed`)
- [ ] Confirm subtotal, indexing factor, corpus overlap, and total all reconcile
- [ ] Same answers print the same receipt id (deterministic hash)
- [ ] "Export PNG" downloads `open-source-receipt-YYYY-MM-DD.png` and the file matches the on-screen receipt (caveats included)
- [ ] "Edit answers" hides the receipt and scrolls to top; "Reset" clears state
- [ ] Mobile width: no horizontal scroll, receipt fits, yes/no controls wrap
- [ ] Refresh keeps answers (localStorage)

Closes #27

https://claude.ai/code/session_01S4FVYexCNPKiQT5MS5byvv

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4FVYexCNPKiQT5MS5byvv)_