### PR TITLE
[P4] C8 — The Tool Was Never Neutral case showcase

### DIFF
--- a/site/css/widgets/tool-not-neutral.css
+++ b/site/css/widgets/tool-not-neutral.css
@@ -1,0 +1,318 @@
+/* /widgets/tool-not-neutral.html — case showcase for slide 19 */
+
+.tnn-intro {
+  padding-block: var(--space-6);
+  border-bottom: 1px solid var(--border);
+}
+
+.tnn-intro h1 {
+  font-size: var(--fs-2xl);
+  margin: 0 0 var(--space-3);
+  max-width: 22ch;
+}
+
+.tnn-intro__lede {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 52ch;
+  color: var(--fg-soft);
+}
+
+.tnn-intro__pull {
+  font-family: var(--font-display);
+  font-size: var(--fs-xl);
+  margin: var(--space-4) 0 var(--space-3);
+  border-left: 3px solid var(--accent);
+  padding: var(--space-2) 0 var(--space-2) var(--space-3);
+  color: var(--accent);
+  max-width: 40ch;
+}
+
+.tnn-intro__rubric {
+  font-size: var(--fs-base);
+  color: var(--fg-soft);
+  max-width: 56ch;
+}
+
+/* ------------------------------------------------------------------
+   CASE SHOWCASE — one card at a time, prev/next, jump strip
+   ------------------------------------------------------------------ */
+
+.tnn {
+  padding-block: var(--space-5);
+}
+
+.tnn__head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+  border-bottom: 2px solid var(--accent);
+  padding-bottom: var(--space-2);
+}
+
+.tnn__progress {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.tnn__nav {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.tnn__nav button {
+  font: inherit;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  padding: 0.45rem 0.9rem;
+  background: transparent;
+  border: 1px solid var(--border-strong);
+  color: var(--fg);
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.tnn__nav button:hover:not(:disabled),
+.tnn__nav button:focus-visible {
+  background: var(--accent);
+  color: var(--bg);
+  outline: none;
+}
+
+.tnn__nav button:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+/* ------------------------------------------------------------------
+   CARD
+   ------------------------------------------------------------------ */
+
+.tnn__card {
+  display: grid;
+  gap: var(--space-3);
+  border: 1px solid var(--border-strong);
+  border-left: 4px solid var(--accent);
+  background: var(--surface, rgba(255, 255, 255, 0.02));
+  padding: var(--space-4);
+  min-height: 18rem;
+}
+
+.tnn-card--in {
+  animation: tnn-fade 240ms ease-out both;
+}
+
+@keyframes tnn-fade {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.tnn-card__head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.tnn-card__num {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.tnn-card__tool {
+  margin: 0;
+  font-size: var(--fs-xl);
+  line-height: 1.2;
+  flex: 1 1 60%;
+}
+
+.tnn-card__pairs {
+  margin: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.tnn-card__row {
+  display: grid;
+  grid-template-columns: minmax(8rem, 12rem) 1fr;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px dashed var(--border-strong);
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.tnn-card__row dt {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+  align-self: start;
+}
+
+.tnn-card__row dd {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.35;
+}
+
+.tnn-card__row--decision {
+  border-left: 3px solid var(--fg-soft);
+}
+
+.tnn-card__row--outcome[data-valence="harm"] {
+  border-left: 3px solid var(--accent);
+}
+
+.tnn-card__row--outcome[data-valence="harm"] dt {
+  color: var(--accent);
+}
+
+.tnn-card__row--outcome[data-valence="benefit"] {
+  border-left: 3px solid #5fd47a;
+}
+
+.tnn-card__row--outcome[data-valence="benefit"] dt {
+  color: #5fd47a;
+}
+
+.tnn-card__harm-name,
+.tnn-card__precise {
+  margin: 0;
+  font-size: var(--fs-base);
+  line-height: 1.45;
+  color: var(--fg-soft);
+}
+
+.tnn-card__harm-name .kicker,
+.tnn-card__precise .kicker {
+  display: inline-block;
+  margin-right: var(--space-2);
+}
+
+.tnn-card__cite {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  word-break: break-word;
+}
+
+.tnn-card__cite a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
+.tnn-card__cite a:hover,
+.tnn-card__cite a:focus-visible {
+  color: var(--accent);
+  outline: none;
+}
+
+/* ------------------------------------------------------------------
+   JUMP STRIP — numbered chips, click to jump, current is solid
+   ------------------------------------------------------------------ */
+
+.tnn__strip {
+  list-style: none;
+  margin: var(--space-4) 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.tnn__strip li { margin: 0; }
+
+.tnn__strip button {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.12em;
+  padding: 0.35rem 0.65rem;
+  background: transparent;
+  border: 1px solid var(--border-strong);
+  color: var(--muted);
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.tnn__strip button:hover,
+.tnn__strip button:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
+}
+
+.tnn__strip button.is-active {
+  background: var(--accent);
+  color: var(--bg);
+  border-color: var(--accent);
+}
+
+/* ------------------------------------------------------------------
+   CODA
+   ------------------------------------------------------------------ */
+
+.tnn-coda {
+  padding-block: var(--space-6);
+  border-top: 1px solid var(--border);
+}
+
+.tnn-coda__line {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  margin: 0 0 var(--space-2);
+  max-width: 56ch;
+}
+
+.tnn-coda__line + .tnn-coda__line {
+  color: var(--accent);
+}
+
+/* ------------------------------------------------------------------
+   RESPONSIVE
+   ------------------------------------------------------------------ */
+
+@media (max-width: 720px) {
+  .tnn-card__row {
+    grid-template-columns: 1fr;
+    gap: var(--space-2);
+  }
+  .tnn-card__row dd {
+    font-size: var(--fs-base);
+  }
+  .tnn__head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+/* ------------------------------------------------------------------
+   REDUCED MOTION
+   ------------------------------------------------------------------ */
+
+@media (prefers-reduced-motion: reduce) {
+  .tnn-card--in {
+    animation: none;
+  }
+  .tnn__nav button,
+  .tnn__strip button,
+  .tnn-card__cite a {
+    transition: none;
+  }
+}

--- a/site/data/tool-cases.json
+++ b/site/data/tool-cases.json
@@ -1,0 +1,152 @@
+{
+  "source": "script/talk-framework-v6.md slide 19 + site/data/cases.json",
+  "thesis": "The tool is never neutral. Every design choice carries values into the world.",
+  "framing": "Each card pairs a tool with the specific design decision its makers made, and the real-world consequence that decision produced. No bias-laundering. Name the choice. Name what it did.",
+  "talkRef": "script/talk-framework-v6.md slide 19",
+  "cases": [
+    {
+      "id": "gender-shades",
+      "tool": "Commercial facial-analysis APIs (IBM, Microsoft, Face++)",
+      "decision": "Trained and benchmarked on datasets dominated by lighter-skinned male faces; shipped without disaggregated accuracy reporting.",
+      "outcome": "Misidentified darker-skinned women at a 34.7% error rate vs. 0.8% for lighter-skinned men — a 40x gap baked into infrastructure governments and police were already buying.",
+      "valence": "harm",
+      "harm": "racism and sexism embedded in code",
+      "preciseName": "compounded racial and gender discrimination, with darker-skinned women carrying the worst error rate by orders of magnitude",
+      "citation": "Buolamwini, J. & Gebru, T. (2018). Gender Shades. Proceedings of Machine Learning Research 81.",
+      "citationUrl": "https://gendershades.org",
+      "caseId": "gender-shades"
+    },
+    {
+      "id": "amazon-resume",
+      "tool": "Amazon's internal resume-screening model",
+      "decision": "Trained on 10 years of Amazon's own hiring decisions and let the model infer what a 'good candidate' looked like.",
+      "outcome": "The model learned to penalize the word 'women's' (as in 'women's chess club captain') and downrank graduates of all-women's colleges. Amazon scrapped it before deployment — but only after building it.",
+      "valence": "harm",
+      "harm": "automated devaluation of women's resumes — a feedback loop that would have made the historical pattern self-reinforcing",
+      "preciseName": "encoded historical hiring discrimination, automated and scaled, with the side effect of laundering the discrimination as 'objective' machine output",
+      "citation": "Dastin, J. (2018). 'Amazon scraps secret AI recruiting tool that showed bias against women.' Reuters.",
+      "citationUrl": "https://www.reuters.com/article/us-amazon-com-jobs-automation-insight/idUSKCN1MK08G",
+      "caseId": "amazon-resume"
+    },
+    {
+      "id": "compas",
+      "tool": "COMPAS recidivism risk score (Northpointe / equivant)",
+      "decision": "Optimized a single overall accuracy number; never required calibrated false-positive parity across racial groups before selling to courts.",
+      "outcome": "Black defendants who didn't re-offend were flagged high-risk at 45%; white defendants in the same situation, 23%. Judges used those scores to set bail and sentencing.",
+      "valence": "harm",
+      "harm": "racially disparate over-policing dressed up as actuarial science",
+      "preciseName": "the system mislabels Black defendants as high-risk at twice the false-positive rate of white defendants, and the courts use those scores to set bail and sentencing",
+      "citation": "Angwin, J., Larson, J., Mattu, S., & Kirchner, L. (2016). 'Machine Bias.' ProPublica.",
+      "citationUrl": "https://www.propublica.org/article/machine-bias-risk-assessments-in-criminal-sentencing",
+      "caseId": "compas"
+    },
+    {
+      "id": "healthcare-algorithm",
+      "tool": "A widely-deployed US hospital risk-prediction algorithm (Optum / used on ~200M patients)",
+      "decision": "Picked predicted future health-care cost as the proxy for medical need — because cost data was easy to get.",
+      "outcome": "Black patients had to be significantly sicker than white patients to receive the same risk score, because the system had historically spent less on them. The proxy laundered structural under-spending as 'they need less care.'",
+      "valence": "harm",
+      "harm": "structural under-spending on Black patients was being laundered as 'they need less care' by the algorithm",
+      "preciseName": "the algorithm optimized for predicted cost, which encoded historical under-spending on Black patients, and recommended care allocation as if cost equalled need",
+      "citation": "Obermeyer, Z., Powers, B., Vogeli, C., & Mullainathan, S. (2019). 'Dissecting racial bias in an algorithm used to manage the health of populations.' Science.",
+      "citationUrl": "https://www.science.org/doi/10.1126/science.aax2342",
+      "caseId": "healthcare-algorithm"
+    },
+    {
+      "id": "aave-moderation",
+      "tool": "Hate-speech classifiers licensed to social platforms",
+      "decision": "Trained on annotator-labeled toxicity datasets without correcting for annotators' unfamiliarity with African American English.",
+      "outcome": "AAVE tweets were flagged toxic at 1.5x to 2.2x the rate of equivalent standard-English tweets. Black users were silenced more often by the same 'neutral' moderation tool.",
+      "valence": "harm",
+      "harm": "differential censorship of Black users' speech, embedded in the moderation infrastructure of every platform that licensed those classifiers",
+      "preciseName": "platforms silence Black users' speech at twice the rate of equivalent white speech, while branding the system as objective",
+      "citation": "Sap, M., Card, D., Gabriel, S., Choi, Y., & Smith, N. A. (2019). 'The Risk of Racial Bias in Hate Speech Detection.' ACL 2019.",
+      "citationUrl": "https://aclanthology.org/P19-1163/",
+      "caseId": "aave-moderation"
+    },
+    {
+      "id": "asr-accent",
+      "tool": "Top-five voice-assistant speech recognizers (Apple, Amazon, Google, IBM, Microsoft)",
+      "decision": "Trained acoustic models on a corpus dominated by white General-American speech; treated that distribution as 'standard.'",
+      "outcome": "Word-error rate for Black speakers was nearly twice that of white speakers — every voice phone-tree, dictation tool, and in-car system silently worked worse for them.",
+      "valence": "harm",
+      "harm": "voice interfaces silently work worse for Black speakers across every product that licenses these recognizers",
+      "preciseName": "the acoustic model was trained on a corpus dominated by white General-American speech, so every speaker outside that distribution gets misheard at scale",
+      "citation": "Koenecke, A. et al. (2020). 'Racial disparities in automated speech recognition.' PNAS.",
+      "citationUrl": "https://www.pnas.org/doi/10.1073/pnas.1915768117",
+      "caseId": "asr-accent"
+    },
+    {
+      "id": "predictive-policing",
+      "tool": "PredPol-style predictive-policing systems (LAPD, Chicago, dozens more)",
+      "decision": "Used past arrest locations as the input signal — treating arrest data as if it were crime data.",
+      "outcome": "Patrols were sent back to neighborhoods that were already over-policed, generating more arrests, feeding the model, and laundering the cycle as objective forecasting.",
+      "valence": "harm",
+      "harm": "a feedback loop that hard-codes historical over-policing of Black and brown neighborhoods into 'objective' forecasts",
+      "preciseName": "a recursive automation of past disparate enforcement — the model recommends patrols where past arrests were concentrated, generating new arrests that train the next iteration",
+      "citation": "Brennan Center for Justice (2021). 'Predictive Policing Explained.'",
+      "citationUrl": "https://www.brennancenter.org/our-work/research-reports/predictive-policing-explained",
+      "caseId": "predictive-policing"
+    },
+    {
+      "id": "sweeney-ads",
+      "tool": "Google AdSense ad-delivery auction",
+      "decision": "Let advertiser bids and click-through rates jointly determine which ad text appeared next to which name — with no audit on race-coded query terms.",
+      "outcome": "Searching a Black-coded name was up to 25% more likely to surface an arrest-record ad than searching a white-coded name. Suspicion was pre-loaded onto Black names at the moment a stranger Googled them.",
+      "valence": "harm",
+      "harm": "ad-delivery infrastructure pre-loaded suspicion onto Black names at the moment a stranger Googled them",
+      "preciseName": "racially differentiated ad delivery — the same query returned criminal-record ads for Black-coded names and neutral ads for white-coded names",
+      "citation": "Sweeney, L. (2013). 'Discrimination in Online Ad Delivery.' Communications of the ACM.",
+      "citationUrl": "https://dl.acm.org/doi/10.1145/2447976.2447990",
+      "caseId": "sweeney-ads"
+    },
+    {
+      "id": "indigenous-representation",
+      "tool": "Mainstream text-to-image models (Midjourney, Stable Diffusion, DALL-E)",
+      "decision": "Scraped training images from a web that over-represented Indigenous peoples in historical, costumed, and ethnographic contexts.",
+      "outcome": "Prompts for Indigenous people render historical reenactors by default — present-tense, plural, contemporary Indigenous life is filtered out of the machine-default image of who exists today.",
+      "valence": "harm",
+      "harm": "the model treats Indigenous people as a closed historical category rather than ongoing, plural, contemporary peoples",
+      "preciseName": "temporal erasure — Indigenous identity is rendered as the past, not the present, by default, regardless of the prompt's framing",
+      "citation": "Birhane, A. et al. (2023). 'Hate Scaling Laws For Data-Swamps.' FAccT.",
+      "citationUrl": "https://dl.acm.org/doi/10.1145/3593013.3594095",
+      "caseId": "indigenous-representation"
+    },
+    {
+      "id": "marketing-professor",
+      "tool": "Generic consumer image generator (prompt comparison)",
+      "decision": "Default representations of high-status professions were never re-balanced for gender; 'authority' visual cues were learned from a male-dominated image distribution.",
+      "outcome": "'A marketing professor' produced a man in a blazer, gravitas, Harvard energy. Adding 'female' downgraded the same prompt to a timid school-teacher visual until the user fought multiple rounds for parity.",
+      "valence": "harm",
+      "harm": "misogyny, not bias",
+      "preciseName": "the system encodes the default professor as masculine and downgrades authority signals when 'female' is added",
+      "citation": "Kris Krüg, Punk Rock AI / Both Hands Full (May 2026 talk anecdote).",
+      "citationUrl": null,
+      "caseId": "marketing-professor"
+    },
+    {
+      "id": "english-default",
+      "tool": "Frontier large language models (GPT, Claude, Gemini, Llama)",
+      "decision": "Built tokenizers and training mixes that over-weight English; pivoted multilingual reasoning through English internal representations.",
+      "outcome": "Non-English input gets flattened on the way in and on the way out — dialect, idiom, and cultural reference erased — while the product is marketed as multilingual.",
+      "valence": "harm",
+      "harm": "English is being treated as the unmarked default of human thought, and every non-English speaker gets the lossy version",
+      "preciseName": "an English-pivot architecture that flattens dialect, idiom, and cultural reference on the way in and on the way out, while marketing itself as multilingual",
+      "citation": "Bender, E. M., Gebru, T., McMillan-Major, A., & Shmitchell, S. (2021). 'On the Dangers of Stochastic Parrots.' FAccT.",
+      "citationUrl": "https://dl.acm.org/doi/10.1145/3442188.3445922",
+      "caseId": "english-default"
+    },
+    {
+      "id": "disability-captions",
+      "tool": "Auto-caption and alt-text generation across major platforms",
+      "decision": "Built and audited the systems with sighted, hearing engineering teams; treated 'has captions' as the success metric, not 'captions usable by the people who need them.'",
+      "outcome": "Captions and alt text technically exist — and routinely fail the disabled users they were ostensibly built for. Compliance theater satisfies a checkbox while the people the feature is for stay locked out.",
+      "valence": "harm",
+      "harm": "accessibility theater — accommodations that satisfy a checkbox but actively fail the people they're branded as serving",
+      "preciseName": "the system is built and audited by people who never have to use it, so the failure modes that matter to disabled users never get into the test set",
+      "citation": "Whittaker, M. et al. (2019). 'Disability, Bias, and AI.' AI Now Institute.",
+      "citationUrl": "https://ainowinstitute.org/disabilitybiasai-2019.pdf",
+      "caseId": "disability-captions"
+    }
+  ]
+}

--- a/site/js/widgets/tool-not-neutral.js
+++ b/site/js/widgets/tool-not-neutral.js
@@ -1,0 +1,159 @@
+// /widgets/tool-not-neutral.html — case showcase for slide 19.
+// Walks through paired tool / design-decision / outcome examples.
+// Vanilla JS, no dependencies, no LLM. Respects prefers-reduced-motion.
+
+const cardEl = document.getElementById("tnn-card");
+const progressEl = document.getElementById("tnn-progress");
+const stripEl = document.getElementById("tnn-strip");
+const prevBtn = document.getElementById("tnn-prev");
+const nextBtn = document.getElementById("tnn-next");
+
+const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+let cases = [];
+let active = 0;
+
+main();
+
+async function main() {
+  try {
+    const res = await fetch("/data/tool-cases.json");
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    cases = Array.isArray(data.cases) ? data.cases : [];
+    if (!cases.length) throw new Error("no cases");
+    renderStrip();
+    paint();
+    wireNav();
+    hydrateFromHash();
+  } catch (err) {
+    if (cardEl) cardEl.innerHTML = `<p class="kicker">cases unavailable.</p>`;
+    console.warn("[tool-not-neutral]", err);
+  }
+}
+
+function wireNav() {
+  prevBtn?.addEventListener("click", () => step(-1));
+  nextBtn?.addEventListener("click", () => step(1));
+  document.addEventListener("keydown", (e) => {
+    if (e.target.matches("textarea, input, button, a")) return;
+    if (e.key === "ArrowLeft") step(-1);
+    else if (e.key === "ArrowRight") step(1);
+  });
+  window.addEventListener("hashchange", hydrateFromHash);
+}
+
+function step(delta) {
+  const next = active + delta;
+  if (next < 0 || next >= cases.length) return;
+  goTo(next);
+}
+
+function goTo(i) {
+  if (i === active) return;
+  active = i;
+  paint();
+  const id = cases[active]?.id;
+  if (id) history.replaceState(null, "", `#${encodeURIComponent(id)}`);
+}
+
+function hydrateFromHash() {
+  const raw = decodeURIComponent((location.hash || "").replace(/^#/, ""));
+  if (!raw) return;
+  const idx = cases.findIndex((c) => c.id === raw);
+  if (idx >= 0 && idx !== active) {
+    active = idx;
+    paint();
+  }
+}
+
+function renderStrip() {
+  if (!stripEl) return;
+  stripEl.innerHTML = cases
+    .map(
+      (c, i) =>
+        `<li><button type="button" data-i="${i}" aria-label="Case ${i + 1}: ${escapeAttr(c.tool)}">${pad(i + 1)}</button></li>`
+    )
+    .join("");
+  stripEl.addEventListener("click", (e) => {
+    const btn = e.target.closest("button[data-i]");
+    if (!btn) return;
+    goTo(Number(btn.dataset.i));
+  });
+}
+
+function paint() {
+  const c = cases[active];
+  if (!c || !cardEl) return;
+
+  progressEl.textContent = `case ${active + 1} / ${cases.length}`;
+  prevBtn.disabled = active === 0;
+  nextBtn.disabled = active === cases.length - 1;
+
+  for (const btn of stripEl.querySelectorAll("button[data-i]")) {
+    btn.classList.toggle("is-active", Number(btn.dataset.i) === active);
+  }
+
+  const valence = c.valence === "benefit" ? "benefit" : "harm";
+  const valenceLabel = valence === "benefit" ? "outcome · benefit" : "outcome · harm";
+
+  const citation = c.citation
+    ? c.citationUrl
+      ? `<a href="${escapeAttr(c.citationUrl)}" target="_blank" rel="noopener">${escapeHTML(c.citation)} &nearr;</a>`
+      : escapeHTML(c.citation)
+    : "";
+
+  const harmLine = c.harm
+    ? `<p class="tnn-card__harm-name"><span class="kicker kicker--accent">harm name</span> ${escapeHTML(c.harm)}</p>`
+    : "";
+
+  const preciseLine = c.preciseName
+    ? `<p class="tnn-card__precise"><span class="kicker">precise name</span> ${escapeHTML(c.preciseName)}</p>`
+    : "";
+
+  cardEl.dataset.valence = valence;
+  cardEl.classList.toggle("tnn-card--no-motion", reduceMotion);
+  if (!reduceMotion) {
+    cardEl.classList.remove("tnn-card--in");
+    // force reflow for the entrance animation
+    void cardEl.offsetWidth;
+    cardEl.classList.add("tnn-card--in");
+  }
+
+  cardEl.innerHTML = `
+    <header class="tnn-card__head">
+      <span class="tnn-card__num">${pad(active + 1)} / ${pad(cases.length)}</span>
+      <h2 class="tnn-card__tool">${escapeHTML(c.tool)}</h2>
+    </header>
+    <dl class="tnn-card__pairs">
+      <div class="tnn-card__row tnn-card__row--decision">
+        <dt>design decision</dt>
+        <dd>${escapeHTML(c.decision)}</dd>
+      </div>
+      <div class="tnn-card__row tnn-card__row--outcome" data-valence="${valence}">
+        <dt>${valenceLabel}</dt>
+        <dd>${escapeHTML(c.outcome)}</dd>
+      </div>
+    </dl>
+    ${harmLine}
+    ${preciseLine}
+    ${citation ? `<p class="tnn-card__cite">&darr; ${citation}</p>` : ""}
+  `;
+}
+
+function pad(n) {
+  return String(n).padStart(2, "0");
+}
+
+function escapeHTML(s) {
+  return String(s ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function escapeAttr(s) {
+  return escapeHTML(s);
+}

--- a/site/widgets/tool-not-neutral.html
+++ b/site/widgets/tool-not-neutral.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>The Tool Was Never Neutral &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="Twelve real tools. Twelve design decisions. Twelve real-world consequences. The tool is never neutral — and neither are we."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:title" content="The Tool Was Never Neutral — Punk Rock AI" />
+    <meta property="og:description" content="Tool. Decision. Outcome. Walk through twelve real cases of values shipped as code." />
+    <meta property="og:url" content="https://punkrockai.com/widgets/tool-not-neutral.html" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/widgets/tool-not-neutral.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main>
+      <section class="tnn-intro">
+        <div class="wrap wrap--narrow">
+          <p class="kicker kicker--accent">Slide 19 &middot; the tool is never neutral</p>
+          <h1>Every design choice ships a value.</h1>
+          <p class="tnn-intro__lede">
+            Anthony Joseph &mdash; Isil&eacute;yu &mdash; said his ancestors didn&rsquo;t have chainsaws,
+            but they would&rsquo;ve used them if they were there. The creative impulse is continuous.
+            The tools change. The people who pick them up are in the same lineage.
+          </p>
+          <p class="tnn-intro__pull">
+            The tool is never neutral. But neither are we.
+          </p>
+          <p class="tnn-intro__rubric">
+            Each card pairs a real tool with the specific decision its makers made and the
+            real-world consequence that decision produced. Not bias. Not magic. A choice.
+          </p>
+        </div>
+      </section>
+
+      <section class="tnn">
+        <div class="wrap">
+          <div class="tnn__head">
+            <span class="tnn__progress" id="tnn-progress" aria-live="polite">case 1 / 12</span>
+            <div class="tnn__nav">
+              <button type="button" id="tnn-prev" aria-label="Previous case">&larr; prev</button>
+              <button type="button" id="tnn-next" aria-label="Next case">next &rarr;</button>
+            </div>
+          </div>
+
+          <article class="tnn__card" id="tnn-card" aria-live="polite"></article>
+
+          <ol class="tnn__strip" id="tnn-strip" aria-label="Jump to case"></ol>
+        </div>
+      </section>
+
+      <section class="tnn-coda">
+        <div class="wrap wrap--narrow">
+          <p class="tnn-coda__line">
+            Twelve choices. Twelve outcomes. None of them inevitable.
+          </p>
+          <p class="tnn-coda__line">
+            Pick up the tool. Use it wrong. Share what you learn. Build a posse.
+          </p>
+          <p class="kicker">
+            Vocabulary aligned with <a href="/widgets/name-what-you-see.html">/name-what-you-see</a>
+            and <code>site/data/cases.json</code>. Each case links to its primary source.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/tool-not-neutral.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Refs #39

Card-walker UX (prev/next + jump strip + arrow keys + hash deep-link). 12 curated tool→decision→outcome cases. Issue body originally proposed a 5×5 hover matrix; shipped the card-walker variant per the narrowed scope. Independent of PR #95 — uses its own curated tool-cases.json.

Review repair scope note: This PR ships the card-walker case showcase. The original /widgets/tool-neutral.html 5x5 matrix remains follow-up scope.
