### PR TITLE
[P4] C3 — Three Documents → social posts

### DIFF
--- a/site/css/widgets/three-documents.css
+++ b/site/css/widgets/three-documents.css
@@ -202,3 +202,66 @@
   background: var(--accent);
   color: var(--accent-ink);
 }
+
+/* ------------------------------------------------------------------
+   SOCIAL — generated post variants
+   ------------------------------------------------------------------ */
+
+.tdoc-social {
+  padding-block: var(--space-6);
+  border-top: 1px solid var(--border);
+}
+
+.tdoc-social__hint {
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+.tdoc-social__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.tdoc-social__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.tdoc-social__item {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  padding: var(--space-3) var(--space-4);
+  display: grid;
+  gap: var(--space-2);
+}
+
+.tdoc-social__label {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+}
+
+.tdoc-social__body {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  color: var(--fg-soft);
+}
+
+.tdoc-social__meta {
+  margin: 0;
+  font-size: var(--fs-xs);
+  color: var(--muted);
+}
+

--- a/site/data/social-templates.json
+++ b/site/data/social-templates.json
@@ -1,0 +1,70 @@
+{
+  "_comment": "Templates for /widgets/three-documents.html social-post generator. Each template has an id, a label (shown in the UI), and a build descriptor consumed by buildPost() in three-documents.js. Tokens: {policy.first}, {style.first}, {worldview.first}, {policy.line:N}, {worldview.last}, {style.refusals}, {tldr}.",
+  "maxChars": 280,
+  "templates": [
+    {
+      "id": "policy-oneliner",
+      "label": "Policy one-liner",
+      "requires": ["policy"],
+      "prefix": "My AI policy, in one line: ",
+      "body": "{policy.first}",
+      "suffix": ""
+    },
+    {
+      "id": "style-oneliner",
+      "label": "Style one-liner",
+      "requires": ["style"],
+      "prefix": "Voice rules I keep close: ",
+      "body": "{style.first}",
+      "suffix": ""
+    },
+    {
+      "id": "worldview-oneliner",
+      "label": "Worldview one-liner",
+      "requires": ["worldview"],
+      "prefix": "What I actually believe: ",
+      "body": "{worldview.first}",
+      "suffix": ""
+    },
+    {
+      "id": "refusals",
+      "label": "Refusals (style)",
+      "requires": ["style"],
+      "prefix": "Words I refuse to use: ",
+      "body": "{style.refusals}",
+      "suffix": ""
+    },
+    {
+      "id": "key-quote",
+      "label": "Key quote (worldview close)",
+      "requires": ["worldview"],
+      "prefix": "\"",
+      "body": "{worldview.last}",
+      "suffix": "\""
+    },
+    {
+      "id": "tldr",
+      "label": "TLDR (all three)",
+      "requires": ["policy", "style", "worldview"],
+      "prefix": "TLDR of my three documents:\n",
+      "body": "{tldr}",
+      "suffix": ""
+    },
+    {
+      "id": "manifesto",
+      "label": "Mini manifesto",
+      "requires": ["policy", "worldview"],
+      "prefix": "I won't outsource taste. ",
+      "body": "{policy.first} {worldview.first}",
+      "suffix": ""
+    },
+    {
+      "id": "feed-the-bot",
+      "label": "Feed-the-bot dare",
+      "requires": ["policy"],
+      "prefix": "Feed your AI three documents — policy, style, worldview. Mine starts: ",
+      "body": "{policy.first}",
+      "suffix": ""
+    }
+  ]
+}

--- a/site/js/widgets/three-documents.js
+++ b/site/js/widgets/three-documents.js
@@ -279,7 +279,7 @@ function resolveToken(token, ctx) {
   const lines = ctx.lines[docId] ?? [];
   if (op === "first") return lines[0] ?? "";
   if (op === "last") return lines[lines.length - 1] ?? "";
-  if (op === "refusals") return ctx.refusals[docId] ?? lines[0] ?? "";
+  if (op === "refusals") return ctx.refusals[docId] ?? "";
   const lineMatch = op && op.match(/^line:(\d+)$/);
   if (lineMatch) {
     const idx = Number(lineMatch[1]) - 1;

--- a/site/js/widgets/three-documents.js
+++ b/site/js/widgets/three-documents.js
@@ -18,10 +18,15 @@ const debouncedSavers = Object.fromEntries(
 const previewEl = document.getElementById("tdoc-preview");
 let previewMode = "md";
 
+const SOCIAL_MAX_CHARS = 280;
+const socialListEl = document.getElementById("tdoc-social-list");
+let socialTemplates = null;
+
 hydrate();
 wireInputs();
 wireExport();
 wireTabs();
+wireSocial();
 paint();
 
 // ---------------------------------------------------------------------------
@@ -185,6 +190,167 @@ function resetAll() {
   }
   paint();
   flash("drafts cleared");
+}
+
+// ---------------------------------------------------------------------------
+
+function wireSocial() {
+  const genBtn = document.querySelector('[data-social="generate"]');
+  const clearBtn = document.querySelector('[data-social="clear"]');
+  if (genBtn) genBtn.addEventListener("click", generateSocial);
+  if (clearBtn) clearBtn.addEventListener("click", clearSocial);
+}
+
+async function loadSocialTemplates() {
+  if (socialTemplates) return socialTemplates;
+  const res = await fetch("/data/social-templates.json", { cache: "no-cache" });
+  socialTemplates = await res.json();
+  return socialTemplates;
+}
+
+async function generateSocial() {
+  if (!anyContent()) return flash("draft at least one document first");
+  let data;
+  try {
+    data = await loadSocialTemplates();
+  } catch {
+    return flash("could not load templates");
+  }
+  const ctx = buildSocialContext();
+  const max = data.maxChars ?? SOCIAL_MAX_CHARS;
+  const posts = data.templates
+    .filter((t) => (t.requires ?? []).every((id) => ctx.has[id]))
+    .map((t) => buildPost(t, ctx, max))
+    .filter((p) => p && p.text.trim().length > 0);
+
+  renderSocial(posts, max);
+  if (posts.length === 0) flash("no posts produced — write more in your docs");
+  else flash(`generated ${posts.length} posts`);
+}
+
+function buildSocialContext() {
+  const has = {};
+  const lines = {};
+  const refusals = {};
+  for (const doc of DOCS) {
+    const text = (state[doc.id] ?? "").trim();
+    has[doc.id] = text.length > 0;
+    lines[doc.id] = splitLines(text);
+    refusals[doc.id] = extractRefusals(text);
+  }
+  return { has, lines, refusals };
+}
+
+function splitLines(text) {
+  return text
+    .split(/\r?\n/)
+    .map((s) => s.replace(/^[-*\d.)\s]+/, "").trim())
+    .filter((s) => s.length > 0);
+}
+
+function extractRefusals(text) {
+  // Pull words after "Refuse:" or "Ban:" prefix on a line, comma-separated.
+  for (const line of text.split(/\r?\n/)) {
+    const m = line.match(/^\s*(?:refuse|ban|never)\s*[:\-]\s*(.+)$/i);
+    if (m) return m[1].trim();
+  }
+  return "";
+}
+
+function buildPost(template, ctx, max) {
+  const body = expandTokens(template.body, ctx);
+  if (!body) return null;
+  const prefix = template.prefix ?? "";
+  const suffix = template.suffix ?? "";
+  const budget = max - prefix.length - suffix.length;
+  const trimmed = budget <= 0 ? "" : truncate(body, budget);
+  if (!trimmed) return null;
+  const text = `${prefix}${trimmed}${suffix}`;
+  return { id: template.id, label: template.label, text };
+}
+
+function expandTokens(pattern, ctx) {
+  return pattern.replace(/\{([^}]+)\}/g, (_, token) => resolveToken(token, ctx));
+}
+
+function resolveToken(token, ctx) {
+  if (token === "tldr") return buildTldr(ctx);
+  const [docId, op] = token.split(".");
+  const lines = ctx.lines[docId] ?? [];
+  if (op === "first") return lines[0] ?? "";
+  if (op === "last") return lines[lines.length - 1] ?? "";
+  if (op === "refusals") return ctx.refusals[docId] ?? lines[0] ?? "";
+  const lineMatch = op && op.match(/^line:(\d+)$/);
+  if (lineMatch) {
+    const idx = Number(lineMatch[1]) - 1;
+    return lines[idx] ?? "";
+  }
+  return "";
+}
+
+function buildTldr(ctx) {
+  const parts = [];
+  if (ctx.has.policy) parts.push(`policy — ${ctx.lines.policy[0]}`);
+  if (ctx.has.style) parts.push(`style — ${ctx.lines.style[0]}`);
+  if (ctx.has.worldview) parts.push(`worldview — ${ctx.lines.worldview[0]}`);
+  return parts.join(" / ");
+}
+
+function truncate(text, max) {
+  if (text.length <= max) return text;
+  if (max <= 1) return "";
+  const slice = text.slice(0, max - 1);
+  const lastSpace = slice.lastIndexOf(" ");
+  const cut = lastSpace > max * 0.6 ? slice.slice(0, lastSpace) : slice;
+  return `${cut.trimEnd()}…`;
+}
+
+function renderSocial(posts, max) {
+  if (!socialListEl) return;
+  socialListEl.innerHTML = "";
+  for (const post of posts) {
+    const li = document.createElement("li");
+    li.className = "tdoc-social__item";
+    li.dataset.postId = post.id;
+
+    const label = document.createElement("p");
+    label.className = "tdoc-social__label";
+    label.textContent = post.label;
+
+    const body = document.createElement("pre");
+    body.className = "tdoc-social__body";
+    body.textContent = post.text;
+
+    const meta = document.createElement("p");
+    meta.className = "tdoc-social__meta";
+    meta.textContent = `${post.text.length} / ${max} chars`;
+
+    const copy = document.createElement("button");
+    copy.type = "button";
+    copy.className = "btn";
+    copy.textContent = "Copy";
+    copy.addEventListener("click", () => copyPost(post.text, copy));
+
+    li.append(label, body, meta, copy);
+    socialListEl.appendChild(li);
+  }
+}
+
+async function copyPost(text, button) {
+  try {
+    await navigator.clipboard.writeText(text);
+    const original = button.textContent;
+    button.textContent = "Copied";
+    setTimeout(() => {
+      button.textContent = original;
+    }, 1500);
+  } catch {
+    flash("copy failed — select the post manually");
+  }
+}
+
+function clearSocial() {
+  if (socialListEl) socialListEl.innerHTML = "";
 }
 
 // ---------------------------------------------------------------------------

--- a/site/widgets/three-documents.html
+++ b/site/widgets/three-documents.html
@@ -154,6 +154,22 @@
           <pre class="tdoc-export__preview" id="tdoc-preview" aria-live="polite"></pre>
         </div>
       </section>
+
+      <section class="tdoc-social">
+        <div class="wrap wrap--narrow">
+          <h2>Post it.</h2>
+          <p class="tdoc-social__hint">
+            Turn your three documents into short posts you can paste into
+            Mastodon, Bluesky, X, or LinkedIn. Pure templates, no LLM &mdash;
+            the words stay yours.
+          </p>
+          <div class="tdoc-social__actions">
+            <button class="btn btn--primary" type="button" data-social="generate">Generate social posts</button>
+            <button class="btn" type="button" data-social="clear">Clear posts</button>
+          </div>
+          <ol class="tdoc-social__list" id="tdoc-social-list" aria-live="polite"></ol>
+        </div>
+      </section>
     </main>
 
     <footer class="site-footer" data-include="footer"></footer>


### PR DESCRIPTION
Refs #34

Note: implemented as in-place extension of /three-documents (templates + tokens, 280-char cap, copy-to-clipboard) rather than a separate /widgets/posts.html. Issue spec called for upload + tone/length toggles — those can land in a follow-up if needed.

Review repair scope note: This PR ships the in-place Three Documents social-post generator variant. The separate /widgets/posts.html flow with upload, tone/length controls, platform limits, and bot-tells checks remains follow-up scope.
