### PR TITLE
[Followup] Wire Anthropic API + KV cache for /pattern-finder Worker

### DIFF
--- a/worker/pattern-finder/README.md
+++ b/worker/pattern-finder/README.md
@@ -7,15 +7,22 @@ prompt caching so per-call cost stays low under load. Per-IP rate-limit
 
 ## Deploy
 
+See `SETUP.md` for the full step-by-step (Anthropic key, KV namespaces,
+secret, deploy, smoke test). TL;DR:
+
 ```sh
 cd worker/pattern-finder
-wrangler kv namespace create RATE_LIMIT     # paste id into wrangler.toml
-wrangler secret put ANTHROPIC_API_KEY        # paste your key
+wrangler kv namespace create RATE_LIMIT      # paste id into wrangler.toml
+wrangler kv namespace create KV_PATTERNS     # paste id into wrangler.toml
+wrangler secret put ANTHROPIC_API_KEY         # paste your key
 wrangler deploy
 ```
 
 Then update `site/_redirects` to point `/api/pattern-finder` at the deployed
 worker URL.
+
+If `ANTHROPIC_API_KEY` isn't set, the worker returns 503 with a clear
+"not configured" message — the front-end already handles that gracefully.
 
 ## Local dev
 
@@ -34,5 +41,8 @@ is gated on the worker existing.
 - `MAX_INPUT_CHARS = 40_000` — caps user corpus size.
 - `MAX_TOKENS = 1500` — caps Claude's response.
 - Rate limit `10 / IP / hour` — adjustable in `index.js`.
+- Response cache in `KV_PATTERNS` — identical corpus skips Anthropic entirely
+  for 7 days. `x-cache: HIT` / `MISS` header signals which path served the
+  request.
 - System prompt has `cache_control: { type: "ephemeral" }` — prompt cache hits
   drop the per-call cost roughly 10x once the cache is warm.

--- a/worker/pattern-finder/SETUP.md
+++ b/worker/pattern-finder/SETUP.md
@@ -1,0 +1,95 @@
+# Pattern Finder Worker — Setup
+
+End-to-end checklist to take the worker from cloned repo to a live deployment
+that proxies Claude Sonnet 4.6 with KV-backed response caching and per-IP rate
+limiting.
+
+## 1. Prerequisites
+
+- Cloudflare account with a Workers plan (free tier is fine)
+- `wrangler` CLI installed and authenticated (`npx wrangler login`)
+- An Anthropic API key
+
+## 2. Get an Anthropic API key
+
+1. Sign in at <https://console.anthropic.com>.
+2. Go to **Settings → API Keys → Create Key**.
+3. Give it a name (e.g. `pattern-finder-prod`) and copy the value once — you
+   cannot view it again.
+4. Confirm the workspace has billing enabled and a usage cap that matches what
+   you're willing to pay for unauthenticated public traffic. The widget caps
+   inbound at 10 requests / IP / hour and 40k input chars per request, but you
+   should still set a hard monthly spend ceiling on the Anthropic side.
+
+The worker uses model `claude-sonnet-4-6` by default. To run cheaper, edit
+`MODEL` in `index.js` to `claude-haiku-4-5-20251001`.
+
+## 3. Create the KV namespaces
+
+```sh
+cd worker/pattern-finder
+npx wrangler kv namespace create RATE_LIMIT
+npx wrangler kv namespace create KV_PATTERNS
+```
+
+Each command prints an `id`. Open `wrangler.toml`, uncomment the two
+`[[kv_namespaces]]` blocks, and paste the ids in.
+
+## 4. Set the API key as a secret
+
+```sh
+npx wrangler secret put ANTHROPIC_API_KEY
+# paste the key from step 2 when prompted
+```
+
+The secret is encrypted at rest on Cloudflare and never written to disk
+locally. Do not put the key in `wrangler.toml` or `.env` files in the repo.
+
+## 5. Deploy
+
+```sh
+npx wrangler deploy
+```
+
+Note the worker URL printed at the end (e.g.
+`https://pattern-finder.<account>.workers.dev`).
+
+## 6. Wire the front-end
+
+Update `site/_redirects` so `/api/pattern-finder` proxies to the deployed
+worker URL. Re-deploy the site.
+
+## 7. Smoke test
+
+```sh
+curl -X POST https://pattern-finder.<account>.workers.dev \
+  -H 'content-type: application/json' \
+  -d '{"corpus":"the night I broke my camera in iceland..."}'
+```
+
+- First call: 200, response body contains `patterns` array, response header
+  `x-cache: MISS`.
+- Identical second call: 200, header `x-cache: HIT` (served from KV, no
+  Anthropic spend).
+- 11th call from same IP within an hour: 429 with rate-limit message.
+- If you intentionally `wrangler secret delete ANTHROPIC_API_KEY` and redeploy,
+  the worker should return 503 with a clear "not configured" message instead
+  of 5xx-ing.
+
+## 8. Monitoring
+
+```sh
+npx wrangler tail
+```
+
+Watch logs while hitting the widget. Confirm `x-cache: HIT` shows up on
+repeats and that the rate-limit returns 429 once exhausted.
+
+## Reference: env vars and bindings
+
+| Name                | Type   | Required | Notes                                  |
+| ------------------- | ------ | -------- | -------------------------------------- |
+| `ANTHROPIC_API_KEY` | secret | yes\*    | \*Without it the worker returns 503.   |
+| `RATE_LIMIT`        | KV     | no       | If unbound, rate limiting is disabled. |
+| `KV_PATTERNS`       | KV     | no       | If unbound, response cache is bypassed.|
+| `ALLOWED_ORIGIN`    | var    | no       | Defaults to `https://punkrockai.com`.  |

