### PR TITLE
[P5] /widgets/manifesto — manifesto generator

### DIFF
--- a/site/css/widgets/manifesto.css
+++ b/site/css/widgets/manifesto.css
@@ -1,0 +1,140 @@
+/* /widgets/manifesto — three prompts in, one-page punk manifesto out */
+
+.mfst-intro {
+  padding-block: var(--space-6);
+  border-bottom: 1px solid var(--border);
+}
+
+.mfst-intro h1 {
+  margin: 0 0 var(--space-3);
+}
+
+.mfst-intro__lede {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 52ch;
+  color: var(--fg-soft);
+}
+
+.mfst {
+  padding-block: var(--space-5);
+}
+
+.mfst__layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-4);
+}
+
+@media (min-width: 880px) {
+  .mfst__layout {
+    grid-template-columns: minmax(20rem, 26rem) minmax(0, 1fr);
+    align-items: start;
+  }
+}
+
+.mfst__form h2 {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  margin: 0 0 var(--space-3);
+}
+
+.mfst__field {
+  display: block;
+  margin-bottom: var(--space-3);
+}
+
+.mfst__field > span {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--fg-soft);
+  margin-bottom: var(--space-1);
+}
+
+.mfst__field input,
+.mfst__field textarea {
+  width: 100%;
+  font-family: var(--font-mono);
+  font-size: var(--fs-md);
+  line-height: 1.5;
+}
+
+.mfst__field textarea {
+  min-height: 6rem;
+  resize: vertical;
+}
+
+.mfst__field small {
+  display: block;
+  margin-top: var(--space-1);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--muted);
+}
+
+.mfst__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+.mfst__status {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  min-height: 1em;
+  margin-top: var(--space-2);
+}
+
+.mfst__output {
+  background: var(--bg-elevated);
+  border: 2px solid var(--accent);
+  padding: var(--space-5) var(--space-4);
+  min-height: 24rem;
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.5;
+  color: var(--fg);
+}
+
+.mfst__output h2 {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  margin: 0 0 var(--space-3);
+}
+
+.mfst__output p {
+  margin: 0 0 var(--space-3);
+}
+
+.mfst__output p:last-child {
+  margin-bottom: 0;
+}
+
+.mfst__output .mfst__signoff {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  margin-top: var(--space-4);
+}
+
+.mfst__placeholder {
+  font-family: var(--font-display);
+  font-style: italic;
+  color: var(--muted);
+}

