### PR TITLE
feat(widget): C4 Daily Refrain banner + wire Wave 2 widgets (#35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ build/
 .env
 .env.local
 
+# Claude Code harness internals (worktrees, agent transcripts)
+.claude/
+
 # Generated assets bigger than git wants — drop in assets/generated/ to ignore
 assets/generated/
 assets/slides/

--- a/site/_redirects
+++ b/site/_redirects
@@ -15,6 +15,9 @@
 /widgets/junior-pipeline     /widgets/junior-pipeline.html     200
 /widgets/pattern-graph       /widgets/pattern-graph.html       200
 /widgets/chainsaws           /widgets/chainsaws.html           200
+/widgets/mastery-gym         /widgets/mastery-gym.html         200
+/widgets/receipt             /widgets/receipt.html             200
+/widgets/detournement        /widgets/detournement.html        200
 
 # If an old companion-site path leaks, route home.
 /companion-site/*           /                                  301

--- a/site/_redirects
+++ b/site/_redirects
@@ -12,6 +12,9 @@
 /widgets/name-what-you-see   /widgets/name-what-you-see.html   200
 /widgets/taste-audit         /widgets/taste-audit.html         200
 /widgets/pattern-finder      /widgets/pattern-finder.html      200
+/widgets/junior-pipeline     /widgets/junior-pipeline.html     200
+/widgets/pattern-graph       /widgets/pattern-graph.html       200
+/widgets/chainsaws           /widgets/chainsaws.html           200
 
 # If an old companion-site path leaks, route home.
 /companion-site/*           /                                  301

--- a/site/css/widgets/daily-refrain.css
+++ b/site/css/widgets/daily-refrain.css
@@ -1,0 +1,71 @@
+/* Daily refrain banner — top of /. One of 19 quotes per calendar day,
+   deterministic. Anchors back to its slide on /talk. Tokens-only. */
+
+.daily-refrain {
+  --refrain-min-h: 4.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--refrain-min-h);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--accent);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  color: var(--fg-soft);
+  text-align: center;
+}
+
+.daily-refrain__inner {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2) var(--space-3);
+  max-width: min(72ch, 100%);
+}
+
+.daily-refrain__tag {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+.daily-refrain__link {
+  color: var(--fg);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  font-family: var(--font-display);
+  font-size: var(--fs-md);
+  line-height: 1.35;
+  transition: border-color 120ms var(--ease-snap), color 120ms var(--ease-snap);
+}
+
+.daily-refrain__link:hover,
+.daily-refrain__link:focus-visible {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  outline: none;
+}
+
+.daily-refrain__cite {
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.daily-refrain[data-state="error"] {
+  display: none;
+}
+
+@media (max-width: 560px) {
+  .daily-refrain {
+    padding-block: var(--space-2);
+  }
+  .daily-refrain__link {
+    font-size: var(--fs-sm);
+  }
+}

--- a/site/index.html
+++ b/site/index.html
@@ -16,11 +16,20 @@
     <meta name="twitter:card" content="summary_large_image" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/widgets/daily-refrain.css" />
   </head>
   <body class="shell">
     <header class="site-header" data-include="header"></header>
 
     <main>
+      <aside class="daily-refrain" id="daily-refrain" aria-label="Daily refrain" data-state="loading">
+        <div class="daily-refrain__inner">
+          <span class="daily-refrain__tag">Refrain &middot; today</span>
+          <a class="daily-refrain__link" data-refrain-link href="/talk.html">&hellip;</a>
+          <span class="daily-refrain__cite" data-refrain-cite></span>
+        </div>
+      </aside>
+
       <section class="hero grain scanlines">
         <div class="wrap">
           <p class="hero__date">Creative Mornings Vancouver &middot; 01 . 05 . 2026</p>
@@ -286,6 +295,42 @@
                 <span class="card__cta">Pick up the tool &rarr;</span>
               </a>
             </li>
+            <li>
+              <a class="card" href="/widgets/mastery-gym.html">
+                <span class="card__num">18</span>
+                <h3 class="card__title">Mastery Gym tracker</h3>
+                <p class="card__body">
+                  Daily check-in. One cycle a day &mdash; try, feedback,
+                  iterate &mdash; with a streak counter, a sixteen-week
+                  heatmap, and a Markdown export of your last thirty cycles.
+                </p>
+                <span class="card__cta">Log a cycle &rarr;</span>
+              </a>
+            </li>
+            <li>
+              <a class="card" href="/widgets/receipt.html">
+                <span class="card__num">19</span>
+                <h3 class="card__title">Open Source Receipt</h3>
+                <p class="card__body">
+                  Toy estimator: how much of you is in the training data?
+                  A short questionnaire prints a paper-receipt-style
+                  heuristic. Heavily caveated &mdash; a feeling, not a fact.
+                </p>
+                <span class="card__cta">Print the receipt &rarr;</span>
+              </a>
+            </li>
+            <li>
+              <a class="card" href="/widgets/detournement.html">
+                <span class="card__num">20</span>
+                <h3 class="card__title">D&eacute;tournement maker</h3>
+                <p class="card__body">
+                  Drop in an ad. Mark it up zine-style with text, redactions,
+                  halftone fills, accent splashes. Export the rebuttal as a
+                  PNG. The tools of spectacle, turned against the spectacle.
+                </p>
+                <span class="card__cta">Mark it up &rarr;</span>
+              </a>
+            </li>
           </ul>
         </div>
       </section>
@@ -309,5 +354,6 @@
     <footer class="site-footer" data-include="footer"></footer>
 
     <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/daily-refrain.js" defer></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -249,6 +249,43 @@
                 <span class="card__cta">Scan &rarr;</span>
               </a>
             </li>
+            <li>
+              <a class="card" href="/widgets/junior-pipeline.html">
+                <span class="card__num">15</span>
+                <h3 class="card__title">Junior Pipeline</h3>
+                <p class="card__body">
+                  Two ladders side by side. The old career path. The new one
+                  with the bottom three rungs eaten by AI. Where the next
+                  masters come from is the open question of this decade.
+                </p>
+                <span class="card__cta">See the gap &rarr;</span>
+              </a>
+            </li>
+            <li>
+              <a class="card" href="/widgets/pattern-graph.html">
+                <span class="card__num">16</span>
+                <h3 class="card__title">Pattern cluster graph</h3>
+                <p class="card__body">
+                  Six eras as nodes. Six moves &mdash; cut-up, sampling,
+                  détournement, selection, reuse, refusal &mdash; as edges.
+                  Hover for citations. Click a move to see how the same
+                  gesture manifests across eras.
+                </p>
+                <span class="card__cta">Trace the through-line &rarr;</span>
+              </a>
+            </li>
+            <li>
+              <a class="card" href="/widgets/chainsaws.html">
+                <span class="card__num">17</span>
+                <h3 class="card__title">Chainsaws of history</h3>
+                <p class="card__body">
+                  Every &ldquo;neutral&rdquo; tool was a corporate spectacle
+                  until somebody used it wrong on purpose. Printing press to
+                  AI in six beats, anchored on Anthony Joseph&rsquo;s line.
+                </p>
+                <span class="card__cta">Pick up the tool &rarr;</span>
+              </a>
+            </li>
           </ul>
         </div>
       </section>

--- a/site/js/widgets/daily-refrain.js
+++ b/site/js/widgets/daily-refrain.js
@@ -1,0 +1,47 @@
+// Daily refrain — pick one of the 19 quotes per calendar day, deterministic
+// by date. Render into the banner at the top of /. Anchors back to its
+// slide on /talk via the existing #q-NN-slug fragment scheme.
+
+const root = document.getElementById("daily-refrain");
+if (root) main();
+
+async function main() {
+  try {
+    const res = await fetch("/data/quotes.json", { credentials: "same-origin" });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    const quotes = Array.isArray(data?.quotes) ? data.quotes : [];
+    if (!quotes.length) throw new Error("no quotes");
+    const pick = pickForToday(quotes);
+    render(pick);
+  } catch (err) {
+    console.warn("[daily-refrain]", err);
+    root.dataset.state = "error";
+  }
+}
+
+// daysSinceEpoch in the user's local timezone, modulo quote count.
+// Whole-day boundary in their wall clock so a single user sees the same
+// refrain all day, then a fresh one tomorrow.
+function pickForToday(quotes) {
+  const now = new Date();
+  const tzMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const days = Math.floor(tzMidnight.getTime() / 86400000);
+  const idx = ((days % quotes.length) + quotes.length) % quotes.length;
+  return quotes[idx];
+}
+
+function render(quote) {
+  const linkEl = root.querySelector("[data-refrain-link]");
+  const citeEl = root.querySelector("[data-refrain-cite]");
+  if (!linkEl || !quote) return;
+  linkEl.textContent = quote.text || "";
+  if (quote.id) linkEl.setAttribute("href", `/talk.html#${quote.id}`);
+  if (citeEl) {
+    const parts = [];
+    if (quote.slideTitle) parts.push(quote.slideTitle);
+    if (quote.slide) parts.push(`slide ${quote.slide}`);
+    citeEl.textContent = parts.length ? `↳ ${parts.join(" · ")}` : "";
+  }
+  root.dataset.state = "ready";
+}


### PR DESCRIPTION
## Summary

- **C4 Daily Refrain banner (#35)** — small banner at the top of `/`. Picks one of the 19 quotes per calendar day, deterministic by local-timezone wall clock (`Math.floor(midnight.getTime() / 86400000) % 19`). Anchors back to its slide on `/talk` via the existing `#q-NN-slug` fragment scheme. No layout shift: banner has `min-height: 4.5rem`, JS only fills text + href. CSS-tokens-only styling, hides on data-state="error".
- **Wires Wave 2 widgets** into the landing card grid (cards #18 Mastery Gym, #19 Open Source Receipt, #20 Détournement maker) and adds matching `/widgets/<slug>` clean-URL aliases in `_redirects`.

Closes #35.

## Test plan

- [ ] Visit `/` — banner shows today's quote with a link to `/talk.html#q-NN-slug`. Refresh: same quote. Tomorrow: rotates to the next.
- [ ] Three new cards (#18, #19, #20) render in the Phase 4 grid in order.
- [ ] `/widgets/mastery-gym`, `/widgets/receipt`, `/widgets/detournement` all serve the widget HTML via Cloudflare Pages clean URL alias.
- [ ] `node --check site/js/widgets/daily-refrain.js` passes (verified locally).

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4FVYexCNPKiQT5MS5byvv)_