### PR TITLE
[P4] C9 — Both Hands gallery

### DIFF
--- a/site/css/widgets/both-hands-gallery.css
+++ b/site/css/widgets/both-hands-gallery.css
@@ -1,0 +1,129 @@
+/* /widgets/both-hands-gallery.html — read-only wall of decoded canvases.
+   Reuses .bhf-* classes from both-hands.css for the diptych itself; this
+   file only adds the wall layout and read-only adjustments. */
+
+.bhg-intro {
+  padding-block: var(--space-6);
+  border-bottom: 1px solid var(--border);
+}
+
+.bhg-intro h1 {
+  margin: 0 0 var(--space-3);
+}
+
+.bhg-intro__lede {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 50ch;
+  color: var(--fg-soft);
+}
+
+.bhg-intro__hint {
+  margin-top: var(--space-3);
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+.bhg-wall {
+  padding-block: var(--space-5);
+}
+
+.bhg-wall__status {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: var(--space-4);
+}
+
+.bhg-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-5);
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 1100px) {
+  .bhg-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.bhg-card {
+  display: block;
+}
+
+.bhg-card__inner {
+  display: grid;
+  gap: var(--space-3);
+}
+
+/* Tighten the diptych for card-density display. The base .bhf-canvas keeps
+   its frame, but we drop min-heights and shrink internal scale. */
+.bhg-canvas {
+  max-width: 100%;
+}
+
+.bhg-canvas .bhf-side {
+  min-height: 0;
+  padding: var(--space-3);
+}
+
+.bhg-canvas .bhf-side h3 {
+  font-family: var(--font-display);
+  font-size: clamp(1.2rem, 2.4vw, 1.6rem);
+  line-height: 1.1;
+  margin: 0 0 var(--space-3);
+}
+
+.bhg-canvas .bhf-side--critique h3 {
+  color: var(--fg);
+}
+
+.bhg-canvas .bhf-side--capability h3 {
+  color: var(--paper-ink);
+}
+
+.bhg-list {
+  gap: var(--space-1);
+}
+
+.bhg-item {
+  grid-template-columns: 1.6rem 1fr;
+}
+
+.bhg-item__text {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  line-height: 1.35;
+  border-bottom: 1px solid currentColor;
+  padding: 0.25rem 0;
+  word-break: break-word;
+}
+
+.bhf-side--critique .bhg-item__text {
+  color: var(--fg);
+  border-color: var(--accent);
+}
+
+.bhf-side--capability .bhg-item__text {
+  color: var(--paper-ink);
+  border-color: var(--paper-ink);
+}
+
+.bhg-card__note {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  color: var(--fg-soft);
+  margin: 0;
+  max-width: 60ch;
+}
+
+.bhg-card__actions {
+  margin: 0;
+}

--- a/site/data/both-hands-gallery.json
+++ b/site/data/both-hands-gallery.json
@@ -1,0 +1,41 @@
+{
+  "source": "site/widgets/both-hands.html — `#s=` hash format",
+  "consentNote": "Public gallery of opt-in Both Hands canvases. Each entry is a base64url-encoded diptych decoded entirely client-side. To add or remove a canvas, open a PR or issue at github.com/WalksWithASwagger/cmvan-keynote.",
+  "entries": [
+    {
+      "id": "kk-may1",
+      "submittedBy": "Kris Krüg",
+      "submittedAt": "2026-05-01",
+      "note": "The seed stance from Slide 12 — both hands full, walking forward.",
+      "hash": "eyJuIjoiS3JpcyBLcsO8ZyIsImMiOlsiVGhlZnQgd2l0aG91dCBjb25zZW50LiIsIlRoZSBqdW5pb3IgcGlwZWxpbmUgY29sbGFwc2luZy4iLCJCaWFzIGxhdW5kZXJpbmcgYXMgbWF0aC4iLCJOYW1lcyBkaXNhcHBlYXJpbmcgZnJvbSBjcmVkaXQgbGluZXMuIiwiUmFjZSB0byB0aGUgYm90dG9tIG9uIHJhdGVzLiJdLCJwIjpbIk1vcmUgY3JlYXRpdmUgdGhhbiBJIGhhdmUgZXZlciBiZWVuLiIsIkFuIGlkZWEgcGVyIG5pZ2h0LCBtYWRlIGJ5IG1vcm5pbmcuIiwiQSBwb3NzZSB0byByZWZ1c2UgdG9nZXRoZXIuIiwiTXkgdm9pY2UgYW1wbGlmaWVkIOKAlCBub3QgYXZlcmFnZWQuIiwiVGltZSBnaXZlbiBiYWNrIHRvIHRoZSB3b3JrIEkgbG92ZS4iXX0"
+    },
+    {
+      "id": "maya-skeptic",
+      "submittedBy": "Maya — strategic skeptic",
+      "submittedAt": "2026-04-22",
+      "note": "From resistant to fluent in six weeks. Critique kept, capability claimed.",
+      "hash": "eyJuIjoiTWF5YSDigJQgc3RyYXRlZ2ljIHNrZXB0aWMiLCJjIjpbIlNrZXB0aWNhbCBvZiB0aGUgaHlwZS4iLCJXb3JyaWVkIGFib3V0IHRoZSB0YWtlLiIsIldhdGNoaW5nIGNvbGxlYWd1ZXMgZ2V0IGJ1bGxkb3plZC4iLCJTdXNwaWNpb3VzIG9mIHZlbmRvciBkZW1vcy4iLCJSZWZ1c2luZyB0byBvdXRzb3VyY2UganVkZ21lbnQuIl0sInAiOlsiRmlnbWEgKyBDaGF0R1BULCBjYXJlZnVsIHRlc3RzLiIsIlRocmVlLXdlZWsgcHJvamVjdHMgaW4gZm91ciBob3Vycy4iLCJSZXNpc3RhbnQg4oaSIGZsdWVudCBpbiBzaXggd2Vla3MuIiwiVGVhY2hpbmcgb3RoZXIgZGVzaWduZXJzIG5vdy4iLCJWYWx1ZSB1cCwgbm90IGRvd24uIl19"
+    },
+    {
+      "id": "emily-bee-school",
+      "submittedBy": "Emily — Bee School",
+      "submittedAt": "2026-03-14",
+      "note": "Capability and consent in the same lesson plan.",
+      "hash": "eyJuIjoiRW1pbHkg4oCUIEJlZSBTY2hvb2wiLCJjIjpbIkRpc3RyaWN0cyB3YW50aW5nIHRvIGJhbiBpdC4iLCJLaWRzIGxlYXJuaW5nIEFJIGZyb20gWW91VHViZS4iLCJDb25zZW50IGVyYXNlZCBmcm9tIHRoZSBjdXJyaWN1bHVtLiIsIkVkdGVjaCBicm9zIHNlbGxpbmcgc25ha2Ugb2lsLiIsIkRhdGEgc292ZXJlaWdudHkgaWdub3JlZC4iXSwicCI6WyJCZWUgU2Nob29sIGJ1aWx0IHdpdGggQUkuIiwiS2lkcyBsZWFybmluZyBjb25zZW50IGZyYW1ld29ya3MuIiwiQ2FwYWJpbGl0eSArIGV0aGljcyBpbiB0aGUgc2FtZSBsZXNzb24uIiwiU3RheWluZyBpbiB0aGUgcm9vbSwgbm90IG9wdGluZyBvdXQuIiwiRGlzdHJpY3RzIGFza2luZyB0byBidXkgdGhlIHRvb2xzLiJdfQ"
+    },
+    {
+      "id": "bcai-working-groups",
+      "submittedBy": "BC + AI working groups",
+      "submittedAt": "2026-02-07",
+      "note": "Practical use of AI alongside Indigenous data sovereignty work.",
+      "hash": "eyJuIjoiQkMgKyBBSSB3b3JraW5nIGdyb3VwcyIsImMiOlsiRXh0cmFjdGlvbiBtYXNxdWVyYWRpbmcgYXMgaW5ub3ZhdGlvbi4iLCJJbmRpZ2Vub3VzIGRhdGEgdGFrZW4gd2l0aG91dCBjb25zZW50LiIsIkV0aGljYWwgZnJhbWV3b3JrcyBib2x0ZWQgb24gYWZ0ZXIuIiwiR292ZXJuYW5jZSBieSB0cnVlIGJlbGlldmVycyBvbmx5LiIsIlB1cmUgYm9vc3RlcnMgZ29pbmcgdW5jaGFsbGVuZ2VkLiJdLCJwIjpbIkluZGlnZW5vdXMgZGF0YSBzb3ZlcmVpZ250eSBncm91cC4iLCJMb2NhbCB0cmFpbmluZyBleHBlcmltZW50cy4iLCJBcnRpc3Qtb3duZWQgZGF0YXNldHMuIiwiQ29uc2VudCBtb2RlbHMgd2UgYWN0dWFsbHkgd3JvdGUuIiwiUHJhY3RpY2FsIHVzZSArIGFjdGl2ZSBjcml0aXF1ZS4iXX0"
+    },
+    {
+      "id": "anonymous-punk",
+      "submittedBy": "Anonymous punk",
+      "submittedAt": "2026-04-30",
+      "note": "Refusal and engagement, both. No clean side picked.",
+      "hash": "eyJuIjoiQW5vbnltb3VzIHB1bmsiLCJjIjpbIkkgYW0gcGlzc2VkIGFib3V0IG5vbi1jb25zZW50LiIsIkkgd2lsbCBub3QgcHJldGVuZCBpdCBpcyBmaW5lLiIsIkkgd2lsbCBuYW1lIHRoZSB0aGVmdCBvdXQgbG91ZC4iLCJJIHdpbGwgbm90IGRyb3AgdGhlIGNyaXRpcXVlLiIsIkkgd2lsbCBub3QgcGVyZm9ybSBwdXJpdHkuIl0sInAiOlsiSSB3aWxsIGxldmVyYWdlIHRoZSBtb21lbnQuIiwiSSB3aWxsIGJ1aWxkIHRoZSBhbHRlcm5hdGl2ZXMuIiwiSSB3aWxsIHRlYWNoIHRoZSBuZXh0IG9uZXMuIiwiSSB3aWxsIGtlZXAgYm90aCBoYW5kcyBmdWxsLiIsIkkgd2lsbCBzdGF5IGluIHRoZSByb29tLiJdfQ"
+    }
+  ]
+}

--- a/site/js/widgets/both-hands-gallery.js
+++ b/site/js/widgets/both-hands-gallery.js
@@ -1,0 +1,141 @@
+// /widgets/both-hands-gallery.html — read-only wall of submitted Both Hands
+// canvases. Each entry has a base64url `hash` (same format produced by
+// /widgets/both-hands.html). We decode client-side and render mini-diptychs.
+// Invalid hashes are skipped silently — never break the page on bad data.
+
+const SLOT_COUNT = 5;
+const EDITOR_PATH = "/widgets/both-hands.html";
+
+const gridEl = document.getElementById("bhg-grid");
+const statusEl = document.getElementById("bhg-status");
+
+main();
+
+async function main() {
+  try {
+    const res = await fetch("/data/both-hands-gallery.json");
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    const entries = Array.isArray(data?.entries) ? data.entries : [];
+    renderEntries(entries);
+  } catch (err) {
+    console.warn("[both-hands-gallery]", err);
+    setStatus("Gallery data unavailable.");
+  }
+}
+
+function renderEntries(entries) {
+  gridEl.innerHTML = "";
+  let ok = 0;
+  for (const entry of entries) {
+    const decoded = decodeEntry(entry.hash);
+    if (!decoded) continue;
+    gridEl.appendChild(renderCard(entry, decoded));
+    ok++;
+  }
+  if (ok === 0) {
+    setStatus("No canvases on the wall yet.");
+  } else {
+    setStatus(`${ok} canvas${ok === 1 ? "" : "es"} on the wall.`);
+  }
+}
+
+function renderCard(entry, state) {
+  const li = document.createElement("li");
+  li.className = "bhg-card";
+  li.id = `bhg-${entry.id || ""}`;
+
+  const editorUrl = `${EDITOR_PATH}#s=${entry.hash}`;
+  const sigName = (state.name && state.name.trim()) || entry.submittedBy || "Anonymous punk";
+
+  li.innerHTML = `
+    <article class="bhg-card__inner">
+      <div class="bhf-canvas bhg-canvas">
+        <section class="bhf-side bhf-side--critique">
+          <p class="bhf-side__eyebrow">In one hand &mdash; the critique</p>
+          <h3>What I refuse to let go.</h3>
+          <ol class="bhf-list bhg-list">${renderItems(state.critique)}</ol>
+        </section>
+
+        <div class="bhf-divider" aria-hidden="true">+</div>
+
+        <section class="bhf-side bhf-side--capability">
+          <p class="bhf-side__eyebrow">In the other &mdash; the capability</p>
+          <h3>What I&rsquo;m building anyway.</h3>
+          <ol class="bhf-list bhg-list">${renderItems(state.capability)}</ol>
+        </section>
+
+        <footer class="bhf-canvas__footer">
+          <span><strong>Both hands full.</strong> &mdash; ${escapeHTML(sigName)}</span>
+          <span class="bhf-canvas__sig">${escapeHTML(entry.submittedAt || "")}</span>
+        </footer>
+      </div>
+
+      ${entry.note ? `<p class="bhg-card__note">${escapeHTML(entry.note)}</p>` : ""}
+
+      <p class="bhg-card__actions">
+        <a class="btn" href="${escapeAttr(editorUrl)}">Open in editor &rarr;</a>
+      </p>
+    </article>
+  `;
+  return li;
+}
+
+function renderItems(arr) {
+  return arr
+    .map((value, idx) => {
+      const display = value && value.trim() ? escapeHTML(value) : "&mdash;";
+      return `
+        <li class="bhf-item bhg-item">
+          <span class="bhf-item__num">${idx + 1}</span>
+          <span class="bhg-item__text">${display}</span>
+        </li>`;
+    })
+    .join("");
+}
+
+// ---------------------------------------------------------------------------
+
+function decodeEntry(hash) {
+  if (typeof hash !== "string" || !hash) return null;
+  try {
+    const json = base64UrlDecode(hash);
+    const data = JSON.parse(json);
+    if (!Array.isArray(data?.c) || !Array.isArray(data?.p)) return null;
+    return {
+      critique: padArray(data.c, SLOT_COUNT),
+      capability: padArray(data.p, SLOT_COUNT),
+      name: typeof data.n === "string" ? data.n : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function base64UrlDecode(s) {
+  const padded = s.replace(/-/g, "+").replace(/_/g, "/") + "===".slice((s.length + 3) % 4);
+  return decodeURIComponent(escape(atob(padded)));
+}
+
+function padArray(arr, n) {
+  const out = arr.slice(0, n).map((v) => (typeof v === "string" ? v : ""));
+  while (out.length < n) out.push("");
+  return out;
+}
+
+function setStatus(msg) {
+  if (statusEl) statusEl.textContent = msg;
+}
+
+function escapeHTML(s) {
+  return String(s ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function escapeAttr(s) {
+  return escapeHTML(s);
+}

--- a/site/widgets/both-hands-gallery.html
+++ b/site/widgets/both-hands-gallery.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Both Hands Gallery &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="A public wall of submitted Both Hands canvases. Each card decodes a shared #s= hash into the same diptych — critique in one hand, capability in the other."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:title" content="Both Hands Gallery — Punk Rock AI" />
+    <meta property="og:description" content="A public wall of opt-in Both Hands canvases. Critique in one hand, capability in the other." />
+    <meta property="og:url" content="https://punkrockai.com/widgets/both-hands-gallery.html" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/widgets/both-hands.css" />
+    <link rel="stylesheet" href="/css/widgets/both-hands-gallery.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main>
+      <section class="bhg-intro grain scanlines">
+        <div class="wrap wrap--narrow">
+          <p class="kicker kicker--accent">Slide 12 &middot; the wall</p>
+          <h1>Both hands full &mdash; the gallery.</h1>
+          <p class="bhg-intro__lede">
+            Other people&rsquo;s stances. Critique in one hand, capability in
+            the other. Each card is a shared canvas decoded from a hash &mdash;
+            no server, no account, just the diptych.
+          </p>
+          <p class="bhg-intro__hint">
+            Want yours up here? Build one on the
+            <a href="/widgets/both-hands.html">canvas</a>, copy the share link,
+            and open a PR or issue at
+            <a href="https://github.com/WalksWithASwagger/cmvan-keynote" target="_blank" rel="noopener">github.com/WalksWithASwagger/cmvan-keynote</a>.
+          </p>
+        </div>
+      </section>
+
+      <section class="bhg-wall">
+        <div class="wrap">
+          <p class="bhg-wall__status" id="bhg-status" aria-live="polite">Loading the wall&hellip;</p>
+          <ul class="bhg-grid" id="bhg-grid"></ul>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/both-hands-gallery.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #40

Built per the issue spec (gallery of submitted canvases via #s= hash decode, NOT extending the editor). Existing both-hands.js (diptych editor) untouched. All 5 seeds round-trip-decode; invalid hashes skip cards safely.