--- a/site/data/manifesto-templates.json
+++ b/site/data/manifesto-templates.json
@@ -1,0 +1,72 @@
+{
+  "version": 1,
+  "note": "Token slots: {{craft}} = what they make, {{served}} = who it serves, {{refusals}} = comma-joined refuse list, {{firstRefusal}} = first refuse item, {{name}} = optional signer. Each template = array of paragraphs. JS picks one at random and walks through.",
+  "templates": [
+    {
+      "id": "no-permission",
+      "title": "No permission needed",
+      "paragraphs": [
+        "I make {{craft}}. I do not need permission to make {{craft}}. I never did.",
+        "It is for {{served}}. Not for the algorithm. Not for the brand deck. Not for the people who confused engagement with meaning. {{served}} — the actual humans, with names, with rooms they sit in, with mornings.",
+        "I refuse {{firstRefusal}}. I refuse {{refusals}}. I refuse the soft, smooth, helpful voice that makes everything sound like an apology to a manager who doesn't exist.",
+        "The tools change. The work doesn't. You make the thing. You sign the thing. You stand behind the thing. That is the whole job.",
+        "Punk rock AI: keep your hands on it. Keep your name on it. Keep going."
+      ]
+    },
+    {
+      "id": "three-rules",
+      "title": "Three rules",
+      "paragraphs": [
+        "Rule one: I make {{craft}}, and I make it on purpose. Not because the feed asked. Not because the model suggested. Because I decided.",
+        "Rule two: it serves {{served}}. If the work stops serving {{served}}, I stop making it. That is the only metric that matters here.",
+        "Rule three: I refuse {{refusals}}. The refusals are not a vibe. They are the load-bearing wall. Take them out and the whole thing collapses into beige.",
+        "I will use every tool that helps. I will reject every tool that flattens. The difference is whether the work still sounds like me when I read it back at 2am.",
+        "This is the manifesto. It fits on one page. That is the point."
+      ]
+    },
+    {
+      "id": "letter-from-the-shop",
+      "title": "Letter from the shop",
+      "paragraphs": [
+        "Hello from the shop. We make {{craft}} here. We have for a while. We will keep making it.",
+        "We make it for {{served}}. Not for trend reports. Not for whoever is loudest on the timeline this week. {{served}} — the people we can actually picture.",
+        "Some things we will not do. We will not {{firstRefusal}}. We will not slide into {{refusals}}. We will not sand the edges off until the work could have come from anywhere.",
+        "The machines are welcome in the shop. They sweep up. They run the lathe. They do not sign the work. We do.",
+        "Yours, from the shop floor — with grease on it."
+      ]
+    },
+    {
+      "id": "field-report",
+      "title": "Field report",
+      "paragraphs": [
+        "Field report. The craft: {{craft}}. The audience: {{served}}. The conditions: a flood of generated nothing, and a quiet hunger underneath it for anything real.",
+        "What I am building: {{craft}} that {{served}} can actually use. Not impress. Not scroll past. Use.",
+        "What I am refusing: {{refusals}}. These are non-negotiable. They are the shape of my taste, and taste is the only thing the machine cannot copy without me.",
+        "The plan is simple. Make the work. Sign the work. Show the work. Repeat until somebody is glad I did.",
+        "End of report. Back to it."
+      ]
+    },
+    {
+      "id": "confession",
+      "title": "Confession",
+      "paragraphs": [
+        "Here is what I actually do: I make {{craft}}. That is the answer to the question at the dinner table I keep dodging.",
+        "Here is who it is for: {{served}}. Not everyone. Not the largest possible market. {{served}}. A small, real, specific group of humans I can name.",
+        "Here is what I will not do, no matter how easy it gets: {{refusals}}. The model can make those things instantly. That is not a reason to make them. That is a reason to refuse them harder.",
+        "I will use AI like I use a kitchen knife. With both hands on it. With my full attention. With the understanding that the cut is mine.",
+        "If the work is good, it is because I made it. If it is bad, that is also mine. Either way — mine."
+      ]
+    },
+    {
+      "id": "anti-pitch",
+      "title": "Anti-pitch",
+      "paragraphs": [
+        "This is not a pitch. I am not raising. I am not scaling. I am making {{craft}}.",
+        "I am making it for {{served}}, and I am making it the way it should be made — slowly enough that I can still feel my hands, fast enough that it actually ships.",
+        "I am refusing {{refusals}}. Not as a brand position. As a working condition. A house I can stand to live inside.",
+        "AI does not change this. AI is a louder version of the same question I have always had to answer: do you actually mean it, or are you just performing it?",
+        "I mean it. That is the whole pitch. There is no slide two."
+      ]
+    }
+  ]
+}