--- a/worker/pattern-finder/index.js
+++ b/worker/pattern-finder/index.js
@@ -9,8 +9,9 @@
 //
 // Required wrangler bindings (see wrangler.toml):
 //   secret  ANTHROPIC_API_KEY
-//   kv      RATE_LIMIT
-//   var     ALLOWED_ORIGIN  (default: https://punkrockai.com)
+//   kv      RATE_LIMIT     (per-IP rate limiting)
+//   kv      KV_PATTERNS    (response cache, keyed by sha256 of corpus)
+//   var     ALLOWED_ORIGIN (default: https://punkrockai.com)
 //
 // Deploy:
 //   cd worker/pattern-finder
@@ -23,6 +24,7 @@ const MODEL = "claude-sonnet-4-6";
 const MAX_TOKENS = 1500;
 const RATE_LIMIT_PER_HOUR = 10;
 const MAX_INPUT_CHARS = 40_000;
+const CACHE_TTL_SECONDS = 60 * 60 * 24 * 7; // 7 days
 
 const SYSTEM_PROMPT = `You are a Pattern Finder. The user gives you a corpus
 of their own creative work — blog posts, photo captions, project descriptions,
@@ -85,7 +87,20 @@ export default {
     }
 
     if (!env.ANTHROPIC_API_KEY) {
-      return jsonError(500, "worker missing ANTHROPIC_API_KEY", env);
+      return jsonError(
+        503,
+        "Pattern Finder is not configured yet — ANTHROPIC_API_KEY missing on the worker",
+        env,
+      );
+    }
+
+    const cacheKey = await sha256(`${MODEL}:${corpus}`);
+    const cached = await readCache(env, cacheKey);
+    if (cached) {
+      return new Response(JSON.stringify(cached), {
+        status: 200,
+        headers: { ...corsHeaders(env), "x-cache": "HIT" },
+      });
     }
 
     try {
@@ -127,9 +142,11 @@ export default {
         return jsonError(502, "claude returned non-JSON output", env);
       }
 
+      ctx.waitUntil(writeCache(env, cacheKey, parsed));
+
       return new Response(JSON.stringify(parsed), {
         status: 200,
-        headers: corsHeaders(env),
+        headers: { ...corsHeaders(env), "x-cache": "MISS" },
       });
     } catch (err) {
       return jsonError(500, `worker error: ${err.message}`, env);
@@ -146,6 +163,36 @@ async function checkRateLimit(env, ip) {
   if (current >= RATE_LIMIT_PER_HOUR) return false;
   await env.RATE_LIMIT.put(key, String(current + 1), { expirationTtl: 3700 });
   return true;
+}
+
+async function readCache(env, key) {
+  if (!env.KV_PATTERNS) return null;
+  try {
+    return await env.KV_PATTERNS.get(`pf:${key}`, "json");
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(env, key, value) {
+  if (!env.KV_PATTERNS) return;
+  try {
+    await env.KV_PATTERNS.put(`pf:${key}`, JSON.stringify(value), {
+      expirationTtl: CACHE_TTL_SECONDS,
+    });
+  } catch {
+    // best-effort cache; never fail the request on cache write
+  }
+}
+
+async function sha256(input) {
+  const buf = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(input),
+  );
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 function currentHour() {

--- a/worker/pattern-finder/wrangler.toml
+++ b/worker/pattern-finder/wrangler.toml
@@ -4,19 +4,28 @@ compatibility_date = "2026-04-01"
 
 # Bindings:
 #   ANTHROPIC_API_KEY  →  wrangler secret put ANTHROPIC_API_KEY
-#   RATE_LIMIT         →  KV namespace, see below
+#   RATE_LIMIT         →  KV namespace, per-IP rate limiting (10 req/hr)
+#   KV_PATTERNS        →  KV namespace, response cache (7-day TTL)
 #
-# To create the KV namespace and bind it:
+# To create the KV namespaces:
 #   wrangler kv namespace create RATE_LIMIT
-# Then paste the returned id into [[kv_namespaces]] below.
+#   wrangler kv namespace create KV_PATTERNS
+# Then paste the returned ids into [[kv_namespaces]] below.
 #
 # To deploy:
+#   wrangler secret put ANTHROPIC_API_KEY
 #   wrangler deploy
+#
+# See SETUP.md for the full walk-through.
 
 [vars]
 ALLOWED_ORIGIN = "https://punkrockai.com"
 
-# Uncomment after creating the KV namespace via wrangler.
+# Uncomment and fill in after creating the KV namespaces via wrangler.
 # [[kv_namespaces]]
 # binding = "RATE_LIMIT"
-# id = "<paste id here>"
+# id = "<paste id from `wrangler kv namespace create RATE_LIMIT`>"
+#
+# [[kv_namespaces]]
+# binding = "KV_PATTERNS"
+# id = "<paste id from `wrangler kv namespace create KV_PATTERNS`>"


### PR DESCRIPTION
Refs #60

KV_PATTERNS sha256-keyed response cache (7-day TTL, ctx.waitUntil write), x-cache: HIT/MISS header. 503 when ANTHROPIC_API_KEY missing (was 500). Existing per-IP RATE_LIMIT 10/hr KV stays intact. Default model claude-sonnet-4-6.

To finish: provision ANTHROPIC_API_KEY secret + 2 KV namespaces, paste ids into wrangler.toml, deploy. Steps in worker/pattern-finder/SETUP.md.

Review repair scope note: This PR ships the Anthropic/KV worker scaffold. Live secret/KV provisioning, deployed smoke tests, cache hit verification, and rate-limit exercise remain follow-up scope.
