### PR TITLE
[Followup] Harden scripts/ingest-slides.mjs for R2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,17 +5,25 @@
 SLIDES_SRC=/absolute/path/to/your/slide/source/folder
 
 # Cloudflare R2 (S3-compatible) — required to upload hi-res originals.
-# Leave blank to run with SKIP_UPLOAD=1 (writes WebP fallbacks only).
+# All five must be set for a real run, or pass --dry-run / --skip-upload.
+# See scripts/README.md for how to mint these from the Cloudflare dashboard.
 R2_ACCOUNT_ID=
 R2_ACCESS_KEY_ID=
 R2_SECRET_ACCESS_KEY=
 R2_BUCKET=punkrockai-slides
-R2_PUBLIC_BASE=https://punkrockai-slides.your-subdomain.r2.dev
+# Public URL prefix for the bucket. Either the auto-generated r2.dev domain
+# (Settings → Public Access on the bucket) or a custom domain you've bound.
+R2_PUBLIC_BASE=https://pub-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.r2.dev
 
-# Set to 1 to skip the R2 upload step (still writes /site/public/images/slides/)
+# Number of upload retry attempts on transient failure (default 3).
+# R2_MAX_RETRIES=3
+
+# Set to 1 to skip the R2 upload step (still writes /site/public/images/slides/).
+# Equivalent to passing `--skip-upload` on the command line.
 # SKIP_UPLOAD=1
 
