### PR TITLE
[P4] C6 — Releases Wall public submissions stream

### DIFF
--- a/site/css/widgets/releases-wall.css
+++ b/site/css/widgets/releases-wall.css
@@ -1,0 +1,157 @@
+/* /widgets/releases-wall — public masonry stream of Release Day submissions */
+
+.rw-intro {
+  padding-block: var(--space-6);
+  border-bottom: 1px solid var(--border);
+}
+
+.rw-intro h1 {
+  margin: 0 0 var(--space-3);
+  font-size: var(--fs-2xl);
+}
+
+.rw-intro__lede {
+  color: var(--fg-soft);
+  max-width: 60ch;
+  margin: 0;
+}
+
+.rw-stats {
+  margin-top: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+}
+
+/* ------------------------------------------------------------------
+   GRID — CSS columns give a true masonry effect with vanilla CSS
+   ------------------------------------------------------------------ */
+
+.rw {
+  padding-block: var(--space-5);
+}
+
+.rw__grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  column-gap: var(--space-3);
+  column-count: 1;
+}
+
+@media (min-width: 40rem) {
+  .rw__grid {
+    column-count: 2;
+  }
+}
+
+@media (min-width: 64rem) {
+  .rw__grid {
+    column-count: 3;
+  }
+}
+
+@media (min-width: 90rem) {
+  .rw__grid {
+    column-count: 4;
+  }
+}
+
+.rw__empty,
+.rw__error {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  color: var(--muted);
+  text-align: center;
+  padding-block: var(--space-5);
+  font-style: italic;
+}
+
+.rw__error {
+  color: var(--accent);
+}
+
+/* ------------------------------------------------------------------
+   CARD — break-inside: avoid keeps cards intact across columns
+   ------------------------------------------------------------------ */
+
+.rw-card {
+  break-inside: avoid;
+  display: block;
+  margin: 0 0 var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+}
+
+.rw-card__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.rw-card__handle {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  word-break: break-word;
+}
+
+.rw-card__time {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.rw-card__title {
+  margin: 0 0 var(--space-2);
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.2;
+}
+
+.rw-card__title-link {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  transition: border-color 120ms ease;
+}
+
+.rw-card__title-link:hover,
+.rw-card__title-link:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.rw-card__body {
+  margin: 0 0 var(--space-2);
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+  color: var(--fg-soft);
+}
+
+.rw-card__cta {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.rw-card__cta:hover,
+.rw-card__cta:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}

--- a/site/js/widgets/releases-wall.js
+++ b/site/js/widgets/releases-wall.js
@@ -1,0 +1,152 @@
+// /widgets/releases-wall — public stream of Release Day submissions.
+// Tries the live worker endpoint first; falls back to the static JSON in
+// site/data/submissions.json. Cards are recency-sorted (newest first) and
+// laid out as a CSS-column masonry stream.
+
+const LIVE_ENDPOINT = "/api/submissions";
+const FALLBACK_ENDPOINT = "/data/submissions.json";
+
+const gridEl = document.getElementById("rw-grid");
+const emptyEl = document.getElementById("rw-empty");
+const errorEl = document.getElementById("rw-error");
+const statsEl = document.getElementById("rw-stats");
+
+main();
+
+async function main() {
+  const submissions = await loadSubmissions();
+  if (submissions === null) {
+    if (errorEl) errorEl.hidden = false;
+    if (statsEl) statsEl.textContent = "feed unavailable";
+    return;
+  }
+  const sorted = sortByRecency(submissions);
+  paintStats(sorted);
+  paintGrid(sorted);
+}
+
+async function loadSubmissions() {
+  const live = await tryFetch(LIVE_ENDPOINT);
+  if (live && Array.isArray(live.submissions)) return live.submissions;
+  const fallback = await tryFetch(FALLBACK_ENDPOINT);
+  if (fallback && Array.isArray(fallback.submissions)) return fallback.submissions;
+  return null;
+}
+
+async function tryFetch(url) {
+  try {
+    const res = await fetch(url, { headers: { accept: "application/json" } });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.json();
+  } catch (err) {
+    console.warn(`[releases-wall] ${url}`, err);
+    return null;
+  }
+}
+
+function sortByRecency(list) {
+  return [...list].sort((a, b) => timestamp(b) - timestamp(a));
+}
+
+function timestamp(s) {
+  const t = Date.parse(s.submittedAt ?? s.queuedAt ?? "");
+  return Number.isNaN(t) ? 0 : t;
+}
+
+function paintStats(list) {
+  if (!statsEl) return;
+  if (!list.length) {
+    statsEl.textContent = "0 releases";
+    return;
+  }
+  const newest = list[0];
+  const ts = timestamp(newest);
+  const when = ts ? formatRelative(ts) : "recently";
+  statsEl.textContent = `${list.length} release${list.length === 1 ? "" : "s"} · latest ${when}`;
+}
+
+function paintGrid(list) {
+  if (!gridEl) return;
+  if (!list.length) {
+    if (emptyEl) emptyEl.hidden = false;
+    gridEl.hidden = true;
+    return;
+  }
+  gridEl.innerHTML = list.map(renderCard).join("");
+}
+
+function renderCard(s) {
+  const handle = displayHandle(s);
+  const when = s.submittedAt ? formatRelative(Date.parse(s.submittedAt)) : "";
+  const what = (s.what ?? "").trim() || "Untitled";
+  const why = snippet(s.why);
+  const url = isHttp(s.url) ? s.url : "";
+  const titleNode = url
+    ? `<a class="rw-card__title-link" href="${escapeAttr(url)}" target="_blank" rel="noopener">${escapeHTML(what)}</a>`
+    : escapeHTML(what);
+
+  return `
+    <li class="rw-card">
+      <header class="rw-card__head">
+        <span class="rw-card__handle">${escapeHTML(handle)}</span>
+        ${when ? `<time class="rw-card__time">${escapeHTML(when)}</time>` : ""}
+      </header>
+      <h3 class="rw-card__title">${titleNode}</h3>
+      ${why ? `<p class="rw-card__body">${escapeHTML(why)}</p>` : ""}
+      ${url ? `<a class="rw-card__cta" href="${escapeAttr(url)}" target="_blank" rel="noopener">Open the work &rarr;</a>` : ""}
+    </li>
+  `;
+}
+
+function displayHandle(s) {
+  const handle = (s.handle ?? "").trim();
+  if (handle) return handle.startsWith("@") ? handle : `@${handle}`;
+  const name = (s.name ?? "").trim();
+  return name || "Anonymous";
+}
+
+function snippet(why) {
+  const text = (why ?? "").trim();
+  if (!text) return "";
+  if (text.length <= 240) return text;
+  return text.slice(0, 237).replace(/\s+\S*$/, "") + "…";
+}
+
+function isHttp(s) {
+  if (typeof s !== "string") return false;
+  try {
+    const u = new URL(s);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function formatRelative(ts) {
+  const diff = Date.now() - ts;
+  if (!Number.isFinite(diff) || diff < 0) return "just now";
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  const years = Math.floor(days / 365);
+  return `${years}y ago`;
+}
+
+function escapeHTML(s) {
+  return String(s ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function escapeAttr(s) {
+  return escapeHTML(s);
+}

--- a/site/js/widgets/releases-wall.js
+++ b/site/js/widgets/releases-wall.js
@@ -77,7 +77,8 @@ function paintGrid(list) {
 
 function renderCard(s) {
   const handle = displayHandle(s);
-  const when = s.submittedAt ? formatRelative(Date.parse(s.submittedAt)) : "";
+  const ts = timestamp(s);
+  const when = ts ? formatRelative(ts) : "";
   const what = (s.what ?? "").trim() || "Untitled";
   const why = snippet(s.why);
   const url = isHttp(s.url) ? s.url : "";

--- a/site/widgets/releases-wall.html
+++ b/site/widgets/releases-wall.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Releases Wall &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="A public stream of Release Day submissions. The keynote's call-to-action as a living artifact — what people shipped, when, and why."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:title" content="Releases Wall — Punk Rock AI" />
+    <meta property="og:description" content="What people shipped on Release Day." />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/widgets/releases-wall.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main>
+      <section class="rw-intro">
+        <div class="wrap wrap--narrow">
+          <p class="kicker kicker--accent">Release Day &middot; living artifact</p>
+          <h1>Releases Wall.</h1>
+          <p class="rw-intro__lede">
+            Everything submitted to <a href="/release-day.html">Release Day</a>
+            lands here once it&rsquo;s published. Most recent first. Open the
+            link, see the work, send the maker a note.
+          </p>
+          <p class="rw-stats" id="rw-stats" aria-live="polite">loading&hellip;</p>
+        </div>
+      </section>
+
+      <section class="rw">
+        <div class="wrap">
+          <p class="rw__empty" id="rw-empty" hidden>
+            No published submissions yet. The first one lands here on May 22.
+          </p>
+          <p class="rw__error" id="rw-error" hidden>
+            Couldn&rsquo;t load the submissions feed. Try again in a moment.
+          </p>
+          <ol class="rw__grid" id="rw-grid" aria-live="polite"></ol>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/releases-wall.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Refs #37

Tries /api/submissions (Worker) first, falls back to /data/submissions.json. CSS multi-column masonry, recency-sorted, handles both schema shapes. Map view deferred — submission schema has no location field yet (would need a schema bump in #14).

Review repair scope note: This PR ships the submissions wall card stream. Map/location filtering remains follow-up scope until the submission schema carries location fields.
