### PR TITLE
[P5] /signal — slide-of-the-day rotator

### DIFF
--- a/site/css/signal.css
+++ b/site/css/signal.css
@@ -1,0 +1,93 @@
+/* Signal — slide of the day. Single-purpose hero page. Tokens only. */
+
+.signal main {
+  display: block;
+}
+
+.signal-hero {
+  min-height: 70vh;
+  display: flex;
+  align-items: center;
+  padding-block: var(--space-8) var(--space-7);
+  background: var(--bg);
+  color: var(--fg);
+}
+
+.signal__eyebrow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin: 0 0 var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.signal__tag {
+  color: var(--accent);
+}
+
+.signal__date {
+  color: var(--fg-soft);
+}
+
+.signal__title {
+  font-family: var(--font-display);
+  font-size: clamp(2.5rem, 8vw, 6rem);
+  line-height: 1.02;
+  letter-spacing: -0.02em;
+  margin: 0 0 var(--space-4);
+  text-wrap: balance;
+}
+
+.signal__act {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 var(--space-3);
+}
+
+.signal__note {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  color: var(--fg-soft);
+  margin: 0 0 var(--space-5);
+}
+
+.signal__meta {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin: 0 0 var(--space-6);
+}
+
+.signal__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin: 0;
+}
+
+.signal[data-state="loading"] .signal__act,
+.signal[data-state="loading"] .signal__meta {
+  opacity: 0.4;
+}
+
+.signal[data-state="error"] .signal__act,
+.signal[data-state="error"] .signal__note,
+.signal[data-state="error"] .signal__meta {
+  display: none;
+}
+
+@media (max-width: 560px) {
+  .signal-hero {
+    min-height: 60vh;
+    padding-block: var(--space-6) var(--space-5);
+  }
+}

--- a/site/js/signal.js
+++ b/site/js/signal.js
@@ -1,0 +1,79 @@
+// Signal — surface one slide per day, deterministic by UTC date so every
+// visitor sees the same slide on the same calendar day. Cycles through the
+// full slide manifest once a year (index = dayOfYear % slides.length).
+
+const root = document.getElementById("signal");
+if (root) main();
+
+async function main() {
+  try {
+    const res = await fetch("/data/slides.json", { credentials: "same-origin" });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    const slides = Array.isArray(data?.slides) ? data.slides : [];
+    if (!slides.length) throw new Error("no slides");
+    const pick = pickForToday(slides);
+    render(pick, slides.length);
+  } catch (err) {
+    console.warn("[signal]", err);
+    root.dataset.state = "error";
+  }
+}
+
+// UTC dayOfYear keeps the pick stable across timezones — every visitor on the
+// same UTC calendar day sees the same slide.
+function dayOfYearUTC(date) {
+  const start = Date.UTC(date.getUTCFullYear(), 0, 0);
+  const now = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+  return Math.floor((now - start) / 86400000);
+}
+
+function pickForToday(slides) {
+  const day = dayOfYearUTC(new Date());
+  const idx = ((day % slides.length) + slides.length) % slides.length;
+  return { slide: slides[idx], idx };
+}
+
+function render({ slide, idx }, total) {
+  if (!slide) return;
+  const dateEl = root.querySelector("[data-signal-date]");
+  const titleEl = root.querySelector("[data-signal-title]");
+  const actEl = root.querySelector("[data-signal-act]");
+  const noteEl = root.querySelector("[data-signal-note]");
+  const indexEl = root.querySelector("[data-signal-index]");
+  const recapEl = root.querySelector("[data-signal-recap]");
+  const talkEl = root.querySelector("[data-signal-talk]");
+
+  if (dateEl) {
+    const today = new Date();
+    const iso = today.toISOString().slice(0, 10);
+    dateEl.setAttribute("datetime", iso);
+    dateEl.textContent = today.toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  }
+  if (titleEl) titleEl.textContent = slide.title || "Slide of the day";
+  if (actEl) actEl.textContent = slide.act || "";
+  if (noteEl) {
+    if (slide.note) {
+      noteEl.textContent = slide.note;
+      noteEl.hidden = false;
+    } else {
+      noteEl.hidden = true;
+    }
+  }
+  if (indexEl) {
+    const n = typeof slide.n === "number" ? slide.n : idx + 1;
+    indexEl.textContent = `Slide ${n} of ${total}`;
+  }
+  if (talkEl && slide.id) {
+    talkEl.setAttribute("href", `/talk.html#${slide.id}`);
+  }
+  if (recapEl) {
+    recapEl.setAttribute("href", "/recap.html#slides");
+  }
+
+  root.dataset.state = "ready";
+}

--- a/site/signal.html
+++ b/site/signal.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Signal &mdash; slide of the day</title>
+    <meta
+      name="description"
+      content="One slide from the Punk Rock AI talk, surfaced for today. Same slide for every visitor on the same day. Cycles through the deck once a year."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="Signal — slide of the day" />
+    <meta property="og:description" content="One slide from the talk, surfaced for today." />
+    <meta property="og:url" content="https://punkrockai.com/signal.html" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/signal.css" />
+  </head>
+  <body class="shell signal">
+    <header class="site-header" data-include="header"></header>
+
+    <main>
+      <section class="signal-hero grain scanlines" id="signal" data-state="loading">
+        <div class="wrap wrap--narrow">
+          <p class="signal__eyebrow">
+            <span class="signal__tag">Signal</span>
+            <time class="signal__date" data-signal-date></time>
+          </p>
+          <h1 class="signal__title" data-signal-title>Slide of the day</h1>
+          <p class="signal__act" data-signal-act></p>
+          <p class="signal__note" data-signal-note hidden></p>
+          <p class="signal__meta">
+            <span data-signal-index></span>
+          </p>
+          <p class="signal__cta">
+            <a class="btn" data-signal-recap href="/recap.html#slides">Read the recap</a>
+            <a class="btn btn--ghost" data-signal-talk href="/talk.html">See the full talk</a>
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/signal.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Refs #63 (slides-only daily pick; quotes mixing + midnight rotate + prev/next nav tracked as #126)

UTC-stable day-of-year mod; reads /data/slides.json. Scope-narrowed to slides-only — quotes.json mixing, midnight auto-rotate, and prev/next nav from the issue body deferred to #126.