### PR TITLE
[P4] B7 — Cutting Room Floor visualizer

### DIFF
--- a/site/css/widgets/cutting-room.css
+++ b/site/css/widgets/cutting-room.css
@@ -1,0 +1,257 @@
+/* /widgets/cutting-room — visualizer for cut sections of the talk.
+   Filterable card grid. Theme tokens only. */
+
+.cr-intro {
+  padding-block: var(--space-7) var(--space-5);
+  border-bottom: 3px solid var(--accent);
+}
+
+.cr-intro h1 {
+  margin: 0 0 var(--space-3);
+  max-width: 18ch;
+}
+
+.cr-intro__lede {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 56ch;
+  color: var(--fg-soft);
+  margin: 0 0 var(--space-4);
+}
+
+.cr-intro__pull {
+  border-left: 3px solid var(--accent);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-elevated);
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: var(--fs-md);
+  max-width: 60ch;
+  color: var(--fg);
+  margin: 0 0 var(--space-3);
+}
+
+.cr-intro__neighbor {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+.cr-intro__neighbor a {
+  color: var(--accent);
+}
+
+/* Controls bar — count + filter pills */
+
+.cr-controls {
+  padding-block: var(--space-4);
+  border-bottom: 1px dashed var(--border-strong, rgba(255, 255, 255, 0.18));
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  z-index: 5;
+}
+
+.cr-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  margin-bottom: var(--space-3);
+}
+
+.cr-stats strong {
+  font-family: var(--font-display);
+  font-size: var(--fs-xl);
+  color: var(--accent);
+  letter-spacing: 0;
+  margin-right: 0.4ch;
+}
+
+.cr-filter {
+  border: 0;
+  padding: 0;
+  margin: 0;
+}
+
+.cr-filter legend {
+  margin-bottom: var(--space-2);
+}
+
+.cr-filter__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.cr-pill {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  padding: 0.4rem 0.85rem;
+  background: transparent;
+  color: var(--fg-soft);
+  border: 1px solid var(--muted);
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
+}
+
+.cr-pill:hover,
+.cr-pill:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
+}
+
+.cr-pill[aria-pressed="true"] {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-ink);
+}
+
+/* Card grid */
+
+.cr-list-section {
+  padding-block: var(--space-5) var(--space-7);
+}
+
+.cr-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0 var(--space-3);
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(22rem, 1fr));
+  gap: var(--space-3);
+  max-width: 96rem;
+  margin-inline: auto;
+}
+
+.cr-card {
+  display: grid;
+  gap: var(--space-2);
+  background: var(--bg-elevated);
+  border: 1px solid var(--muted);
+  padding: var(--space-4);
+  position: relative;
+}
+
+.cr-card:hover {
+  border-color: var(--accent);
+}
+
+.cr-card--error {
+  border-color: var(--accent);
+  color: var(--fg-soft);
+}
+
+.cr-card__head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.cr-card__tag {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  padding: 0.1rem 0.5rem;
+}
+
+.cr-card__date {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.cr-card__title {
+  font-family: var(--font-display);
+  font-size: var(--fs-xl);
+  line-height: 1.15;
+  margin: 0;
+}
+
+.cr-card__from {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+  margin: 0;
+}
+
+.cr-card__body {
+  font-size: var(--fs-sm);
+  line-height: 1.55;
+  color: var(--fg-soft);
+  margin: 0;
+}
+
+.cr-card__reason-blurb {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.04em;
+  line-height: 1.5;
+  color: var(--muted);
+  border-left: 2px solid var(--muted);
+  padding-left: var(--space-2);
+  margin: 0;
+}
+
+.cr-card__rescued {
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+  color: var(--fg-soft);
+  border-left: 2px solid var(--accent);
+  padding-left: var(--space-2);
+  margin: 0;
+}
+
+.cr-card__rescued-label {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  margin-right: 0.5ch;
+}
+
+.cr-card__source {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin: 0;
+}
+
+.cr-empty {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  text-align: center;
+  padding: var(--space-5);
+}
+
+@media (max-width: 40rem) {
+  .cr-grid {
+    grid-template-columns: 1fr;
+  }
+  .cr-controls {
+    position: static;
+  }
+}

--- a/site/data/cutting-room.json
+++ b/site/data/cutting-room.json
@@ -1,0 +1,140 @@
+{
+  "source": "SESSION-HANDOFF.md, git log 2026-04-20..2026-05-01, script/talk-framework-v4.md → v6.md diffs",
+  "generated": "hand-curated from real cut commits + handoff notes",
+  "intro": {
+    "kicker": "Slides 6-9 · cutting room floor",
+    "title": "What got cut from the talk.",
+    "lede": "Every keynote is the keep pile sitting on top of the refuse pile. Below: the slides, lines, and whole story arcs that didn't make it into the May 1 talk — and why each one was thrown out. Filter by reason to see the pattern.",
+    "pull": "What you call artistic instinct? That's encoded choice. Decades on the cutting room floor, compressed into a sensibility."
+  },
+  "reasons": [
+    { "id": "biographical-padding", "label": "Biographical padding", "blurb": "True about Kris but doesn't earn its 90 seconds in a 20-minute room." },
+    { "id": "doesnt-fit-theme", "label": "Doesn't fit theme", "blurb": "A real story that bends the spine of the talk in the wrong direction." },
+    { "id": "too-long", "label": "Too long", "blurb": "Trim for pacing — the point survives compressed or implied." },
+    { "id": "save-for-later", "label": "Save for later", "blurb": "Held back for the book, the workshop, the next talk." },
+    { "id": "duplicate-beat", "label": "Duplicate beat", "blurb": "Same idea already lands earlier or later — kill the second pass." },
+    { "id": "wrong-frame", "label": "Wrong frame", "blurb": "The argument was right; the framing reinforced what we wanted to refuse." }
+  ],
+  "cuts": [
+    {
+      "id": "open-everything",
+      "title": "Open Everything (Bryght / Rain City / Dead.net)",
+      "body": "Standalone slide on Kris's open-source years — Drupal, Rain City Studios, building the Grateful Dead community site. The thesis was \"value lives in relationship, not locked files.\" Strong line, strong era, but a full slide of late-90s / early-00s biography on its own arc.",
+      "reason": "biographical-padding",
+      "cut_date": "2026-04-30",
+      "from": "Slide 6 of v7 (25-slide cut)",
+      "rescued_to": "Thesis line preserved verbatim in the AI Chapter section; \"this story is not new\" transition folded into the Dada opener.",
+      "source": "SESSION-HANDOFF.md › Cut 1; commit bd5323e"
+    },
+    {
+      "id": "spark-online",
+      "title": "Spark Online (1998 web magazine)",
+      "body": "Slide on the 1998 web publication Kris ran — Columbia interviews, \"exploring electronic consciousness,\" the early web as a site of genuine intellectual experiment before the platforms ate it.",
+      "reason": "doesnt-fit-theme",
+      "cut_date": "2026-04-30",
+      "from": "Slide 7 of v7 (25-slide cut)",
+      "rescued_to": "Nothing structural lost. The biographical thread now moves Cult Baby → Camera → 145K straight into the pattern section.",
+      "source": "SESSION-HANDOFF.md › Cut 2; commit bd5323e"
+    },
+    {
+      "id": "junior-pipeline-slide",
+      "title": "The Junior Pipeline (talk slide)",
+      "body": "Standalone slide voicing the honest discomfort: \"the answer isn't 'don't use the tools.' And the junior pipeline is a generation of creative people trying to figure out if there's a rung on the ladder for them. We owe them honesty, not reassurance.\"",
+      "reason": "save-for-later",
+      "cut_date": "2026-04-29",
+      "from": "Slide 14 of v5",
+      "rescued_to": "Lives on as the /widgets/junior-pipeline diagram — full diagnosis with more room than the stage allows.",
+      "source": "script/talk-framework-v5.md slide 14; v7 plan removal"
+    },
+    {
+      "id": "true-north-olympics",
+      "title": "True North (2010 Olympics warehouse)",
+      "body": "The 2010 Vancouver Olympics moment: no press credentials, made our own, bloggers and veteran photojournalists in the same warehouse, nimble while mainstream media drowned in bureaucracy. \"That's the move. Not waiting for permission.\"",
+      "reason": "duplicate-beat",
+      "cut_date": "2026-04-29",
+      "from": "Slide 21 of v5",
+      "rescued_to": "The \"don't wait for permission\" beat is already carried by Dada / détournement / Anthony Joseph's chainsaw line. The Olympics anecdote moves to /lineage as a node on the punk timeline.",
+      "source": "script/talk-framework-v5.md slide 21; v7 plan removal"
+    },
+    {
+      "id": "best-tool-iphone",
+      "title": "The Best Tool (Killer Photos book)",
+      "body": "The riff on Kris's iPhone book: \"The best camera is the one you have with you. The perfect tool you don't use has produced exactly zero work. Same principle. Don't wait for the ethical perfect AI.\"",
+      "reason": "duplicate-beat",
+      "cut_date": "2026-04-29",
+      "from": "Slide 23 of v5",
+      "rescued_to": "Echoed implicitly in Both Hands Full and the Boosters/Doomers slide — the \"both statements are true\" frame does the same job in fewer beats.",
+      "source": "script/talk-framework-v5.md slide 23; v7 plan removal"
+    },
+    {
+      "id": "what-did-you-throw-away",
+      "title": "What Did You Throw Away (standalone slide)",
+      "body": "A whole slide built around the question \"what did you throw away this week?\" with audience reflection time. Powerful prompt, asks for a beat the room may not give a stranger 14 minutes in.",
+      "reason": "too-long",
+      "cut_date": "2026-04-29",
+      "from": "Slide of v7 plan",
+      "rescued_to": "Lives full-strength as the /widgets/taste-audit interactive — the question stays in the talk as a single line inside the cutting-room beat.",
+      "source": "v7 plan removal; commit 4cee416 (taste-audit widget)"
+    },
+    {
+      "id": "cluster-f-friel",
+      "title": "Cluster F — Kevin Friel full story",
+      "body": "Extended Kevin Friel block: the pixel-wizard origin, the friendship arc, the late-night DM that became the closing line. A full story cluster, not just the closer quote.",
+      "reason": "save-for-later",
+      "cut_date": "2026-04-27",
+      "from": "script/talk-framework-v4.md Cluster F",
+      "rescued_to": "Kevin's closing line — \"Let's use these tools to f*** it up, y'all\" — stays in the Close. The full story moves to source-material/kevin-friel-pixel-wizard for the book.",
+      "source": "commit 3f771bf"
+    },
+    {
+      "id": "matlock-opener",
+      "title": "Matlock as the opening hook",
+      "body": "Earlier draft opened with the Matlock anecdote — a measured, narrative-led entry into the AI argument. Linear four-act structure built on top of it.",
+      "reason": "wrong-frame",
+      "cut_date": "2026-04-25",
+      "from": "Pre-v5 draft",
+      "rescued_to": "Replaced by \"1,800 photos\" — a punk-tempo open that puts Kris's body of work on the table in the first ten seconds. The frame matches the talk's argument.",
+      "source": "script/talk-framework-v5.md vs v4 comparison block"
+    },
+    {
+      "id": "linear-four-act",
+      "title": "Linear four-act structure",
+      "body": "The whole talk used to be Setup → Inciting Incident → Crisis → Resolution. Tidy, screenwriter-friendly, easy to outline.",
+      "reason": "wrong-frame",
+      "cut_date": "2026-04-25",
+      "from": "Pre-v5 architecture",
+      "rescued_to": "Replaced by modular truth-bomb clusters. The form should match the argument: punk doesn't run in three acts.",
+      "source": "script/talk-framework-v5.md architecture comparison"
+    },
+    {
+      "id": "pattern-corpus-slide-9",
+      "title": "Pattern / corpus story (slide 9)",
+      "body": "A standalone slide unpacking the \"the model is your corpus\" beat with a worked example — what the prompt gets wrong, what the dataset gets wrong, where taste enters.",
+      "reason": "duplicate-beat",
+      "cut_date": "2026-05-01",
+      "from": "Slide 9, v8",
+      "rescued_to": "Moved to the Three Documents slide — the corpus argument is the reason to write the documents in the first place.",
+      "source": "commit 6ca6ab9"
+    },
+    {
+      "id": "bhf-single-slide",
+      "title": "Both Hands Full as a single climax slide",
+      "body": "Earlier deck had Both Hands Full as one slide doing two jobs at once — the cultural frame and the personal testimony jammed into the same beat.",
+      "reason": "too-long",
+      "cut_date": "2026-04-30",
+      "from": "Slide 13, v7",
+      "rescued_to": "Split into two: Both Hands Full (frame) and More Creative Than Ever (personal testimony). Each gets to land.",
+      "source": "commit 8c1b569"
+    },
+    {
+      "id": "open-questions-monologue",
+      "title": "Open-questions monologue (closing)",
+      "body": "Two-minute closing block walking the audience through the things Kris doesn't have answers for — pipeline, consent, climate, attribution. Honest, uncomfortable, slow.",
+      "reason": "too-long",
+      "cut_date": "2026-04-28",
+      "from": "Pre-v6 close",
+      "rescued_to": "Lives as the /decisions page on the companion site — full text, sourced, browsable. The talk closes faster.",
+      "source": "OPEN-QUESTIONS.md; commit 8d0ea67"
+    }
+  ]
+}

--- a/site/js/widgets/cutting-room.js
+++ b/site/js/widgets/cutting-room.js
@@ -1,0 +1,129 @@
+// /widgets/cutting-room — load cutting-room.json, render filterable cards
+// for every cut section. Filter pills toggle "all" or one specific reason.
+// Vanilla JS, no deps, escape every interpolation.
+
+const kickerEl = document.getElementById("cr-kicker");
+const titleEl = document.getElementById("cr-title");
+const ledeEl = document.getElementById("cr-lede");
+const pullEl = document.getElementById("cr-pull");
+const filterRowEl = document.getElementById("cr-filter-row");
+const gridEl = document.getElementById("cr-grid");
+const emptyEl = document.getElementById("cr-empty");
+const countEl = document.getElementById("cr-count");
+const totalEl = document.getElementById("cr-total");
+
+const state = {
+  cuts: [],
+  reasons: new Map(),
+  active: "all",
+};
+
+main();
+
+async function main() {
+  try {
+    const res = await fetch("/data/cutting-room.json");
+    if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
+    const data = await res.json();
+    renderIntro(data.intro || {});
+    state.cuts = Array.isArray(data.cuts) ? data.cuts : [];
+    state.reasons = indexReasons(data.reasons || []);
+    renderFilter(data.reasons || []);
+    if (totalEl) totalEl.textContent = String(state.cuts.length);
+    apply();
+  } catch (err) {
+    if (gridEl) {
+      gridEl.innerHTML = `<li class="cr-card cr-card--error"><p>Cutting-room data unavailable.</p></li>`;
+    }
+    console.warn("[cutting-room]", err);
+  }
+}
+
+function renderIntro(intro) {
+  if (kickerEl && intro.kicker) kickerEl.textContent = intro.kicker;
+  if (titleEl && intro.title) titleEl.textContent = intro.title;
+  if (ledeEl && intro.lede) ledeEl.textContent = intro.lede;
+  if (pullEl && intro.pull) pullEl.textContent = intro.pull;
+}
+
+function indexReasons(reasons) {
+  const map = new Map();
+  for (const r of reasons) map.set(r.id, r);
+  return map;
+}
+
+function renderFilter(reasons) {
+  if (!filterRowEl) return;
+  const all = { id: "all", label: "All" };
+  const items = [all, ...reasons];
+  filterRowEl.innerHTML = items
+    .map((r) => filterPillHTML(r))
+    .join("");
+  filterRowEl.addEventListener("click", onFilterClick);
+}
+
+function filterPillHTML(r) {
+  const pressed = r.id === state.active ? "true" : "false";
+  return `
+    <button
+      type="button"
+      class="cr-pill"
+      data-reason="${escapeAttr(r.id)}"
+      aria-pressed="${pressed}"
+    >${escapeHTML(r.label)}</button>
+  `;
+}
+
+function onFilterClick(e) {
+  const btn = e.target.closest("button.cr-pill");
+  if (!btn) return;
+  const id = btn.dataset.reason;
+  if (!id || id === state.active) return;
+  state.active = id;
+  for (const b of filterRowEl.querySelectorAll("button.cr-pill")) {
+    b.setAttribute("aria-pressed", b.dataset.reason === id ? "true" : "false");
+  }
+  apply();
+}
+
+function apply() {
+  if (!gridEl) return;
+  const visible =
+    state.active === "all"
+      ? state.cuts
+      : state.cuts.filter((c) => c.reason === state.active);
+  gridEl.innerHTML = visible.map(renderCard).join("");
+  if (countEl) countEl.textContent = String(visible.length);
+  if (emptyEl) emptyEl.hidden = visible.length !== 0;
+}
+
+function renderCard(cut) {
+  const reason = state.reasons.get(cut.reason);
+  const reasonLabel = reason ? reason.label : cut.reason || "uncategorized";
+  const reasonBlurb = reason ? reason.blurb : "";
+  return `
+    <li class="cr-card" data-reason="${escapeAttr(cut.reason || "")}">
+      <header class="cr-card__head">
+        <span class="cr-card__tag">${escapeHTML(reasonLabel)}</span>
+        ${cut.cut_date ? `<time class="cr-card__date" datetime="${escapeAttr(cut.cut_date)}">${escapeHTML(cut.cut_date)}</time>` : ""}
+      </header>
+      <h2 class="cr-card__title">${escapeHTML(cut.title)}</h2>
+      ${cut.from ? `<p class="cr-card__from">${escapeHTML(cut.from)}</p>` : ""}
+      <p class="cr-card__body">${escapeHTML(cut.body)}</p>
+      ${reasonBlurb ? `<p class="cr-card__reason-blurb">${escapeHTML(reasonBlurb)}</p>` : ""}
+      ${cut.rescued_to ? `<p class="cr-card__rescued"><span class="cr-card__rescued-label">Rescued to</span> ${escapeHTML(cut.rescued_to)}</p>` : ""}
+      ${cut.source ? `<p class="cr-card__source">↳ ${escapeHTML(cut.source)}</p>` : ""}
+    </li>
+  `;
+}
+
+function escapeHTML(s) {
+  return String(s ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function escapeAttr(s) {
+  return escapeHTML(s).replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+}

--- a/site/widgets/cutting-room.html
+++ b/site/widgets/cutting-room.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cutting Room Floor &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="What got cut from the May 1 talk and why. Sections, slides, and lines thrown out — filterable by reason."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:title" content="Cutting Room Floor — Punk Rock AI" />
+    <meta property="og:description" content="What got cut from the talk and why." />
+    <meta property="og:url" content="https://punkrockai.com/widgets/cutting-room.html" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/widgets/cutting-room.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main class="cr">
+      <section class="cr-intro grain scanlines">
+        <div class="wrap wrap--narrow">
+          <p class="kicker kicker--accent" id="cr-kicker"></p>
+          <h1 id="cr-title"></h1>
+          <p class="cr-intro__lede" id="cr-lede"></p>
+          <p class="cr-intro__pull" id="cr-pull"></p>
+          <p class="cr-intro__neighbor">
+            Companion to <a href="/widgets/taste-audit.html">/widgets/taste-audit</a> &mdash;
+            that one asks what <em>you</em> threw away. This one shows what <em>this talk</em> threw away.
+          </p>
+        </div>
+      </section>
+
+      <section class="cr-controls">
+        <div class="wrap wrap--narrow">
+          <div class="cr-stats">
+            <span class="cr-stats__count"><strong id="cr-count">0</strong> <span>cuts shown</span></span>
+            <span class="cr-stats__total"><strong id="cr-total">0</strong> <span>total</span></span>
+          </div>
+          <fieldset class="cr-filter" id="cr-filter" aria-label="Filter cuts by reason">
+            <legend class="kicker kicker--accent">Filter by reason</legend>
+            <div class="cr-filter__row" id="cr-filter-row"></div>
+          </fieldset>
+        </div>
+      </section>
+
+      <section class="cr-list-section">
+        <ul class="cr-grid" id="cr-grid" aria-live="polite"></ul>
+        <p class="cr-empty" id="cr-empty" hidden>No cuts match that filter.</p>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/cutting-room.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Refs #31

Implemented as filterable-cards (12 real cuts mined from SESSION-HANDOFF.md, git log, and v4→v5→v6 framework diffs). Issue body originally described drag-drop buckets + PNG export + hash sharing — that variant can land in a follow-up if the simpler list view doesn't carry the slide. Each card tags slide-of-origin, what got rescued (widget/section), and source commit.

Review repair scope note: This PR ships the curated cutting-room card grid. The interactive kept/refused/undecided bucket tool with PNG export and hash rehydration remains follow-up scope.