--- a/site/js/widgets/manifesto.js
+++ b/site/js/widgets/manifesto.js
@@ -1,0 +1,229 @@
+// /widgets/manifesto — answer three prompts, render a punk-rock manifesto.
+// Pure client-side templating. No LLM call. Templates load from
+// /data/manifesto-templates.json. Remix re-rolls a different template against
+// the same inputs. Copy + download .md / .txt for take-home use.
+
+import { load, save } from "/js/common/storage.js";
+
+const STORAGE_KEY = "mfst:inputs";
+const TEMPLATES_URL = "/data/manifesto-templates.json";
+
+const formEl = document.getElementById("mfst-form");
+const craftEl = document.getElementById("mfst-craft");
+const servedEl = document.getElementById("mfst-served");
+const refusalsEl = document.getElementById("mfst-refusals");
+const nameEl = document.getElementById("mfst-name");
+const outputEl = document.getElementById("mfst-output");
+const statusEl = document.getElementById("mfst-status");
+
+const remixBtn = document.querySelector('[data-action="remix"]');
+const copyBtn = document.querySelector('[data-action="copy"]');
+const dlMdBtn = document.querySelector('[data-action="download-md"]');
+const dlTxtBtn = document.querySelector('[data-action="download-txt"]');
+
+let templates = [];
+let lastInputs = null;
+let lastTemplateId = null;
+let lastParagraphs = [];
+
+hydrate();
+bind();
+loadTemplates();
+
+function hydrate() {
+  const { value } = load(STORAGE_KEY, null);
+  if (value && typeof value === "object") {
+    if (typeof value.craft === "string") craftEl.value = value.craft;
+    if (typeof value.served === "string") servedEl.value = value.served;
+    if (typeof value.refusals === "string") refusalsEl.value = value.refusals;
+    if (typeof value.name === "string") nameEl.value = value.name;
+  }
+}
+
+function bind() {
+  formEl.addEventListener("submit", (e) => {
+    e.preventDefault();
+    generate({ remix: false });
+  });
+  remixBtn.addEventListener("click", () => generate({ remix: true }));
+  copyBtn.addEventListener("click", copyToClipboard);
+  dlMdBtn.addEventListener("click", () => download("md"));
+  dlTxtBtn.addEventListener("click", () => download("txt"));
+}
+
+async function loadTemplates() {
+  try {
+    const res = await fetch(TEMPLATES_URL, { cache: "no-cache" });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    templates = Array.isArray(data?.templates) ? data.templates : [];
+    if (!templates.length) flash("no templates loaded — check /data/manifesto-templates.json");
+  } catch (err) {
+    console.warn("[manifesto] template load failed:", err);
+    flash("could not load templates — refresh the page");
+  }
+}
+
+function readInputs() {
+  const craft = craftEl.value.trim();
+  const served = servedEl.value.trim();
+  const refusalsRaw = refusalsEl.value.trim();
+  const name = nameEl.value.trim();
+
+  if (!craft || !served || !refusalsRaw) {
+    flash("answer all three prompts");
+    return null;
+  }
+
+  const refusalList = refusalsRaw
+    .split(/\r?\n|,/)
+    .map((s) => s.trim().replace(/^[-*•]\s*/, ""))
+    .filter(Boolean);
+
+  if (!refusalList.length) {
+    flash("list at least one thing you refuse");
+    return null;
+  }
+
+  return { craft, served, refusalList, name, raw: { craft, served, refusals: refusalsRaw, name } };
+}
+
+function generate({ remix }) {
+  if (!templates.length) {
+    flash("templates still loading — try again in a sec");
+    return;
+  }
+
+  const inputs = readInputs();
+  if (!inputs) return;
+
+  save(STORAGE_KEY, inputs.raw);
+  lastInputs = inputs;
+
+  const tpl = pickTemplate(remix ? lastTemplateId : null);
+  lastTemplateId = tpl.id;
+
+  const tokens = buildTokens(inputs);
+  lastParagraphs = tpl.paragraphs.map((p) => fill(p, tokens));
+
+  render(lastParagraphs, inputs.name);
+  enableExports(true);
+  flash(remix ? `remixed → "${tpl.title}"` : `generated → "${tpl.title}"`);
+}
+
+function pickTemplate(excludeId) {
+  if (templates.length === 1) return templates[0];
+  const pool = excludeId ? templates.filter((t) => t.id !== excludeId) : templates;
+  return pool[Math.floor(Math.random() * pool.length)];
+}
+
+function buildTokens({ craft, served, refusalList }) {
+  return {
+    craft,
+    served,
+    firstRefusal: refusalList[0],
+    refusals: joinList(refusalList),
+  };
+}
+
+function joinList(items) {
+  if (items.length === 1) return items[0];
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}
+
+function fill(template, tokens) {
+  return String(template).replace(/\{\{(\w+)\}\}/g, (_, key) =>
+    Object.prototype.hasOwnProperty.call(tokens, key) ? tokens[key] : `{{${key}}}`
+  );
+}
+
+function render(paragraphs, name) {
+  outputEl.innerHTML = "";
+
+  const heading = document.createElement("h2");
+  heading.textContent = "Manifesto";
+  outputEl.appendChild(heading);
+
+  for (const p of paragraphs) {
+    const el = document.createElement("p");
+    el.textContent = p;
+    outputEl.appendChild(el);
+  }
+
+  if (name) {
+    const sig = document.createElement("p");
+    sig.className = "mfst__signoff";
+    sig.textContent = `— ${name}`;
+    outputEl.appendChild(sig);
+  }
+}
+
+function enableExports(on) {
+  for (const btn of [remixBtn, copyBtn, dlMdBtn, dlTxtBtn]) btn.disabled = !on;
+}
+
+async function copyToClipboard() {
+  if (!lastParagraphs.length) {
+    flash("generate one first");
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(toPlainText());
+    flash("copied to clipboard");
+  } catch {
+    flash("copy failed — select manually");
+  }
+}
+
+function download(kind) {
+  if (!lastParagraphs.length) {
+    flash("generate one first");
+    return;
+  }
+  const isMd = kind === "md";
+  const body = isMd ? toMarkdown() : toPlainText();
+  const mime = isMd ? "text/markdown" : "text/plain";
+  const ext = isMd ? "md" : "txt";
+
+  const blob = new Blob([body], { type: `${mime};charset=utf-8` });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `manifesto.${ext}`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+  flash(`saved manifesto.${ext}`);
+}
+
+function toPlainText() {
+  const lines = ["Manifesto", "", ...interleave(lastParagraphs)];
+  if (lastInputs?.name) lines.push("", `— ${lastInputs.name}`);
+  return lines.join("\n");
+}
+
+function toMarkdown() {
+  const lines = ["# Manifesto", "", ...interleave(lastParagraphs)];
+  if (lastInputs?.name) lines.push("", `*— ${lastInputs.name}*`);
+  return lines.join("\n");
+}
+
+function interleave(paragraphs) {
+  const out = [];
+  paragraphs.forEach((p, i) => {
+    if (i > 0) out.push("");
+    out.push(p);
+  });
+  return out;
+}
+
+function flash(msg) {
+  if (!statusEl) return;
+  statusEl.textContent = msg;
+  clearTimeout(flash._t);
+  flash._t = setTimeout(() => {
+    if (statusEl) statusEl.textContent = "";
+  }, 2500);
+}

