### PR TITLE
[P4] C2 — Receipt printer for AI output

### DIFF
--- a/site/css/widgets/receipt-print.css
+++ b/site/css/widgets/receipt-print.css
@@ -1,0 +1,401 @@
+/* /widgets/receipt-print.html — Thermal receipt printer for AI output.
+   Narrow column, monospace, black on white, perforated edges, line-by-line
+   reveal animation. The point is to make the bot's words look mortal.
+   ------------------------------------------------------------------ */
+
+.rcpp-intro {
+  padding-block: var(--space-6);
+  border-bottom: 1px solid var(--border);
+}
+
+.rcpp-intro h1 {
+  margin: 0 0 var(--space-3);
+}
+
+.rcpp-intro__lede {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 50ch;
+  color: var(--fg-soft);
+}
+
+.rcpp-intro__hint {
+  margin-top: var(--space-3);
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+/* ------------------------------------------------------------------
+   APP LAYOUT
+   ------------------------------------------------------------------ */
+
+.rcpp-app {
+  padding-block: var(--space-5);
+}
+
+.rcpp-layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-5);
+  align-items: start;
+}
+
+@media (min-width: 880px) {
+  .rcpp-layout {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: var(--space-6);
+  }
+}
+
+.rcpp-panel {
+  font-family: var(--font-mono);
+}
+
+.rcpp-h2 {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 var(--space-2);
+}
+
+.rcpp-h3 {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: var(--space-5) 0 var(--space-2);
+}
+
+.rcpp-textarea {
+  width: 100%;
+  min-height: 12rem;
+  padding: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+  background: #0d0d0d;
+  color: var(--fg);
+  border: 1px solid var(--border-strong);
+  border-radius: 0;
+  resize: vertical;
+}
+
+.rcpp-textarea:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.rcpp-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+}
+
+.rcpp-row--options {
+  align-items: center;
+}
+
+.rcpp-opt {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fg-soft);
+}
+
+.rcpp-opt--check {
+  cursor: pointer;
+}
+
+.rcpp-select {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  background: #0d0d0d;
+  color: var(--fg);
+  border: 1px solid var(--border-strong);
+  padding: 0.35rem 0.5rem;
+  border-radius: 0;
+}
+
+.rcpp-status {
+  margin-top: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  min-height: 1.2em;
+}
+
+.rcpp-samples {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.rcpp-sample {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  padding: var(--space-3);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--fg);
+  text-align: left;
+  width: 100%;
+  display: block;
+  transition: border-color 120ms var(--ease-snap), background 120ms var(--ease-snap);
+}
+
+.rcpp-sample:hover,
+.rcpp-sample:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.rcpp-sample__label {
+  display: block;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 0.25rem;
+}
+
+.rcpp-sample__prompt {
+  display: block;
+  color: var(--muted);
+  font-style: italic;
+  font-size: var(--fs-xs);
+}
+
+/* ------------------------------------------------------------------
+   STAGE — printer hardware + paper
+   ------------------------------------------------------------------ */
+
+.rcpp-stage {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-block: var(--space-3);
+}
+
+.rcpp-printer {
+  width: 100%;
+  max-width: 22rem;
+  height: 4.5rem;
+  background: linear-gradient(#2a2a2a, #1a1a1a);
+  border-radius: 6px 6px 2px 2px;
+  position: relative;
+  box-shadow:
+    inset 0 -2px 0 rgba(0, 0, 0, 0.6),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 4px 0 rgba(0, 0, 0, 0.4);
+  z-index: 2;
+}
+
+.rcpp-printer::before {
+  content: "";
+  position: absolute;
+  top: 0.5rem;
+  left: 0.75rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: #d3504a;
+  box-shadow: 0 0 6px rgba(211, 80, 74, 0.6);
+}
+
+.rcpp-printer__slot {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0;
+  height: 0.55rem;
+  background: #050505;
+  border-top: 1px solid #000;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.8);
+}
+
+/* Paper feeds out of the slot. */
+.rcpp-receipt {
+  font-family: var(--font-mono);
+  color: #1a1a1a;
+  background-color: #f6f1e6;
+  background-image:
+    repeating-linear-gradient(
+      0deg,
+      rgba(0, 0, 0, 0.02) 0,
+      rgba(0, 0, 0, 0.02) 1px,
+      transparent 1px,
+      transparent 3px
+    );
+  width: 100%;
+  max-width: 22rem;
+  padding: var(--space-4) var(--space-3) var(--space-3);
+  margin-top: -0.4rem;
+  position: relative;
+  z-index: 1;
+  box-shadow:
+    0 1px 0 rgba(0, 0, 0, 0.3),
+    6px 10px 0 rgba(0, 0, 0, 0.35);
+  /* perforated/torn paper edges top + bottom */
+  --edge: polygon(
+    0 6px,
+    3% 0,
+    9% 5px,
+    16% 1px,
+    24% 5px,
+    33% 0,
+    41% 5px,
+    50% 1px,
+    59% 5px,
+    68% 0,
+    77% 5px,
+    86% 1px,
+    94% 5px,
+    100% 0,
+    100% calc(100% - 6px),
+    96% 100%,
+    89% calc(100% - 5px),
+    80% calc(100% - 1px),
+    71% calc(100% - 5px),
+    62% 100%,
+    53% calc(100% - 5px),
+    44% calc(100% - 1px),
+    35% calc(100% - 5px),
+    26% 100%,
+    17% calc(100% - 5px),
+    8% calc(100% - 1px),
+    2% calc(100% - 5px),
+    0 100%
+  );
+  clip-path: var(--edge);
+}
+
+.rcpp-receipt p,
+.rcpp-receipt div,
+.rcpp-receipt li {
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-mono);
+  color: #1a1a1a;
+  font-size: 0.78rem;
+  line-height: 1.55;
+}
+
+.rcpp-receipt__head {
+  text-align: center;
+  margin-bottom: var(--space-2);
+}
+
+.rcpp-receipt__brand {
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  font-size: 0.85rem;
+}
+
+.rcpp-receipt__sub {
+  letter-spacing: 0.14em;
+  font-size: 0.7rem;
+  opacity: 0.75;
+}
+
+.rcpp-receipt__rule {
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  user-select: none;
+  margin-block: 0.25rem;
+}
+
+.rcpp-receipt__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-2);
+  letter-spacing: 0.1em;
+  font-size: 0.7rem;
+}
+
+.rcpp-receipt__body {
+  margin-top: var(--space-2);
+  /* receipt printers use ~32 char columns. Hard-wrap text to that width. */
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.rcpp-receipt__line {
+  display: block;
+  white-space: pre-wrap;
+  word-break: break-word;
+  /* line-by-line reveal */
+  opacity: 0;
+  transform: translateY(-0.4rem);
+  animation: rcpp-feed 240ms var(--ease-snap, ease-out) forwards;
+}
+
+.rcpp-receipt__line--blank {
+  height: 0.9em;
+}
+
+@keyframes rcpp-feed {
+  0% {
+    opacity: 0;
+    transform: translateY(-0.6rem);
+    filter: blur(1px);
+  }
+  60% {
+    opacity: 0.85;
+    filter: blur(0);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+}
+
+.rcpp-receipt__placeholder {
+  text-align: center;
+  font-style: italic;
+  opacity: 0.6;
+  padding-block: var(--space-3);
+}
+
+.rcpp-receipt__foot {
+  margin-top: var(--space-3);
+  text-align: center;
+}
+
+.rcpp-receipt__thanks {
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  margin-block: var(--space-2);
+}
+
+.rcpp-receipt__barcode {
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+  letter-spacing: 0.22em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rcpp-receipt__line {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/site/data/receipt-samples.json
+++ b/site/data/receipt-samples.json
@@ -1,0 +1,30 @@
+{
+  "source": "Hand-curated AI outputs that read like AI outputs.",
+  "generated": "hand-curated",
+  "samples": [
+    {
+      "id": "delve-tapestry",
+      "label": "The classic delve",
+      "prompt": "Write a paragraph about creativity in the age of AI.",
+      "output": "In today's rapidly evolving digital landscape, it's important to delve into the multifaceted ways artificial intelligence is reshaping the creative process. From streamlining workflows to unlocking unprecedented possibilities, AI serves as both a tool and a collaborator. Ultimately, the synergy between human ingenuity and machine intelligence weaves a rich tapestry of innovation that empowers creators to push boundaries and redefine what's possible."
+    },
+    {
+      "id": "hedge-stack",
+      "label": "Hedge stack",
+      "prompt": "Should I use AI for writing my novel?",
+      "output": "It's worth noting that the answer may vary depending on a number of factors. While some writers find AI tools helpful, others may prefer to rely on their own creativity. Generally speaking, it could be argued that the best approach is one that aligns with your individual goals and writing style. That said, it's important to remember that AI is just a tool, and the creative spark must ultimately come from you."
+    },
+    {
+      "id": "bullet-spam",
+      "label": "Bullet spam",
+      "prompt": "Tips for taking better photographs.",
+      "output": "Here are some key tips to help you take better photographs:\n- Pay attention to lighting: natural light is your friend.\n- Use the rule of thirds to compose more dynamic shots.\n- Don't be afraid to experiment with angles and perspectives.\n- Practice consistently to develop your eye.\n- Remember: the best camera is the one you have with you.\n\nBy following these guidelines, you'll be well on your way to capturing more compelling images."
+    },
+    {
+      "id": "punk-rock-ai",
+      "label": "Punk Rock AI manifesto",
+      "prompt": "Why does punk rock matter for AI?",
+      "output": "Punk wasn't a sound. It was a permission slip.\n\nThree chords. A garage. A xerox zine. The covenant: if you make it, you ship it. If you ship it, somebody else can take it apart.\n\nThe machines we use today were trained on the open web that covenant built. We kept our side of the deal. Now the deal is being renegotiated without us in the room.\n\nSo: name what you see. Make the thing. Show your work. Bring a posse.\n\nThe mainstream will catch up in eighteen months. By then we'll be somewhere else."
+    }
+  ]
+}

--- a/site/js/widgets/receipt-print.js
+++ b/site/js/widgets/receipt-print.js
@@ -1,0 +1,346 @@
+// /widgets/receipt-print.html — Thermal receipt printer for AI output.
+//
+// Paste any AI output. We word-wrap it to a 32-character column and reveal
+// it one line at a time, like paper feeding out of a thermal receipt
+// printer. Optional WebAudio "chrr-chrr" stepper sound plays per line.
+//
+// No model call. No network. Just a tactile re-render of text the user
+// already has.
+
+import { load, save } from "/js/common/storage.js";
+
+const STORAGE_KEY = "rcpp:state";
+const SAMPLES_URL = "/data/receipt-samples.json";
+const COLUMN_WIDTH = 32; // classic 80mm thermal printer column
+
+const SPEED_MS = {
+  fast: 35,
+  medium: 90,
+  slow: 220,
+};
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const state = {
+  speed: "medium",
+  sound: false,
+  samples: [],
+  printing: false,
+  abort: false,
+};
+
+const els = {};
+
+bootstrap();
+
+async function bootstrap() {
+  cacheEls();
+  hydrate();
+  wire();
+  paintMeta();
+  await loadSamples();
+}
+
+function cacheEls() {
+  els.input = document.getElementById("rcpp-input");
+  els.speed = document.getElementById("rcpp-speed");
+  els.sound = document.getElementById("rcpp-sound");
+  els.status = document.getElementById("rcpp-status");
+  els.samples = document.getElementById("rcpp-samples");
+  els.lines = document.querySelector("[data-lines]");
+  els.foot = document.querySelector("[data-foot]");
+  els.stamp = document.querySelector("[data-stamp]");
+  els.time = document.querySelector("[data-time]");
+}
+
+function hydrate() {
+  const { value } = load(STORAGE_KEY, null);
+  if (value && typeof value === "object") {
+    if (value.speed in SPEED_MS) state.speed = value.speed;
+    if (typeof value.sound === "boolean") state.sound = value.sound;
+  }
+  if (els.speed) els.speed.value = state.speed;
+  if (els.sound) els.sound.checked = state.sound;
+}
+
+function persist() {
+  save(STORAGE_KEY, { speed: state.speed, sound: state.sound });
+}
+
+function wire() {
+  document
+    .querySelector('[data-action="print"]')
+    ?.addEventListener("click", onPrint);
+  document
+    .querySelector('[data-action="stop"]')
+    ?.addEventListener("click", onStop);
+  document
+    .querySelector('[data-action="clear"]')
+    ?.addEventListener("click", onClear);
+
+  els.speed?.addEventListener("change", () => {
+    state.speed = els.speed.value in SPEED_MS ? els.speed.value : "medium";
+    persist();
+  });
+  els.sound?.addEventListener("change", () => {
+    state.sound = !!els.sound.checked;
+    persist();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Samples
+// ---------------------------------------------------------------------------
+
+async function loadSamples() {
+  if (!els.samples) return;
+  try {
+    const res = await fetch(SAMPLES_URL, { cache: "no-cache" });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    state.samples = Array.isArray(data?.samples) ? data.samples : [];
+    renderSamples();
+  } catch (err) {
+    console.warn("[receipt-print] sample load failed:", err);
+    els.samples.innerHTML =
+      '<li class="rcpp-sample__error">samples unavailable - paste your own</li>';
+  }
+}
+
+function renderSamples() {
+  if (!els.samples) return;
+  els.samples.innerHTML = "";
+  for (const s of state.samples) {
+    const li = document.createElement("li");
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "rcpp-sample";
+    btn.innerHTML = `
+      <span class="rcpp-sample__label">${escapeHTML(s.label || s.id)}</span>
+      <span class="rcpp-sample__prompt">prompt: ${escapeHTML(s.prompt || "(none)")}</span>
+    `;
+    btn.addEventListener("click", () => {
+      if (els.input) els.input.value = s.output || "";
+      flash("sample loaded - press print");
+      els.input?.focus();
+    });
+    li.appendChild(btn);
+    els.samples.appendChild(li);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Print
+// ---------------------------------------------------------------------------
+
+async function onPrint() {
+  if (state.printing) {
+    flash("already printing - stop first");
+    return;
+  }
+  const text = (els.input?.value || "").trim();
+  if (!text) {
+    flash("paste something first");
+    return;
+  }
+  const lines = wrapLines(text, COLUMN_WIDTH);
+  if (!lines.length) {
+    flash("nothing to print");
+    return;
+  }
+  await printLines(lines);
+}
+
+function onStop() {
+  if (!state.printing) return;
+  state.abort = true;
+  flash("stopping...");
+}
+
+function onClear() {
+  if (state.printing) {
+    state.abort = true;
+  }
+  if (els.input) els.input.value = "";
+  resetReceipt();
+  flash("cleared");
+}
+
+async function printLines(lines) {
+  resetReceipt();
+  paintMeta();
+
+  state.printing = true;
+  state.abort = false;
+  flash("printing...");
+
+  const delay = SPEED_MS[state.speed] || SPEED_MS.medium;
+  const reduced = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+  const sound = state.sound ? new PrinterSound() : null;
+
+  for (const line of lines) {
+    if (state.abort) break;
+    appendLine(line);
+    if (sound && line.length) sound.tick();
+    if (!reduced) {
+      // small per-line wait so the reveal is paced like a printer feed
+      await wait(delay);
+    }
+  }
+
+  if (sound) sound.dispose();
+
+  if (els.foot) els.foot.hidden = state.abort;
+  state.printing = false;
+  flash(state.abort ? "stopped" : "done");
+}
+
+function resetReceipt() {
+  if (els.lines) els.lines.innerHTML = "";
+  if (els.foot) els.foot.hidden = true;
+}
+
+function appendLine(text) {
+  if (!els.lines) return;
+  const p = document.createElement("p");
+  if (text === "") {
+    p.className = "rcpp-receipt__line rcpp-receipt__line--blank";
+    p.innerHTML = "&nbsp;";
+  } else {
+    p.className = "rcpp-receipt__line";
+    p.textContent = text;
+  }
+  els.lines.appendChild(p);
+  // keep newest line in view inside the receipt
+  p.scrollIntoView({ block: "nearest", behavior: "smooth" });
+}
+
+// ---------------------------------------------------------------------------
+// Word wrap to fixed column width. Preserves blank lines, breaks long words.
+// ---------------------------------------------------------------------------
+
+function wrapLines(text, width) {
+  const out = [];
+  const paragraphs = String(text).replace(/\r\n/g, "\n").split("\n");
+  for (const para of paragraphs) {
+    if (para.trim() === "") {
+      out.push("");
+      continue;
+    }
+    const words = para.split(/\s+/).filter(Boolean);
+    let current = "";
+    for (const word of words) {
+      if (word.length > width) {
+        if (current) {
+          out.push(current);
+          current = "";
+        }
+        for (let i = 0; i < word.length; i += width) {
+          const chunk = word.slice(i, i + width);
+          if (chunk.length === width) {
+            out.push(chunk);
+          } else {
+            current = chunk;
+          }
+        }
+        continue;
+      }
+      const tentative = current ? current + " " + word : word;
+      if (tentative.length > width) {
+        out.push(current);
+        current = word;
+      } else {
+        current = tentative;
+      }
+    }
+    if (current) out.push(current);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// WebAudio "chrr-chrr" stepper sound. Built per-print so a stopped print
+// can release its AudioContext cleanly.
+// ---------------------------------------------------------------------------
+
+class PrinterSound {
+  constructor() {
+    this.ctx = null;
+    try {
+      const Ctor = window.AudioContext || window.webkitAudioContext;
+      if (Ctor) this.ctx = new Ctor();
+    } catch (err) {
+      console.warn("[receipt-print] audio unavailable:", err);
+    }
+  }
+  tick() {
+    if (!this.ctx) return;
+    const t = this.ctx.currentTime;
+    const dur = 0.045;
+    // short noise burst -> stepper-motor "chrr"
+    const buf = this.ctx.createBuffer(
+      1,
+      Math.floor(this.ctx.sampleRate * dur),
+      this.ctx.sampleRate,
+    );
+    const data = buf.getChannelData(0);
+    for (let i = 0; i < data.length; i++) {
+      data[i] = (Math.random() * 2 - 1) * (1 - i / data.length);
+    }
+    const src = this.ctx.createBufferSource();
+    src.buffer = buf;
+    const filt = this.ctx.createBiquadFilter();
+    filt.type = "bandpass";
+    filt.frequency.value = 1800;
+    filt.Q.value = 6;
+    const gain = this.ctx.createGain();
+    gain.gain.setValueAtTime(0.18, t);
+    gain.gain.exponentialRampToValueAtTime(0.001, t + dur);
+    src.connect(filt).connect(gain).connect(this.ctx.destination);
+    src.start(t);
+    src.stop(t + dur);
+  }
+  dispose() {
+    if (!this.ctx) return;
+    try {
+      this.ctx.close();
+    } catch (_err) {
+      // ignore
+    }
+    this.ctx = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function paintMeta() {
+  const now = new Date();
+  if (els.stamp) els.stamp.textContent = now.toISOString().slice(0, 10);
+  if (els.time) els.time.textContent = now.toTimeString().slice(0, 5);
+}
+
+function flash(msg) {
+  if (!els.status) return;
+  els.status.textContent = msg;
+  clearTimeout(flash._t);
+  flash._t = setTimeout(() => {
+    if (els.status) els.status.textContent = "";
+  }, 3000);
+}
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function escapeHTML(str) {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/site/widgets/receipt-print.html
+++ b/site/widgets/receipt-print.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Receipt printer &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="Paste any AI output. Watch the bot's reply print out of a thermal receipt printer, line by line, in monospace black on white. A small act of de-glamorization."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/widgets/receipt-print.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main>
+      <section class="rcpp-intro grain scanlines">
+        <div class="wrap wrap--narrow">
+          <p class="kicker kicker--accent">Slides 14 + 18 &middot; the bot, downgraded</p>
+          <h1>Receipt printer.</h1>
+          <p class="rcpp-intro__lede">
+            Paste anything an AI wrote. Watch it print out of a tiny
+            thermal receipt printer &mdash; black on white, narrow
+            column, one line at a time. The same words, deglamorized.
+          </p>
+          <p class="rcpp-intro__hint">
+            No magic. No model call. Just paper-feel rendering of text
+            you already have.
+          </p>
+        </div>
+      </section>
+
+      <section class="rcpp-app">
+        <div class="wrap">
+          <div class="rcpp-layout">
+            <div class="rcpp-panel">
+              <h2 class="rcpp-h2">Source text</h2>
+              <label class="sr-only" for="rcpp-input">AI output to print</label>
+              <textarea
+                id="rcpp-input"
+                class="rcpp-textarea"
+                rows="10"
+                placeholder="Paste AI output here. Or pick a sample below."
+              ></textarea>
+
+              <div class="rcpp-row">
+                <button class="btn btn--primary" type="button" data-action="print">Print receipt</button>
+                <button class="btn" type="button" data-action="stop">Stop</button>
+                <button class="btn" type="button" data-action="clear">Clear</button>
+              </div>
+
+              <div class="rcpp-row rcpp-row--options">
+                <label class="rcpp-opt">
+                  <span>Speed</span>
+                  <select id="rcpp-speed" class="rcpp-select">
+                    <option value="fast">Fast</option>
+                    <option value="medium" selected>Medium</option>
+                    <option value="slow">Slow</option>
+                  </select>
+                </label>
+                <label class="rcpp-opt rcpp-opt--check">
+                  <input type="checkbox" id="rcpp-sound" />
+                  <span>Printer sound</span>
+                </label>
+              </div>
+              <p class="rcpp-status" id="rcpp-status" aria-live="polite"></p>
+
+              <h3 class="rcpp-h3">Or pick a sample</h3>
+              <ul class="rcpp-samples" id="rcpp-samples" data-samples></ul>
+            </div>
+
+            <div class="rcpp-stage" aria-label="Receipt printer">
+              <div class="rcpp-printer" aria-hidden="true">
+                <div class="rcpp-printer__slot"></div>
+              </div>
+              <article
+                class="rcpp-receipt"
+                id="rcpp-receipt"
+                aria-live="polite"
+                aria-label="Printed receipt"
+              >
+                <header class="rcpp-receipt__head">
+                  <p class="rcpp-receipt__brand">PUNK ROCK AI</p>
+                  <p class="rcpp-receipt__sub">RECEIPT PRINTER v1</p>
+                  <p class="rcpp-receipt__rule" aria-hidden="true">================================</p>
+                  <p class="rcpp-receipt__meta">
+                    <span data-stamp>0000-00-00</span>
+                    <span data-time>00:00</span>
+                  </p>
+                  <p class="rcpp-receipt__rule" aria-hidden="true">--------------------------------</p>
+                </header>
+                <div class="rcpp-receipt__body" data-lines>
+                  <p class="rcpp-receipt__placeholder">
+                    Paste text and press <em>Print receipt</em>.
+                  </p>
+                </div>
+                <footer class="rcpp-receipt__foot" data-foot hidden>
+                  <p class="rcpp-receipt__rule" aria-hidden="true">================================</p>
+                  <p class="rcpp-receipt__thanks">END OF OUTPUT</p>
+                  <p class="rcpp-receipt__barcode" aria-hidden="true">|||| |||| || |||| ||||</p>
+                </footer>
+              </article>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/receipt-print.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Refs #33 (the heuristics widget #33 originally specified is tracked as #125 — this PR delivers a separate thermal-printer aesthetic at /widgets/receipt-print)

Important: existing site/widgets/receipt.html is the shipped "Open Source Receipt" widget (PR #78, training-data footprint estimator) — not a stub as the brief assumed. Built this at receipt-print.* to avoid collision. Thermal-printer aesthetic, 32-col wrap, line-by-line reveal, optional chrr-chrr WebAudio, prefers-reduced-motion respected.