### PR TITLE
feat(widget): B4 Détournement maker (#28)

### DIFF
--- a/site/css/widgets/detournement.css
+++ b/site/css/widgets/detournement.css
@@ -1,0 +1,358 @@
+/* /widgets/detournement.html — image annotator, zine-style overlay tools */
+
+.det-intro {
+  padding-block: var(--space-6);
+  border-bottom: 1px solid var(--border);
+}
+
+.det-intro h1 {
+  margin: 0 0 var(--space-3);
+}
+
+.det-intro__lede {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 52ch;
+  color: var(--fg-soft);
+}
+
+.det-intro__hint {
+  margin-top: var(--space-3);
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+.det-intro__hint kbd {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  border: 1px solid var(--border-strong);
+  padding: 0 0.35rem;
+  border-radius: 2px;
+  background: var(--bg-elevated);
+  color: var(--fg);
+}
+
+/* ------------------------------------------------------------------
+   LOAD ROW — file upload + URL paste
+   ------------------------------------------------------------------ */
+
+.det-load {
+  padding-block: var(--space-4);
+  border-bottom: 1px solid var(--border);
+}
+
+.det-load__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: var(--space-3);
+  align-items: end;
+}
+
+@media (max-width: 640px) {
+  .det-load__row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.det-load__field {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.det-load__field input {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  background: var(--bg-elevated);
+  color: var(--fg);
+  border: 1px solid var(--border-strong);
+  padding: 0.55rem 0.7rem;
+  width: 100%;
+}
+
+.det-load__field input:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-color: var(--accent);
+}
+
+.det-load__field input[type="file"] {
+  padding: 0.4rem 0.5rem;
+}
+
+.det-load__note {
+  margin-top: var(--space-3);
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  max-width: 70ch;
+  font-family: var(--font-mono);
+  line-height: 1.5;
+}
+
+.det-load__note code {
+  color: var(--fg-soft);
+}
+
+/* ------------------------------------------------------------------
+   TOOLBAR — pick which annotation type the next click adds
+   ------------------------------------------------------------------ */
+
+.det-toolbar-wrap {
+  padding-block: var(--space-3);
+}
+
+.det-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.det-tool {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  background: var(--bg-elevated);
+  color: var(--fg);
+  border: 1px solid var(--border-strong);
+  padding: 0.55rem 0.9rem;
+  cursor: pointer;
+  transition: background 120ms var(--ease-snap),
+    color 120ms var(--ease-snap),
+    border-color 120ms var(--ease-snap);
+}
+
+.det-tool:hover,
+.det-tool:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.det-tool.is-active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-ink);
+}
+
+.det-tool--ghost {
+  margin-inline-start: auto;
+  color: var(--fg-soft);
+}
+
+/* ------------------------------------------------------------------
+   CANVAS — exported as PNG. The image plus the layer share a
+   stacking context so positions match the export.
+   ------------------------------------------------------------------ */
+
+.det-canvas-wrap {
+  padding-block: var(--space-4);
+}
+
+.det-canvas {
+  position: relative;
+  border: 4px solid var(--fg);
+  background: var(--bg-elevated);
+  margin-inline: auto;
+  max-width: 64rem;
+  width: 100%;
+  min-height: 18rem;
+  overflow: hidden;
+  user-select: none;
+  touch-action: none;
+}
+
+.det-canvas[data-tool="text"] {
+  cursor: text;
+}
+
+.det-canvas[data-tool="redaction"],
+.det-canvas[data-tool="halftone"],
+.det-canvas[data-tool="splash"] {
+  cursor: crosshair;
+}
+
+.det-canvas__empty {
+  display: grid;
+  place-content: center;
+  text-align: center;
+  padding: var(--space-6) var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  gap: var(--space-2);
+  min-height: 18rem;
+}
+
+.det-canvas__empty p {
+  margin: 0;
+}
+
+.det-canvas__img {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-width: 100%;
+  pointer-events: none;
+}
+
+.det-canvas__layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none; /* annotations re-enable themselves */
+}
+
+/* ------------------------------------------------------------------
+   ANNOTATIONS — absolutely positioned children of .det-canvas__layer
+   ------------------------------------------------------------------ */
+
+.det-anno {
+  position: absolute;
+  pointer-events: auto;
+  cursor: grab;
+  outline: 1px dashed transparent;
+  outline-offset: 2px;
+  min-width: 2rem;
+  min-height: 1.5rem;
+  box-sizing: border-box;
+}
+
+.det-anno:focus-visible,
+.det-anno.is-selected {
+  outline-color: var(--accent);
+  z-index: 5;
+}
+
+.det-anno.is-dragging {
+  cursor: grabbing;
+}
+
+.det-anno__remove {
+  position: absolute;
+  top: -0.65rem;
+  right: -0.65rem;
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 50%;
+  background: var(--accent);
+  color: var(--accent-ink);
+  border: 2px solid var(--bg);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  line-height: 1;
+  cursor: pointer;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  z-index: 6;
+}
+
+.det-anno:hover .det-anno__remove,
+.det-anno:focus-within .det-anno__remove,
+.det-anno.is-selected .det-anno__remove {
+  display: flex;
+}
+
+/* TEXT annotation */
+.det-anno--text {
+  font-family: var(--font-display);
+  font-size: clamp(1.1rem, 3vw, 1.8rem);
+  line-height: 1.1;
+  color: var(--accent-ink);
+  background: var(--fg);
+  padding: 0.25rem 0.6rem;
+  letter-spacing: 0.02em;
+  max-width: 80%;
+}
+
+.det-anno--text .det-anno__text {
+  outline: none;
+  white-space: pre-wrap;
+  word-break: break-word;
+  cursor: text;
+  min-width: 1ch;
+  min-height: 1em;
+}
+
+.det-anno--text .det-anno__text:empty::before {
+  content: attr(data-placeholder);
+  color: var(--muted);
+  font-style: italic;
+}
+
+/* REDACTION — black bar */
+.det-anno--redaction {
+  background: var(--fg);
+  width: 12rem;
+  height: 1.5rem;
+  border: 0;
+}
+
+/* HALFTONE — radial-stipple fill, draggable rectangle */
+.det-anno--halftone {
+  width: 10rem;
+  height: 6rem;
+  background-color: var(--bg);
+  background-image: radial-gradient(
+    circle,
+    rgba(255, 255, 255, 0.45) 1px,
+    transparent 1.5px
+  );
+  background-size: 6px 6px;
+  border: 1px solid var(--fg);
+}
+
+/* ACCENT SPLASH — solid accent rectangle */
+.det-anno--splash {
+  width: 8rem;
+  height: 3rem;
+  background: var(--accent);
+  transform: rotate(-3deg);
+  box-shadow: 4px 4px 0 var(--fg);
+}
+
+/* ------------------------------------------------------------------
+   ACTIONS
+   ------------------------------------------------------------------ */
+
+.det-actions {
+  padding-block: var(--space-5);
+  border-top: 1px solid var(--border);
+  display: grid;
+  gap: var(--space-3);
+}
+
+.det-actions__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.det-actions__hint {
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+.det-actions__status {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  min-height: 1em;
+}
+
+.det-actions__status.is-error {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .det-tool {
+    transition: none;
+  }
+}

--- a/site/js/widgets/detournement.js
+++ b/site/js/widgets/detournement.js
@@ -1,0 +1,450 @@
+// /widgets/detournement.html — image annotator. Drop an image (upload or
+// URL paste), then drop zine-style annotations on top: text, redactions,
+// halftone fills, accent splashes. Drag to position with pointer events.
+// Export the whole canvas as a flattened PNG via window.htmlToImage (loaded
+// from the CDN as a non-module script).
+//
+// Annotations are ephemeral — there is no persistence layer. The only state
+// that crosses a reload is the image itself, and that's by design: a
+// détournement should be a single sitting.
+
+const TOOLS = ["text", "redaction", "halftone", "splash"];
+const TOOL_PLACEHOLDER = {
+  text: "Type your rebuttal…",
+};
+
+let currentTool = "text";
+let activeAnno = null;
+let imageLoaded = false;
+let imageIsTainted = false; // true when URL paste hits a non-CORS server
+let annoIdSeq = 0;
+
+const els = {};
+
+init();
+
+// ---------------------------------------------------------------------------
+
+function init() {
+  els.canvas = document.getElementById("det-canvas");
+  els.layer = document.getElementById("det-layer");
+  els.img = document.getElementById("det-img");
+  els.empty = document.getElementById("det-empty");
+  els.file = document.getElementById("det-file");
+  els.url = document.getElementById("det-url");
+  els.status = document.getElementById("det-status");
+
+  if (!els.canvas || !els.layer || !els.img) return;
+
+  wireToolbar();
+  wireLoaders();
+  wireCanvas();
+  wireActions();
+  wireKeyboard();
+}
+
+// ---------------------------------------------------------------------------
+// TOOLBAR
+// ---------------------------------------------------------------------------
+
+function wireToolbar() {
+  for (const btn of document.querySelectorAll(".det-tool[data-tool]")) {
+    btn.addEventListener("click", () => setTool(btn.dataset.tool));
+  }
+  document
+    .querySelector('[data-action="clear-overlays"]')
+    ?.addEventListener("click", clearOverlays);
+}
+
+function setTool(tool) {
+  if (!TOOLS.includes(tool)) return;
+  currentTool = tool;
+  els.canvas.dataset.tool = tool;
+  for (const btn of document.querySelectorAll(".det-tool[data-tool]")) {
+    const active = btn.dataset.tool === tool;
+    btn.classList.toggle("is-active", active);
+    btn.setAttribute("aria-pressed", String(active));
+  }
+}
+
+function clearOverlays() {
+  if (!els.layer) return;
+  if (els.layer.children.length === 0) return;
+  const ok = window.confirm("Remove every annotation? The image stays.");
+  if (!ok) return;
+  els.layer.replaceChildren();
+  activeAnno = null;
+  flash("overlays cleared");
+}
+
+// ---------------------------------------------------------------------------
+// IMAGE LOADERS — upload + URL paste
+// ---------------------------------------------------------------------------
+
+function wireLoaders() {
+  els.file?.addEventListener("change", onFileChange);
+  els.url?.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      loadUrl();
+    }
+  });
+  document
+    .querySelector('[data-action="load-url"]')
+    ?.addEventListener("click", loadUrl);
+}
+
+function onFileChange(e) {
+  const file = e.target.files && e.target.files[0];
+  if (!file) return;
+  if (!file.type.startsWith("image/")) {
+    flash("not an image file", true);
+    return;
+  }
+  // Same-origin via blob: URL — html-to-image can read these freely.
+  const objectUrl = URL.createObjectURL(file);
+  // remove crossorigin so the blob loads cleanly (it's same-origin already)
+  els.img.removeAttribute("crossorigin");
+  imageIsTainted = false;
+  setImageSrc(objectUrl, "image uploaded");
+}
+
+function loadUrl() {
+  const raw = (els.url?.value || "").trim();
+  if (!raw) {
+    flash("paste a URL first", true);
+    return;
+  }
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    flash("that doesn't look like a URL", true);
+    return;
+  }
+  if (!/^https?:$/.test(parsed.protocol)) {
+    flash("URL must be http(s)", true);
+    return;
+  }
+  // Anonymous CORS request so html-to-image can read the pixels back. If the
+  // server doesn't send Access-Control-Allow-Origin, the browser still loads
+  // the image visually but the resulting <canvas> is tainted and toBlob()
+  // throws — we surface that on export.
+  els.img.setAttribute("crossorigin", "anonymous");
+  imageIsTainted = true; // assume tainted until proven otherwise (best-effort)
+  setImageSrc(parsed.href, "image loaded — export may fail if server omits CORS");
+  // Note: we can't reliably detect taint until we draw the image to a canvas,
+  // so we keep the optimistic flag and let exportPng() catch the SecurityError.
+}
+
+function setImageSrc(src, statusMsg) {
+  els.img.onload = () => {
+    imageLoaded = true;
+    els.img.hidden = false;
+    if (els.empty) els.empty.hidden = true;
+    flash(statusMsg);
+  };
+  els.img.onerror = () => {
+    imageLoaded = false;
+    els.img.hidden = true;
+    if (els.empty) els.empty.hidden = false;
+    flash("image failed to load", true);
+  };
+  // Reset the alt because escapeAttr is unnecessary for empty string but be
+  // explicit: the alt stays empty (decorative inside the canvas region).
+  els.img.alt = "";
+  els.img.src = src;
+}
+
+// ---------------------------------------------------------------------------
+// CANVAS — click to drop, pointer events to drag
+// ---------------------------------------------------------------------------
+
+function wireCanvas() {
+  els.canvas.addEventListener("pointerdown", (e) => {
+    // Don't intercept clicks that started on an existing annotation or its
+    // remove button; those have their own handlers.
+    if (e.target.closest(".det-anno") || e.target.closest(".det-anno__remove")) {
+      return;
+    }
+    if (!imageLoaded) {
+      flash("load an image first", true);
+      return;
+    }
+    // Pointerdown on empty canvas with a tool selected → drop new annotation
+    // at the click point. Use canvas-relative coordinates so the layer's
+    // absolute children align.
+    const rect = els.canvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const anno = createAnnotation(currentTool, x, y);
+    if (anno) selectAnnotation(anno);
+  });
+}
+
+function createAnnotation(tool, x, y) {
+  if (!TOOLS.includes(tool)) return null;
+  const node = document.createElement("div");
+  node.className = `det-anno det-anno--${tool}`;
+  node.dataset.tool = tool;
+  node.dataset.id = `anno-${++annoIdSeq}`;
+  node.tabIndex = 0;
+
+  if (tool === "text") {
+    // contenteditable inner div so the text is selectable/editable but the
+    // outer div remains the drag handle. The placeholder is rendered via
+    // CSS (data-placeholder + :empty::before) — escapeAttr the value.
+    const inner = document.createElement("div");
+    inner.className = "det-anno__text";
+    inner.contentEditable = "true";
+    inner.setAttribute("spellcheck", "false");
+    inner.dataset.placeholder = TOOL_PLACEHOLDER.text;
+    // Stop pointerdown inside the editable from triggering the drag — the
+    // user is trying to place a caret, not move the box.
+    inner.addEventListener("pointerdown", (e) => e.stopPropagation());
+    node.appendChild(inner);
+    // Auto-focus so the user can just type.
+    setTimeout(() => inner.focus(), 0);
+  }
+
+  // Position so the click is roughly the top-left, but clamp to canvas.
+  const rect = els.canvas.getBoundingClientRect();
+  node.style.left = `${clamp(x, 0, rect.width - 16)}px`;
+  node.style.top = `${clamp(y, 0, rect.height - 16)}px`;
+
+  // Remove control
+  const x_btn = document.createElement("button");
+  x_btn.type = "button";
+  x_btn.className = "det-anno__remove";
+  x_btn.setAttribute("aria-label", "Remove annotation");
+  x_btn.textContent = "×";
+  x_btn.addEventListener("pointerdown", (e) => e.stopPropagation());
+  x_btn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    removeAnnotation(node);
+  });
+  node.appendChild(x_btn);
+
+  // Drag handlers
+  attachDrag(node);
+
+  // Selection on focus
+  node.addEventListener("focus", () => selectAnnotation(node));
+  node.addEventListener("pointerdown", () => selectAnnotation(node));
+
+  els.layer.appendChild(node);
+  return node;
+}
+
+function selectAnnotation(node) {
+  if (activeAnno && activeAnno !== node) {
+    activeAnno.classList.remove("is-selected");
+  }
+  activeAnno = node;
+  if (node) node.classList.add("is-selected");
+}
+
+function removeAnnotation(node) {
+  if (!node) return;
+  if (activeAnno === node) activeAnno = null;
+  node.remove();
+}
+
+// ---------------------------------------------------------------------------
+// DRAG — pointer events (mouse, touch, pen)
+// ---------------------------------------------------------------------------
+
+function attachDrag(node) {
+  let startX = 0;
+  let startY = 0;
+  let originLeft = 0;
+  let originTop = 0;
+  let dragging = false;
+  let pointerId = null;
+
+  node.addEventListener("pointerdown", (e) => {
+    // Ignore right-click / middle-click
+    if (e.button !== 0 && e.pointerType === "mouse") return;
+    // If the inner editable text or the remove button caught it, bail.
+    if (e.target.closest(".det-anno__remove")) return;
+    if (e.target.classList?.contains("det-anno__text")) return;
+    dragging = true;
+    pointerId = e.pointerId;
+    node.classList.add("is-dragging");
+    node.setPointerCapture?.(pointerId);
+    startX = e.clientX;
+    startY = e.clientY;
+    originLeft = parseFloat(node.style.left) || 0;
+    originTop = parseFloat(node.style.top) || 0;
+    e.preventDefault();
+  });
+
+  node.addEventListener("pointermove", (e) => {
+    if (!dragging || e.pointerId !== pointerId) return;
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+    const rect = els.canvas.getBoundingClientRect();
+    const nodeRect = node.getBoundingClientRect();
+    const maxLeft = rect.width - Math.max(16, nodeRect.width);
+    const maxTop = rect.height - Math.max(16, nodeRect.height);
+    node.style.left = `${clamp(originLeft + dx, 0, Math.max(0, maxLeft))}px`;
+    node.style.top = `${clamp(originTop + dy, 0, Math.max(0, maxTop))}px`;
+  });
+
+  const endDrag = (e) => {
+    if (!dragging) return;
+    if (e.pointerId !== pointerId) return;
+    dragging = false;
+    node.classList.remove("is-dragging");
+    try {
+      node.releasePointerCapture?.(pointerId);
+    } catch {
+      /* ignore */
+    }
+    pointerId = null;
+  };
+  node.addEventListener("pointerup", endDrag);
+  node.addEventListener("pointercancel", endDrag);
+}
+
+// ---------------------------------------------------------------------------
+// KEYBOARD — Delete/Backspace removes the focused annotation
+// ---------------------------------------------------------------------------
+
+function wireKeyboard() {
+  document.addEventListener("keydown", (e) => {
+    if (e.key !== "Delete" && e.key !== "Backspace") return;
+    const target = document.activeElement;
+    if (!target) return;
+    // Don't hijack delete inside the contenteditable text area or any input.
+    if (target.isContentEditable) return;
+    const tag = target.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA") return;
+    const anno = target.closest?.(".det-anno");
+    if (!anno) return;
+    e.preventDefault();
+    removeAnnotation(anno);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// ACTIONS — export PNG, reset
+// ---------------------------------------------------------------------------
+
+function wireActions() {
+  document
+    .querySelector('[data-action="png"]')
+    ?.addEventListener("click", exportPng);
+  document
+    .querySelector('[data-action="reset"]')
+    ?.addEventListener("click", reset);
+}
+
+async function exportPng() {
+  if (!imageLoaded) {
+    flash("load an image first", true);
+    return;
+  }
+  if (!window.htmlToImage) {
+    flash("html-to-image still loading — try again in a sec.", true);
+    return;
+  }
+  // Hide the empty placeholder if it slipped through, and clear selection
+  // outline so it doesn't bake into the export.
+  if (activeAnno) activeAnno.classList.remove("is-selected");
+  try {
+    flash("rendering…");
+    const dataUrl = await window.htmlToImage.toPng(els.canvas, {
+      pixelRatio: 2,
+      backgroundColor: "#0a0a0a",
+      cacheBust: true,
+    });
+    const a = document.createElement("a");
+    a.href = dataUrl;
+    a.download = `detournement-${stamp()}.png`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    flash("PNG downloaded");
+  } catch (err) {
+    console.error(err);
+    // Best-effort: SecurityError or "Tainted canvases may not be exported"
+    // means the URL paste hit a server without CORS headers. Surface a
+    // clear message that points at the workaround (download + upload).
+    const msg = String(err?.message || err || "");
+    const looksTainted = /tainted|cors|cross.?origin|securityerror/i.test(msg);
+    // Browsers throw a SecurityError when a tainted canvas hits toBlob/toDataURL,
+    // but the message text isn't always identifiable. If we loaded via URL paste
+    // (imageIsTainted set optimistically) and the export blew up, the most
+    // likely cause is a missing CORS header, so we lead with that hypothesis.
+    if (looksTainted || imageIsTainted) {
+      flash(
+        "export blocked — remote image has no CORS headers. Download it and upload instead.",
+        true,
+      );
+    } else {
+      flash("PNG export failed — see console", true);
+    }
+  } finally {
+    if (activeAnno) activeAnno.classList.add("is-selected");
+  }
+}
+
+function reset() {
+  const ok = window.confirm("Wipe the image and every annotation?");
+  if (!ok) return;
+  els.layer.replaceChildren();
+  activeAnno = null;
+  imageLoaded = false;
+  imageIsTainted = false;
+  els.img.hidden = true;
+  els.img.removeAttribute("src");
+  els.img.removeAttribute("crossorigin");
+  if (els.empty) els.empty.hidden = false;
+  if (els.file) els.file.value = "";
+  if (els.url) els.url.value = "";
+  flash("canvas cleared");
+}
+
+// ---------------------------------------------------------------------------
+// HELPERS
+// ---------------------------------------------------------------------------
+
+function clamp(v, min, max) {
+  return Math.min(Math.max(v, min), max);
+}
+
+function stamp() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function flash(msg, isError = false) {
+  if (!els.status) return;
+  els.status.textContent = msg || "";
+  els.status.classList.toggle("is-error", Boolean(isError && msg));
+  clearTimeout(flash._t);
+  flash._t = setTimeout(() => {
+    if (!els.status) return;
+    els.status.textContent = "";
+    els.status.classList.remove("is-error");
+  }, 5000);
+}
+
+// XSS hygiene — exported for parity with the project convention even though
+// every user-supplied string in this widget reaches the DOM via textContent
+// or contentEditable (never innerHTML). Keep these here so future edits that
+// reach for innerHTML have a sanitizer one import-line away.
+// eslint-disable-next-line no-unused-vars
+function escapeHTML(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// eslint-disable-next-line no-unused-vars
+function escapeAttr(s) {
+  return String(s).replace(/"/g, "&quot;").replace(/&/g, "&amp;");
+}

--- a/site/widgets/detournement.html
+++ b/site/widgets/detournement.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>D&eacute;tournement maker &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="Drop an ad image, then overlay zine-style annotations: text, redactions, halftone fills, accent splashes. Export PNG. The original is the spectacle; the export is the d&eacute;tournement."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:title" content="D&eacute;tournement maker — Punk Rock AI" />
+    <meta property="og:description" content="Take the tools of the spectacle and turn them against the spectacle. Annotate any image, export a zine." />
+    <meta property="og:url" content="https://punkrockai.com/widgets/detournement.html" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/widgets/detournement.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main>
+      <section class="det-intro grain scanlines">
+        <div class="wrap wrap--narrow">
+          <p class="kicker kicker--accent">Slide 5 &middot; turn the tools against the spectacle</p>
+          <h1>D&eacute;tournement maker.</h1>
+          <p class="det-intro__lede">
+            The Situationists called it <em>d&eacute;tournement</em> &mdash; taking
+            the tools of corporate spectacle and turning them against the spectacle.
+            Drop in an ad. Mark it up. The original is the message; your export
+            is the rebuttal.
+          </p>
+          <p class="det-intro__hint">
+            Upload a file or paste an image URL. Pick a tool. Click on the canvas
+            to drop an annotation. Drag to reposition. Press <kbd>Delete</kbd>
+            (or hit the <span aria-hidden="true">&times;</span>) to remove.
+          </p>
+        </div>
+      </section>
+
+      <section class="det-load">
+        <div class="wrap wrap--narrow">
+          <div class="det-load__row">
+            <label class="det-load__field">
+              <span class="kicker">Upload image</span>
+              <input id="det-file" type="file" accept="image/*" />
+            </label>
+            <label class="det-load__field">
+              <span class="kicker">&hellip; or paste URL</span>
+              <input id="det-url" type="url" placeholder="https://example.com/ad.jpg" inputmode="url" autocomplete="off" />
+            </label>
+            <button class="btn" type="button" data-action="load-url">Load URL</button>
+          </div>
+          <p class="det-load__note">
+            URL paste sets <code>crossorigin=&quot;anonymous&quot;</code>. If the
+            remote server doesn&rsquo;t send CORS headers, the browser taints the
+            canvas and PNG export fails &mdash; download the image and upload it
+            instead.
+          </p>
+        </div>
+      </section>
+
+      <section class="det-toolbar-wrap">
+        <div class="wrap wrap--narrow">
+          <div class="det-toolbar" role="toolbar" aria-label="Annotation tools">
+            <button class="det-tool is-active" type="button" data-tool="text" aria-pressed="true">Text</button>
+            <button class="det-tool" type="button" data-tool="redaction" aria-pressed="false">Redaction</button>
+            <button class="det-tool" type="button" data-tool="halftone" aria-pressed="false">Halftone</button>
+            <button class="det-tool" type="button" data-tool="splash" aria-pressed="false">Accent splash</button>
+            <button class="det-tool det-tool--ghost" type="button" data-action="clear-overlays">Clear overlays</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="det-canvas-wrap">
+        <div class="wrap">
+          <div class="det-canvas" id="det-canvas" data-tool="text">
+            <div class="det-canvas__empty" id="det-empty">
+              <p>No image yet.</p>
+              <p>Upload a file or paste a URL above to begin.</p>
+            </div>
+            <img class="det-canvas__img" id="det-img" alt="" hidden />
+            <div class="det-canvas__layer" id="det-layer" aria-label="Annotation layer"></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="det-actions">
+        <div class="wrap wrap--narrow">
+          <p class="det-actions__hint">
+            Export flattens the image plus your annotations into a single PNG at
+            2&times; resolution. No server, no upload &mdash; the file is built
+            in your browser.
+          </p>
+          <div class="det-actions__row">
+            <button class="btn btn--primary" type="button" data-action="png">Export PNG</button>
+            <button class="btn" type="button" data-action="reset">Reset everything</button>
+          </div>
+          <p class="det-actions__status" id="det-status" aria-live="polite"></p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.13/dist/html-to-image.min.js" defer></script>
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/detournement.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

New `/widgets/detournement.html` — drop an ad image (upload or URL paste), overlay zine-style annotations (text, redactions, halftone fills, accent splashes), drag to position, export a flattened PNG. Ties to slide 5 (Dada → Punk → DJs → Hip Hop → AI): the original is the spectacle, the export is the détournement.

- Toolbar toggles which annotation the next canvas click drops; each annotation is an absolutely-positioned div inside the export wrapper, draggable via plain pointer events (mouse + touch + pen).
- Text annotations are `contenteditable`; the outer div is the drag handle. Each annotation has a small `×` remove control; Delete/Backspace removes the focused annotation.
- PNG export reuses the `html-to-image` CDN integration from Both Hands at `pixelRatio: 2`. Filename: `detournement-YYYY-MM-DD.png`.
- All theming via existing `theme.css` tokens. No inline scripts/styles. No CSP changes.

## CORS caveat

URL paste sets `crossorigin="anonymous"`. If the remote server omits `Access-Control-Allow-Origin`, the browser taints the canvas and `toPng` throws a `SecurityError`. The catch in `exportPng()` recognises that case and surfaces an inline error pointing at the workaround: download the image and upload it instead. We don't pretend the export worked.

## Test plan

- [ ] Visit `/widgets/detournement.html`, upload a local image, drop one of each tool, drag, export PNG — verify dimensions and that annotations are baked in.
- [ ] Paste a URL from a CORS-friendly host (e.g. an S3 bucket with the right header), export — should succeed.
- [ ] Paste a URL from a server without CORS — export should fail with the explicit "no CORS headers" message instead of silent breakage.
- [ ] Touch device: drag works for all four annotation types; no horizontal scroll outside the canvas.
- [ ] `node --check site/js/widgets/detournement.js` (passes locally).

Closes #28

https://claude.ai/code/session_01S4FVYexCNPKiQT5MS5byvv

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4FVYexCNPKiQT5MS5byvv)_