-# Set to 1 for a no-op preview of what ingest will do
+# Set to 1 for a no-op preview of what ingest will do.
+# Equivalent to passing `--dry-run` on the command line.
 # DRY_RUN=1
 
 # ---------------------------------------------------------------------------

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,124 @@
+# scripts/
+
+Build and ingest tooling for the punkrockai.com static site.
+
+| Script | What it does |
+| --- | --- |
+| `build-quotes.mjs` | Seeds `site/data/slides.json` from talk source-of-truth. Run before `ingest-slides`. |
+| `build-lineage.mjs` | Generates lineage graph data. |
+| `build-library-index.mjs` | Indexes the reading-list / library page. |
+| `build-audio-cues.mjs` | Compiles per-slide audio cue manifest. |
+| `build-decisions.mjs` | Generates the decisions log page data. |
+| `ingest-slides.mjs` | Resizes slide imagery, uploads originals to Cloudflare R2, merges URLs into `slides.json`. |
+
+The rest of this file documents `ingest-slides.mjs`, which is the only script that talks to a remote service.
+
+---
+
+## ingest-slides.mjs
+
+### What it does
+
+1. Reads images from `$SLIDES_SRC` (a local folder, gitignored, lives outside the repo).
+2. Extracts the slide number from the filename (`01_*.ext`, `slide-12-*.ext`, etc.).
+3. Writes a ~1200px WebP fallback into `site/public/images/slides/` (these are committed).
+4. Uploads the original to a Cloudflare R2 bucket via the S3-compatible API.
+5. Merges `loRes` / `hiRes` / `alt` / `prompt` fields into `site/data/slides.json` on top of the title/act fields produced by `build-quotes.mjs`.
+
+Re-running is idempotent. Fields the script owns (`loRes`, `hiRes`, `alt`, `prompt`) get overwritten with current values; fields it doesn't own (`title`, `act`, `note`, …) are preserved.
+
+### Prerequisites
+
+- Node 20+ and `npm install` from the repo root.
+- A populated `site/data/slides.json` (run `npm run build:quotes` first).
+- A local folder of source images named with a slide number (e.g. `01_neon-storefront.png`, `slide-12-bloodbath.jpg`).
+- For a real run: a Cloudflare R2 bucket and an API token with object-write permission on it.
+
+### Required environment variables
+
+Copy `.env.example` to `.env` and fill in:
+
+| Var | Description |
+| --- | --- |
+| `SLIDES_SRC` | Absolute path to the local slide images folder. |
+| `R2_ACCOUNT_ID` | Cloudflare account ID (Dashboard → R2 → Overview, top-right). |
+| `R2_ACCESS_KEY_ID` | R2 API token access key. |
+| `R2_SECRET_ACCESS_KEY` | R2 API token secret. |
+| `R2_BUCKET` | Bucket name, e.g. `punkrockai-slides`. |
+| `R2_PUBLIC_BASE` | Public URL prefix for the bucket (auto `pub-*.r2.dev` or a custom domain). |
+
+Optional:
+
+| Var | Default | Description |
+| --- | --- | --- |
+| `R2_MAX_RETRIES` | `3` | Upload retry attempts on transient failure. |
+| `SKIP_UPLOAD` | unset | Skip R2 upload, still write WebPs. Same as `--skip-upload`. |
+| `DRY_RUN` | unset | Print plan, no writes, no uploads. Same as `--dry-run`. |
+
+### How to obtain R2 credentials
+
+1. Sign in to the Cloudflare dashboard, select the account.
+2. **R2 → Create bucket**. Pick a name (e.g. `punkrockai-slides`). Region: Automatic.
+3. On the bucket's **Settings** tab, enable **Public Access** (or bind a custom domain). Copy the public URL — that's `R2_PUBLIC_BASE`.
+4. **R2 → Manage R2 API Tokens → Create API Token**.
+   - Permission: **Object Read & Write**.
+   - Bucket: scope to the bucket you just made.
+   - TTL: as long as you need.
+5. Copy **Access Key ID** → `R2_ACCESS_KEY_ID`.
+6. Copy **Secret Access Key** → `R2_SECRET_ACCESS_KEY`.
+7. Account ID is on the **R2 → Overview** page, top right → `R2_ACCOUNT_ID`.
+
+### wrangler.toml
+
+The repo root `wrangler.toml` is for Cloudflare Pages and does not need to know about R2. If you want to bind the bucket to a Worker (we currently don't), the stanza looks like:
+
+```toml
+# Example only — not used by this repo today.
+[[r2_buckets]]
+binding = "SLIDES"
+bucket_name = "punkrockai-slides"
+preview_bucket_name = "punkrockai-slides-preview"
+```
+
+R2 credentials for `ingest-slides.mjs` are read from `process.env`, **not** from `wrangler.toml`. The script runs locally on your machine, not inside a Worker.
+
+### How to run
+
+```bash
+# 1. Preview what would happen (no creds needed beyond SLIDES_SRC):
+node scripts/ingest-slides.mjs --dry-run
+
+# 2. Build local WebPs only, skip the R2 upload:
+node scripts/ingest-slides.mjs --skip-upload
+
+# 3. Real run (requires all five R2 vars):
+node scripts/ingest-slides.mjs
+# or via npm:
+npm run ingest:slides
+```
+
+If `.env` exists, source it first (`set -a; source .env; set +a`) or use a wrapper like `dotenv-cli`.
+
+### How to verify
+
+After a real run:
+
+- `site/public/images/slides/` contains a `<slide-id>.webp` for each ingested slide.
+- `site/data/slides.json` has `loRes` and `hiRes` URLs filled in for each entry.
+- `curl -I "$R2_PUBLIC_BASE/slides/<slide-id>.png"` returns `200`.
+- Open `/talk` locally (`npm run dev`) — the slide reel renders real imagery instead of placeholders.
+- Commit the updated `slides.json` and the new WebPs.
+
+### Troubleshooting
+
+| Symptom | Likely cause / fix |
+| --- | --- |
+| `SLIDES_SRC is required` | Set `SLIDES_SRC` to an absolute path, or pass `--dry-run` to preview. |
+| `missing R2 env: ...` | Set the listed variables, or use `--skip-upload` / `--dry-run`. |
+| `missing dep: install with npm i ...` | Run `npm install` at the repo root. |
+| `no slide images found under <path>` | Filenames must contain a 1- or 2-digit slide number, e.g. `01_*.png`. |
+| `slide N not in slides.json — skipped` | Add the slide to the source-of-truth and re-run `npm run build:quotes`. |
+| `upload <key> failed (attempt N/3)` | Transient — script retries with exponential backoff. If all attempts fail, check token scope and bucket name. |
+| `403 Forbidden` from R2 | API token isn't scoped to the bucket, or lacks Object Write. |
+| Public URL returns `404` | Public Access not enabled on the bucket, or `R2_PUBLIC_BASE` points at the wrong host. |
+| Public URL returns `200` but browser blocks it | Configure bucket CORS for the deployed site origin. |

--- a/scripts/ingest-slides.mjs
+++ b/scripts/ingest-slides.mjs
@@ -23,6 +23,11 @@
 // Optional env:
 //   DRY_RUN=1                 – no R2 upload, no file writes; prints plan only
 //   SKIP_UPLOAD=1             – build WebPs + manifest, but don't push to R2
+//   R2_MAX_RETRIES=3          – upload retry attempts on transient failure
+//
+// CLI flags:
+//   --dry-run                 – same as DRY_RUN=1
+//   --skip-upload             – same as SKIP_UPLOAD=1
 //
 // Optional per-slide overrides: $SLIDES_SRC/manifest.json with shape
 //   { "01": { "alt": "...", "prompt": "..." }, ... }
@@ -37,12 +42,23 @@ const ROOT = resolve(HERE, "..");
 const SLIDES_JSON = resolve(ROOT, "site/data/slides.json");
 const FALLBACK_DIR = resolve(ROOT, "site/public/images/slides");
 
-const DRY_RUN = !!process.env.DRY_RUN;
-const SKIP_UPLOAD = !!process.env.SKIP_UPLOAD;
+const argv = new Set(process.argv.slice(2));
+const DRY_RUN = !!process.env.DRY_RUN || argv.has("--dry-run");
+const SKIP_UPLOAD = !!process.env.SKIP_UPLOAD || argv.has("--skip-upload");
+const MAX_RETRIES = Math.max(1, Number(process.env.R2_MAX_RETRIES) || 3);
 const SRC = process.env.SLIDES_SRC;
 
-if (!SRC) die("SLIDES_SRC is required (absolute path to your slide source dir).");
+if (!SRC) die(envHelp("SLIDES_SRC is required (absolute path to your slide source dir)."));
 if (!existsSync(SRC)) die(`SLIDES_SRC does not exist: ${SRC}`);
+
+// Fail fast on missing R2 creds for a real run, with a clear message that
+// names exactly which vars are missing — we don't want a cryptic AWS SDK
+// error 200ms into the upload loop.
+if (!DRY_RUN && !SKIP_UPLOAD) {
+  const need = ["R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY", "R2_BUCKET", "R2_PUBLIC_BASE"];
+  const missing = need.filter((k) => !process.env[k]);
+  if (missing.length) die(envHelp(`missing R2 env: ${missing.join(", ")}`));
+}
 
 if (!existsSync(SLIDES_JSON)) {
   die("site/data/slides.json not found — run `node scripts/build-quotes.mjs` first.");
@@ -148,14 +164,9 @@ async function loadManifest(dir) {
 
 async function initR2() {
   if (DRY_RUN || SKIP_UPLOAD) return null;
-  const need = ["R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY", "R2_BUCKET", "R2_PUBLIC_BASE"];
-  const missing = need.filter((k) => !process.env[k]);
-  if (missing.length) {
-    console.warn(`  ! R2 env missing (${missing.join(", ")}) — skipping upload`);
-    return null;
-  }
+  // Required-env check happens up-front; if we got here, all five are set.
   const sdk = await tryImport("@aws-sdk/client-s3");
-  if (!sdk) die("missing dep: install @aws-sdk/client-s3.");
+  if (!sdk) die("missing dep: install @aws-sdk/client-s3 (run `npm install`).");
   const { S3Client, PutObjectCommand } = sdk;
   const client = new S3Client({
     region: "auto",
@@ -167,14 +178,27 @@ async function initR2() {
   });
   return {
     async put(key, body, contentType) {
-      await client.send(
-        new PutObjectCommand({
-          Bucket: process.env.R2_BUCKET,
-          Key: key,
-          Body: body,
-          ContentType: contentType,
-        })
-      );
+      let lastErr;
+      for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        try {
+          await client.send(
+            new PutObjectCommand({
+              Bucket: process.env.R2_BUCKET,
+              Key: key,
+              Body: body,
+              ContentType: contentType,
+            })
+          );
+          return;
+        } catch (err) {
+          lastErr = err;
+          if (attempt === MAX_RETRIES) break;
+          const delay = 500 * 2 ** (attempt - 1);
+          console.warn(`  ! upload ${key} failed (attempt ${attempt}/${MAX_RETRIES}): ${err.message} — retrying in ${delay}ms`);
+          await new Promise((r) => setTimeout(r, delay));
+        }
+      }
+      throw new Error(`upload failed for ${key} after ${MAX_RETRIES} attempts: ${lastErr?.message}`);
     },
   };
 }
@@ -207,4 +231,21 @@ function rel(p) {
 function die(msg) {
   console.error(msg);
   process.exit(1);
+}
+
+function envHelp(headline) {
+  return [
+    headline,
+    "",
+    "Required env (see .env.example and scripts/README.md):",
+    "  SLIDES_SRC            absolute path to local slide images",
+    "  R2_ACCOUNT_ID         Cloudflare account id",
+    "  R2_ACCESS_KEY_ID      R2 token",
+    "  R2_SECRET_ACCESS_KEY  R2 token",
+    "  R2_BUCKET             e.g. punkrockai-slides",
+    "  R2_PUBLIC_BASE        public URL prefix (e.g. https://pub-xxx.r2.dev)",
+    "",
+    "To preview without creds:  node scripts/ingest-slides.mjs --dry-run",
+    "To skip just the upload:   node scripts/ingest-slides.mjs --skip-upload",
+  ].join("\n");
 }


### PR DESCRIPTION
Refs #56

Added --dry-run / --skip-upload flags, fail-fast env validation with help block, exponential-backoff retry around PutObject. .env.example + scripts/README.md document the full flow. Kept R2_PUBLIC_BASE name (existing) rather than R2_PUBLIC_URL (issue body) to avoid breaking rename.

To finish: real R2 creds in .env, populated $SLIDES_SRC with 22 slide images, Public Access on bucket (or custom domain), `npm install` then `node scripts/ingest-slides.mjs`.

Review repair scope note: This PR ships the R2 ingest hardening scaffold. Live R2 ingest, committed generated slide assets, /talk verification, and public URL/CORS verification remain follow-up scope.