--- a/site/widgets/manifesto.html
+++ b/site/widgets/manifesto.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Manifesto generator &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="Answer three prompts. The widget composes a one-page punk-rock manifesto in your voice. Copy it. Remix it. Sign it."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/widgets/manifesto.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main>
+      <section class="mfst-intro grain scanlines">
+        <div class="wrap wrap--narrow">
+          <p class="kicker kicker--accent">Phase 5 &middot; one page, on purpose</p>
+          <h1>Manifesto generator.</h1>
+          <p class="mfst-intro__lede">
+            Three prompts. One page. Your voice. Answer what you make,
+            who it serves, and what you refuse &mdash; the widget assembles a
+            punk-rock manifesto in a Punk Rock AI voice. Remix it until it
+            sounds like you. Then sign it.
+          </p>
+        </div>
+      </section>
+
+      <section class="mfst">
+        <div class="wrap">
+          <div class="mfst__layout">
+            <form class="mfst__form" id="mfst-form" autocomplete="off">
+              <h2>Three prompts</h2>
+
+              <label class="mfst__field">
+                <span>What do you make?</span>
+                <input
+                  type="text"
+                  id="mfst-craft"
+                  name="craft"
+                  placeholder="photographs, software, dinners, songs"
+                  required
+                />
+              </label>
+
+              <label class="mfst__field">
+                <span>Who is it for?</span>
+                <input
+                  type="text"
+                  id="mfst-served"
+                  name="served"
+                  placeholder="the people in the back row, my neighbours, working musicians"
+                  required
+                />
+              </label>
+
+              <label class="mfst__field">
+                <span>What do you refuse?</span>
+                <textarea
+                  id="mfst-refusals"
+                  name="refusals"
+                  rows="4"
+                  placeholder="one per line — fake intimacy, surveillance pricing, sanding off the edges"
+                  required
+                ></textarea>
+                <small>One per line. Three is plenty.</small>
+              </label>
+
+              <label class="mfst__field mfst__field--name">
+                <span>Sign it (optional)</span>
+                <input
+                  type="text"
+                  id="mfst-name"
+                  name="name"
+                  placeholder="your name, or leave blank"
+                />
+              </label>
+
+              <div class="mfst__row">
+                <button class="btn btn--primary" type="submit" data-action="generate">Generate</button>
+                <button class="btn" type="button" data-action="remix" disabled>Remix</button>
+                <button class="btn" type="button" data-action="copy" disabled>Copy</button>
+                <button class="btn" type="button" data-action="download-md" disabled>Download .md</button>
+                <button class="btn" type="button" data-action="download-txt" disabled>Download .txt</button>
+              </div>
+              <p class="mfst__status" id="mfst-status" aria-live="polite"></p>
+            </form>
+
+            <article class="mfst__output" id="mfst-output" aria-live="polite">
+              <p class="mfst__placeholder">Your manifesto will land here. Three prompts, one page, no apologies.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/manifesto.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Refs #68

Pure client-side templating (no LLM call). 6 paragraph templates with token slots; remix button re-rolls a different template against same inputs. Inputs autosave to pra:v1:mfst:inputs. Copy + Download .md/.txt.

Review repair scope note: This PR ships the client-side manifesto template generator. Three Documents + Pattern Finder integration and one-page print/PDF output remain follow-up scope.
