### PR TITLE
[P5] /widgets/sig — email signature generator

### DIFF
--- a/site/css/widgets/sig.css
+++ b/site/css/widgets/sig.css
@@ -1,0 +1,210 @@
+/* /widgets/sig.html — Email signature generator
+   Page chrome only. The signature itself is rendered with inline styles
+   so it survives Gmail/Outlook pasteboards untouched.
+   ------------------------------------------------------------------ */
+
+.sig-intro {
+  padding-block: var(--space-6);
+  border-bottom: 1px solid var(--border);
+}
+
+.sig-intro h1 {
+  margin: 0 0 var(--space-3);
+}
+
+.sig-intro__lede {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 50ch;
+  color: var(--fg-soft);
+}
+
+/* ------------------------------------------------------------------
+   FORM
+   ------------------------------------------------------------------ */
+
+.sig-form-wrap {
+  padding-block: var(--space-5);
+  border-bottom: 1px solid var(--border);
+}
+
+.sig-form {
+  font-family: var(--font-mono);
+}
+
+.sig-fieldset {
+  border: 1px solid var(--border-strong);
+  padding: var(--space-4);
+  margin: 0;
+}
+
+.sig-legend {
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: var(--fs-sm);
+  padding: 0 var(--space-2);
+}
+
+.sig-field {
+  display: block;
+  margin-bottom: var(--space-3);
+}
+
+.sig-field__label {
+  display: block;
+  font-size: var(--fs-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+
+.sig-field input[type="text"],
+.sig-field input[type="email"],
+.sig-field select {
+  width: 100%;
+  font: inherit;
+  padding: 8px 10px;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border-strong);
+}
+
+.sig-field input:focus,
+.sig-field select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.sig-field__hint {
+  display: block;
+  margin-top: 4px;
+  font-size: var(--fs-xs);
+  color: var(--muted);
+}
+
+.sig-field__row {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.sig-field--check {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.sig-field--check input {
+  width: auto;
+}
+
+.sig-form__row {
+  margin-top: var(--space-3);
+  display: flex;
+  gap: var(--space-2);
+}
+
+/* ------------------------------------------------------------------
+   PREVIEW + ACTIONS
+   ------------------------------------------------------------------ */
+
+.sig-preview-wrap {
+  padding-block: var(--space-5);
+}
+
+.sig-h2 {
+  margin: 0 0 var(--space-2);
+}
+
+.sig-hint {
+  margin: 0 0 var(--space-3);
+  color: var(--muted);
+  font-size: var(--fs-sm);
+}
+
+.sig-preview {
+  background: #fff;
+  color: #0a0a0a;
+  padding: var(--space-4);
+  border: 1px solid var(--border-strong);
+  min-height: 6em;
+}
+
+/* The preview rebrands to a light surface to mimic an email client
+   compose window. Anything inside is an inline-styled inert HTML island. */
+
+.sig-actions {
+  margin-top: var(--space-3);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.sig-status {
+  margin-top: var(--space-2);
+  min-height: 1.25em;
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  color: var(--accent);
+}
+
+.sig-source {
+  margin-top: var(--space-3);
+  border: 1px dashed var(--border);
+  padding: var(--space-2) var(--space-3);
+}
+
+.sig-source > summary {
+  cursor: pointer;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: var(--fs-sm);
+}
+
+.sig-source__pre {
+  margin: var(--space-2) 0 0;
+  padding: var(--space-2);
+  background: var(--bg-soft, #1a1a1a);
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: auto;
+  max-height: 22em;
+}
+
+.sig-howto {
+  margin-top: var(--space-4);
+  border: 1px dashed var(--border);
+  padding: var(--space-2) var(--space-3);
+}
+
+.sig-howto > summary {
+  cursor: pointer;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: var(--fs-sm);
+}
+
+.sig-howto__list {
+  margin: var(--space-2) 0 0;
+  padding-left: var(--space-4);
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+}
+
+.sig-howto__list li {
+  margin-bottom: 6px;
+}
+
+.btn--small {
+  padding: 4px 10px;
+  font-size: var(--fs-xs);
+}

--- a/site/data/sig-taglines.json
+++ b/site/data/sig-taglines.json
@@ -1,0 +1,77 @@
+{
+  "source": "script/talk-framework-v6.md",
+  "note": "Tagline options for the email signature widget. Pulled from the talk's load-bearing lines.",
+  "count": 14,
+  "taglines": [
+    {
+      "id": "tag-both-hands",
+      "text": "Both hands full. That's the only honest place to stand.",
+      "act": "Act III"
+    },
+    {
+      "id": "tag-tool-neutral",
+      "text": "The tool is never neutral. But neither are we.",
+      "act": "Act VI"
+    },
+    {
+      "id": "tag-pickup",
+      "text": "Pick up the tool. Use it wrong. Share what you learn.",
+      "act": "Act VII"
+    },
+    {
+      "id": "tag-live-fish",
+      "text": "Any dead fish can float downstream. It takes a live fish to swim.",
+      "act": "Act VII"
+    },
+    {
+      "id": "tag-taste",
+      "text": "Generation is free now. Taste is what's scarce.",
+      "act": "Act II"
+    },
+    {
+      "id": "tag-leaf-blower",
+      "text": "Speed without judgment is a leaf blower.",
+      "act": "Act II"
+    },
+    {
+      "id": "tag-name-it",
+      "text": "Stop saying bias. Name what you're seeing.",
+      "act": "Act IV"
+    },
+    {
+      "id": "tag-remix",
+      "text": "Remix has culture. Extraction has appetite.",
+      "act": "Act IV"
+    },
+    {
+      "id": "tag-values-text",
+      "text": "If your values aren't in text, to AI they don't exist.",
+      "act": "Act VI"
+    },
+    {
+      "id": "tag-stay-table",
+      "text": "We need the most critical voices at the table.",
+      "act": "Act VI"
+    },
+    {
+      "id": "tag-camera",
+      "text": "The camera interrupted the despair.",
+      "act": "Act I"
+    },
+    {
+      "id": "tag-give-away",
+      "text": "Giving away made me invaluable.",
+      "act": "Act I"
+    },
+    {
+      "id": "tag-both-true",
+      "text": "Both statements are true. At the exact same time.",
+      "act": "Act V"
+    },
+    {
+      "id": "tag-coming",
+      "text": "You coming?",
+      "act": "Act VII"
+    }
+  ]
+}

--- a/site/js/widgets/sig.js
+++ b/site/js/widgets/sig.js
@@ -295,7 +295,7 @@ function renderHTML(p) {
     );
   }
   if (p.handle) {
-    if (p.handleLink) {
+    if (p.handleLink && isHttpUrl(p.handleLink)) {
       contactBits.push(
         `<a href="${escapeAttr(p.handleLink)}" style="color:${soft};text-decoration:none;">${escapeHTML(p.handle)}</a>`,
       );
@@ -440,4 +440,17 @@ function escapeHTML(str) {
 
 function escapeAttr(str) {
   return escapeHTML(str);
+}
+
+// Protocol whitelist for user-supplied URLs. Defense-in-depth: keeps
+// javascript:/data:/vbscript: out of href= even if upstream resolution
+// changes. URL parsing (not prefix match) handles whitespace/case tricks
+// like " javascript:..." or "JaVaScRiPt:".
+function isHttpUrl(str) {
+  try {
+    const u = new URL(String(str));
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
 }

--- a/site/js/widgets/sig.js
+++ b/site/js/widgets/sig.js
@@ -1,0 +1,443 @@
+// /widgets/sig.html — Email signature generator.
+// User types name/role/handle, picks a tagline from the talk, gets back
+// an inline-styled HTML signature that pastes cleanly into Gmail / Apple
+// Mail / Outlook. Plain-text fallback is rendered alongside.
+
+import { load, save, remove } from "/js/common/storage.js";
+
+const STORAGE_KEY = "sig:state";
+const PORTAL_URL = "https://punkrockai.com";
+const UTM_SUFFIX = "?ref=email-sig";
+const BADGE_URL =
+  "https://punkrockai.com/public/images/badge-attended.png";
+
+const DEFAULTS = {
+  name: "",
+  role: "",
+  handle: "",
+  email: "",
+  taglineId: "",
+  badge: false,
+};
+
+let state = { ...DEFAULTS };
+let taglines = [];
+
+bootstrap();
+
+async function bootstrap() {
+  hydrate();
+  await loadTaglines();
+  ensureTaglineId();
+  renderForm();
+  wireForm();
+  render();
+}
+
+function hydrate() {
+  const { value } = load(STORAGE_KEY, null);
+  if (value && typeof value === "object") {
+    state = { ...DEFAULTS, ...sanitize(value) };
+  }
+}
+
+function sanitize(value) {
+  return {
+    name: stringOf(value.name),
+    role: stringOf(value.role),
+    handle: stringOf(value.handle),
+    email: stringOf(value.email),
+    taglineId: stringOf(value.taglineId),
+    badge: value.badge === true,
+  };
+}
+
+function stringOf(v) {
+  return typeof v === "string" ? v : "";
+}
+
+function persist() {
+  save(STORAGE_KEY, state);
+}
+
+async function loadTaglines() {
+  try {
+    const res = await fetch("/data/sig-taglines.json", { cache: "no-cache" });
+    const data = await res.json();
+    taglines = Array.isArray(data.taglines) ? data.taglines : [];
+  } catch (err) {
+    console.warn("[sig] tagline load failed:", err);
+    taglines = [
+      {
+        id: "tag-fallback",
+        text: "The tool is never neutral. But neither are we.",
+        act: "Act VI",
+      },
+    ];
+  }
+}
+
+function ensureTaglineId() {
+  const exists = taglines.some((t) => t.id === state.taglineId);
+  if (!exists) {
+    state.taglineId = pickByDate(taglines).id;
+  }
+}
+
+// Deterministic-by-date pick so a returning visitor gets a stable rotating
+// quote per day, while still feeling fresh across the week.
+function pickByDate(list) {
+  if (!list.length) return { id: "", text: "", act: "" };
+  const d = new Date();
+  const seed = d.getUTCFullYear() * 1000 + dayOfYear(d);
+  return list[seed % list.length];
+}
+
+function dayOfYear(d) {
+  const start = Date.UTC(d.getUTCFullYear(), 0, 0);
+  const now = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  return Math.floor((now - start) / 86400000);
+}
+
+// ---------------------------------------------------------------------------
+// Form
+// ---------------------------------------------------------------------------
+
+function renderForm() {
+  const select = document.getElementById("sig-tagline");
+  if (select) {
+    select.innerHTML = taglines
+      .map(
+        (t) =>
+          `<option value="${escapeAttr(t.id)}">${escapeHTML(t.text)}</option>`,
+      )
+      .join("");
+    select.value = state.taglineId;
+  }
+  paintInputs();
+}
+
+function paintInputs() {
+  setInput("sig-name", state.name);
+  setInput("sig-role", state.role);
+  setInput("sig-handle", state.handle);
+  setInput("sig-email", state.email);
+  const badge = document.getElementById("sig-badge");
+  if (badge) badge.checked = state.badge;
+  const select = document.getElementById("sig-tagline");
+  if (select) select.value = state.taglineId;
+}
+
+function setInput(id, value) {
+  const el = document.getElementById(id);
+  if (el) el.value = value;
+}
+
+function wireForm() {
+  document.querySelectorAll("[data-field]").forEach((el) => {
+    const field = el.dataset.field;
+    const evt = el.type === "checkbox" || el.tagName === "SELECT" ? "change" : "input";
+    el.addEventListener(evt, () => {
+      if (el.type === "checkbox") {
+        state[field] = el.checked;
+      } else {
+        state[field] = el.value;
+      }
+      persist();
+      render();
+    });
+  });
+
+  document
+    .querySelector('[data-action="rotate-tagline"]')
+    ?.addEventListener("click", rotateTagline);
+  document
+    .querySelector('[data-action="random-tagline"]')
+    ?.addEventListener("click", randomTagline);
+  document
+    .querySelector('[data-action="reset"]')
+    ?.addEventListener("click", reset);
+  document
+    .querySelector('[data-action="copy-rich"]')
+    ?.addEventListener("click", copyRich);
+  document
+    .querySelector('[data-action="copy-html"]')
+    ?.addEventListener("click", copyHtml);
+  document
+    .querySelector('[data-action="copy-text"]')
+    ?.addEventListener("click", copyText);
+}
+
+function rotateTagline() {
+  if (!taglines.length) return;
+  const idx = taglines.findIndex((t) => t.id === state.taglineId);
+  const next = taglines[(idx + 1) % taglines.length];
+  state.taglineId = next.id;
+  persist();
+  paintInputs();
+  render();
+}
+
+function randomTagline() {
+  if (!taglines.length) return;
+  let next = state.taglineId;
+  if (taglines.length > 1) {
+    while (next === state.taglineId) {
+      next = taglines[Math.floor(Math.random() * taglines.length)].id;
+    }
+  }
+  state.taglineId = next;
+  persist();
+  paintInputs();
+  render();
+}
+
+function reset() {
+  const ok = window.confirm("Clear all fields and reset the tagline?");
+  if (!ok) return;
+  state = { ...DEFAULTS };
+  remove(STORAGE_KEY);
+  ensureTaglineId();
+  paintInputs();
+  render();
+  flash("reset");
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+function render() {
+  const sig = buildSignature();
+  const preview = document.getElementById("sig-preview");
+  if (preview) preview.innerHTML = sig.html;
+  setText("sig-html", sig.html);
+  setText("sig-text", sig.text);
+}
+
+function setText(id, value) {
+  const el = document.getElementById(id);
+  if (el) el.textContent = value;
+}
+
+function currentTagline() {
+  return (
+    taglines.find((t) => t.id === state.taglineId) ||
+    pickByDate(taglines)
+  );
+}
+
+// Build both the HTML and plain-text variants. The HTML uses inline styles
+// only and a table-based layout — that's the lowest common denominator that
+// survives Gmail, Apple Mail, and Outlook (web + desktop) without restyling.
+function buildSignature() {
+  const tagline = currentTagline();
+  const name = state.name.trim() || "Your name";
+  const role = state.role.trim();
+  const handle = state.handle.trim();
+  const email = state.email.trim();
+  const handleLink = resolveHandleLink(handle);
+  const portal = `${PORTAL_URL}/${UTM_SUFFIX}`;
+
+  const html = renderHTML({
+    name,
+    role,
+    email,
+    handle,
+    handleLink,
+    tagline: tagline.text,
+    badge: state.badge,
+    portal,
+  });
+  const text = renderText({
+    name,
+    role,
+    email,
+    handle,
+    tagline: tagline.text,
+    badge: state.badge,
+    portal,
+  });
+  return { html, text };
+}
+
+function resolveHandleLink(handle) {
+  if (!handle) return "";
+  if (handle.startsWith("http://") || handle.startsWith("https://")) {
+    return handle;
+  }
+  if (handle.startsWith("@")) {
+    return `https://www.google.com/search?q=${encodeURIComponent(handle)}`;
+  }
+  if (handle.includes(".")) {
+    return `https://${handle}`;
+  }
+  return "";
+}
+
+function renderHTML(p) {
+  const ink = "#0a0a0a";
+  const soft = "#444";
+  const accent = "#d6202b";
+  const muted = "#777";
+  const fontStack =
+    "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif";
+
+  const nameLine = `<strong style="color:${ink};font-weight:700;">${escapeHTML(p.name)}</strong>`;
+  const roleLine = p.role
+    ? `<span style="color:${soft};">&nbsp;&middot;&nbsp;${escapeHTML(p.role)}</span>`
+    : "";
+
+  const contactBits = [];
+  if (p.email) {
+    contactBits.push(
+      `<a href="mailto:${escapeAttr(p.email)}" style="color:${soft};text-decoration:none;">${escapeHTML(p.email)}</a>`,
+    );
+  }
+  if (p.handle) {
+    if (p.handleLink) {
+      contactBits.push(
+        `<a href="${escapeAttr(p.handleLink)}" style="color:${soft};text-decoration:none;">${escapeHTML(p.handle)}</a>`,
+      );
+    } else {
+      contactBits.push(
+        `<span style="color:${soft};">${escapeHTML(p.handle)}</span>`,
+      );
+    }
+  }
+  const contactLine = contactBits.length
+    ? `<div style="margin-top:2px;font-family:${fontStack};font-size:13px;line-height:1.5;color:${soft};">${contactBits.join(' &nbsp;|&nbsp; ')}</div>`
+    : "";
+
+  const badgeBlock = p.badge
+    ? `<tr><td style="padding-top:8px;"><a href="${escapeAttr(p.portal)}" style="text-decoration:none;"><img src="${escapeAttr(BADGE_URL)}" alt="I attended Punk Rock AI" width="120" height="40" style="display:block;border:0;outline:0;text-decoration:none;" /></a></td></tr>`
+    : "";
+
+  const portalLink = `<a href="${escapeAttr(p.portal)}" style="color:${accent};text-decoration:none;font-weight:600;">punkrockai.com</a>`;
+
+  // The signature is wrapped in a single table — Outlook desktop does not
+  // honour margin on top-level divs, but it does honour table cell padding.
+  return [
+    `<table cellpadding="0" cellspacing="0" border="0" role="presentation" style="border-collapse:collapse;font-family:${fontStack};font-size:14px;line-height:1.5;color:${ink};">`,
+    `<tr><td style="padding:0;">`,
+    `<div style="font-family:${fontStack};font-size:14px;line-height:1.5;color:${ink};">`,
+    `${nameLine}${roleLine}`,
+    `</div>`,
+    contactLine,
+    `<div style="margin-top:8px;padding-left:10px;border-left:3px solid ${accent};font-family:${fontStack};font-style:italic;font-size:13px;line-height:1.45;color:${ink};max-width:42em;">`,
+    `&ldquo;${escapeHTML(p.tagline)}&rdquo;`,
+    `</div>`,
+    `<div style="margin-top:8px;font-family:${fontStack};font-size:12px;line-height:1.5;color:${muted};">`,
+    `from <em style="color:${muted};">Punk Rock AI</em> &middot; ${portalLink}`,
+    `</div>`,
+    `</td></tr>`,
+    badgeBlock,
+    `</table>`,
+  ].join("");
+}
+
+function renderText(p) {
+  const lines = [];
+  lines.push(p.role ? `${p.name} | ${p.role}` : p.name);
+  const contact = [];
+  if (p.email) contact.push(p.email);
+  if (p.handle) contact.push(p.handle);
+  if (contact.length) lines.push(contact.join(" | "));
+  lines.push("");
+  lines.push(`"${p.tagline}"`);
+  lines.push("");
+  lines.push(`from Punk Rock AI -- ${p.portal}`);
+  if (p.badge) lines.push("[I attended Punk Rock AI]");
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Copy
+// ---------------------------------------------------------------------------
+
+async function copyRich() {
+  const sig = buildSignature();
+  // Rich copy uses the Clipboard API's text/html mime type so paste targets
+  // that accept rich content (Gmail compose, Apple Mail) get the styled
+  // signature, while plain-text targets get the fallback.
+  try {
+    if (navigator.clipboard && window.ClipboardItem) {
+      const item = new ClipboardItem({
+        "text/html": new Blob([sig.html], { type: "text/html" }),
+        "text/plain": new Blob([sig.text], { type: "text/plain" }),
+      });
+      await navigator.clipboard.write([item]);
+      flash("rich signature copied");
+      return;
+    }
+  } catch (err) {
+    console.warn("[sig] rich copy failed, falling back:", err);
+  }
+  // Fallback: select the rendered preview and execCommand('copy'). This
+  // preserves formatting in browsers that lack ClipboardItem.
+  selectPreviewAndCopy();
+}
+
+function selectPreviewAndCopy() {
+  const node = document.getElementById("sig-preview");
+  if (!node) return;
+  const range = document.createRange();
+  range.selectNodeContents(node);
+  const sel = window.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(range);
+  try {
+    document.execCommand("copy");
+    flash("rich signature copied");
+  } catch (err) {
+    flash("copy failed - try Copy raw HTML");
+  }
+  sel.removeAllRanges();
+}
+
+async function copyHtml() {
+  const sig = buildSignature();
+  await writeText(sig.html, "raw HTML copied");
+}
+
+async function copyText() {
+  const sig = buildSignature();
+  await writeText(sig.text, "plain text copied");
+}
+
+async function writeText(value, ok) {
+  try {
+    await navigator.clipboard.writeText(value);
+    flash(ok);
+  } catch (err) {
+    console.warn("[sig] writeText failed:", err);
+    flash("copy failed - select and copy from the box below");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function flash(msg) {
+  const el = document.getElementById("sig-status");
+  if (!el) return;
+  el.textContent = msg;
+  clearTimeout(el._t);
+  el._t = setTimeout(() => {
+    el.textContent = "";
+  }, 2500);
+}
+
+function escapeHTML(str) {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escapeAttr(str) {
+  return escapeHTML(str);
+}

--- a/site/widgets/sig.html
+++ b/site/widgets/sig.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Email signature generator &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="Type your name + handle. The widget emits a copy-pastable HTML email signature with a rotating talk quote and a link back to the portal."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:title" content="Email signature generator — Punk Rock AI" />
+    <meta property="og:description" content="Carry the talk into every email. Pick a quote. Copy. Paste." />
+    <meta property="og:url" content="https://punkrockai.com/widgets/sig.html" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/widgets/sig.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main>
+      <section class="sig-intro grain scanlines">
+        <div class="wrap wrap--narrow">
+          <p class="kicker kicker--accent">Phase 5 &middot; distribution surface</p>
+          <h1>Email signature generator.</h1>
+          <p class="sig-intro__lede">
+            Type your name, role, and handle. Pick a line from the talk.
+            Copy. Paste into Gmail / Apple Mail / Outlook. Carry the
+            covenant into every email you send for the next year.
+          </p>
+        </div>
+      </section>
+
+      <section class="sig-form-wrap">
+        <div class="wrap wrap--narrow">
+          <form class="sig-form" id="sig-form" novalidate>
+            <fieldset class="sig-fieldset">
+              <legend class="sig-legend">Inputs</legend>
+
+              <label class="sig-field">
+                <span class="sig-field__label">Name</span>
+                <input
+                  type="text"
+                  id="sig-name"
+                  data-field="name"
+                  autocomplete="name"
+                  placeholder="Kris Kr&uuml;g"
+                  maxlength="80"
+                />
+              </label>
+
+              <label class="sig-field">
+                <span class="sig-field__label">Role / title</span>
+                <input
+                  type="text"
+                  id="sig-role"
+                  data-field="role"
+                  autocomplete="organization-title"
+                  placeholder="Photographer, AI educator"
+                  maxlength="120"
+                />
+              </label>
+
+              <label class="sig-field">
+                <span class="sig-field__label">Handle or URL</span>
+                <input
+                  type="text"
+                  id="sig-handle"
+                  data-field="handle"
+                  autocomplete="url"
+                  placeholder="@kk or kriskrug.co"
+                  maxlength="120"
+                />
+                <span class="sig-field__hint">@handle becomes a search link. Anything with a dot becomes a website link.</span>
+              </label>
+
+              <label class="sig-field">
+                <span class="sig-field__label">Email (optional)</span>
+                <input
+                  type="email"
+                  id="sig-email"
+                  data-field="email"
+                  autocomplete="email"
+                  placeholder="you@example.com"
+                  maxlength="160"
+                />
+              </label>
+
+              <div class="sig-field">
+                <span class="sig-field__label">Tagline</span>
+                <select id="sig-tagline" data-field="taglineId"></select>
+                <div class="sig-field__row">
+                  <button class="btn btn--small" type="button" data-action="rotate-tagline">Rotate</button>
+                  <button class="btn btn--small" type="button" data-action="random-tagline">Random</button>
+                </div>
+              </div>
+
+              <label class="sig-field sig-field--check">
+                <input type="checkbox" id="sig-badge" data-field="badge" />
+                <span>Include &ldquo;I attended Punk Rock AI&rdquo; badge</span>
+              </label>
+            </fieldset>
+
+            <div class="sig-form__row">
+              <button class="btn" type="button" data-action="reset">Reset</button>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <section class="sig-preview-wrap">
+        <div class="wrap wrap--narrow">
+          <h2 class="sig-h2">Preview</h2>
+          <p class="sig-hint">
+            This is how the signature will render in most email clients.
+            Inline styles only &mdash; nothing external.
+          </p>
+          <div class="sig-preview" id="sig-preview" aria-live="polite"></div>
+
+          <div class="sig-actions">
+            <button class="btn btn--primary" type="button" data-action="copy-rich">Copy rich (HTML)</button>
+            <button class="btn" type="button" data-action="copy-html">Copy raw HTML</button>
+            <button class="btn" type="button" data-action="copy-text">Copy plain text</button>
+          </div>
+          <p class="sig-status" id="sig-status" aria-live="polite"></p>
+
+          <details class="sig-source">
+            <summary>Plain-text fallback</summary>
+            <pre class="sig-source__pre" id="sig-text"></pre>
+          </details>
+
+          <details class="sig-source">
+            <summary>Raw HTML</summary>
+            <pre class="sig-source__pre" id="sig-html"></pre>
+          </details>
+
+          <details class="sig-howto">
+            <summary>How to install</summary>
+            <ul class="sig-howto__list">
+              <li><strong>Gmail (web):</strong> Settings &rarr; See all settings &rarr; General &rarr; Signature. Paste with <em>Copy rich</em>.</li>
+              <li><strong>Apple Mail:</strong> Mail &rarr; Settings &rarr; Signatures. Paste, then <em>uncheck</em> &ldquo;Always match my default message font.&rdquo;</li>
+              <li><strong>Outlook (web):</strong> Settings &rarr; Mail &rarr; Compose and reply &rarr; Email signature. Paste rich.</li>
+              <li><strong>Mobile clients:</strong> use the plain-text fallback.</li>
+            </ul>
+          </details>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/sig.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Refs #64

14 taglines from the talk, table-based inline-styled HTML (Outlook-safe), plain-text fallback. Rich / raw HTML / plain copy modes via ClipboardItem with execCommand fallback. UTC-day rotation + manual Rotate/Random. Badge image opt-in (asset to be supplied separately).

Review repair scope note: This PR ships the email signature generator with talk taglines. The original quotes.json-backed source requirement remains follow-up scope unless the issue is revised.
