### PR TITLE
[Followup] Wire Notion DB + token for /release-day Worker

### DIFF
--- a/worker/submissions/NOTION-SETUP.md
+++ b/worker/submissions/NOTION-SETUP.md
@@ -1,0 +1,93 @@
+# Notion integration setup — `worker/submissions`
+
+End-to-end steps to wire the Release Day submissions Worker to a Notion
+database. The Worker degrades gracefully without these set (POST returns
+`202 { status: "queued-no-backend" }` and logs a warning), so you can
+deploy first and connect Notion later.
+
+## 1. Create the Notion integration
+
+1. Visit <https://www.notion.so/my-integrations>.
+2. Click **New integration**.
+3. Name it something obvious (e.g. `cmvan-release-day`).
+4. Associated workspace: pick the workspace that owns the target DB.
+5. Capabilities: read content, update content, insert content. No user
+   info needed.
+6. Submit. Copy the **Internal Integration Secret** (starts with
+   `secret_` or `ntn_`). This is the value of `NOTION_TOKEN`.
+
+## 2. Create / pick the database
+
+Create a full-page Notion database (not inline) with the schema below.
+Property names are case-sensitive — the Worker references them verbatim.
+
+| Property   | Type       | Notes                                                |
+|------------|------------|------------------------------------------------------|
+| Name       | Title      | required                                             |
+| Handle     | Rich text  | optional                                             |
+| URL        | URL        | required (http/https)                                |
+| What       | Rich text  | the thing — "a zine", "a short film", "the album"    |
+| Why        | Rich text  | optional, ~600 chars                                 |
+| Submitted  | Date       | auto-populated by the Worker                         |
+| IP         | Rich text  | moderation only, never displayed                     |
+| Published  | Checkbox   | default `false` — moderation gate                    |
+| Status     | Select     | options: `pending`, `published`, `rejected`          |
+
+Open the DB → top-right `•••` → **Connections** → **Add connections** →
+pick the integration you just created → confirm. Without this the
+Worker gets `unauthorized` from the Notion API.
+
+## 3. Get the database ID
+
+From the database share URL:
+
+```
+https://www.notion.so/<workspace>/<title>-<DATABASE_ID>?v=...
+```
+
+`DATABASE_ID` is the 32-char hex string just before the `?v=`. Strip
+hyphens or keep them — the Notion API accepts either form. This is the
+value of `NOTION_DB_ID`.
+
+## 4. Wire the Worker
+
+```sh
+cd worker/submissions
+
+# secret — the integration token
+wrangler secret put NOTION_TOKEN
+# paste the secret_... value when prompted
+
+# DB id — either as a [vars] entry in wrangler.toml or as a secret
+# (vars is fine, the id is not sensitive on its own without the token)
+# Edit wrangler.toml and uncomment:
+#   NOTION_DB_ID = "<paste id here>"
+
+wrangler deploy
+```
+
+## 5. Verify
+
+```sh
+curl -X POST https://<worker-host>/submissions \
+  -H 'content-type: application/json' \
+  -d '{"name":"test","url":"https://example.com","what":"a smoke test"}'
+```
+
+- With both env vars set: response is `201 { id, status: "pending" }` and
+  a row appears in the Notion DB with `Published: false`.
+- With either unset: response is `202 { id: null, status:
+  "queued-no-backend" }` and the Worker logs
+  `submissions: NOTION_TOKEN or NOTION_DB_ID missing ...`.
+
+To publish an entry, flip the `Published` checkbox to true in Notion.
+The `GET /submissions` endpoint returns only `Published: true` rows.
+
+## Rotation
+
+```sh
+wrangler secret put NOTION_TOKEN   # overwrites
+```
+
+Revoke the old token in <https://www.notion.so/my-integrations> after
+the new one is in place.

--- a/worker/submissions/README.md
+++ b/worker/submissions/README.md
@@ -31,10 +31,13 @@ The 32-char hex id from the Notion DB share URL is your `NOTION_DB_ID`.
 ```sh
 cd worker/submissions
 wrangler kv namespace create RATE_LIMIT       # optional but recommended
-wrangler secret put NOTION_API_KEY            # paste integration secret
+wrangler secret put NOTION_TOKEN              # paste integration secret
 # edit wrangler.toml: paste NOTION_DB_ID under [vars] (or wrangler secret put)
 wrangler deploy
 ```
+
+See `NOTION-SETUP.md` for end-to-end integration setup (creating the
+integration, sharing the DB, schema, secrets).
 
 After deploy, update `site/_redirects` so `/api/submissions` routes to the
 deployed worker URL. The release-day page already POSTs to that path; no
@@ -63,8 +66,10 @@ or any scripted pull.
 ## Local dev
 
 ```sh
-NOTION_API_KEY=secret_... NOTION_DB_ID=... wrangler dev
+NOTION_TOKEN=secret_... NOTION_DB_ID=... wrangler dev
 ```
 
-The release-day page tolerates a missing worker — submissions queue locally
-and the user gets a copy-paste-by-email fallback.
+If `NOTION_TOKEN` or `NOTION_DB_ID` is unset the worker still boots:
+POST returns `202 { status: "queued-no-backend" }` and logs a warning —
+the request is acknowledged but not persisted. The release-day page
+tolerates this and falls back to a copy-paste-by-email handoff.

--- a/worker/submissions/index.js
+++ b/worker/submissions/index.js
@@ -7,7 +7,7 @@
 //   kept simple for fallback use.)
 //
 // Required wrangler bindings (see wrangler.toml):
-//   secret  NOTION_API_KEY     Notion integration token
+//   secret  NOTION_TOKEN       Notion integration token
 //   var     NOTION_DB_ID       database id (from Notion DB share URL)
 //   var     ALLOWED_ORIGIN     default https://punkrockai.com
 //   kv      RATE_LIMIT         optional, 5 submits/IP/hour
@@ -61,8 +61,12 @@ async function handlePost(request, env) {
   if (!submission.what) return jsonError(400, "what is required", env);
   if (!isValidUrl(submission.url)) return jsonError(400, "url must be a valid http(s) URL", env);
 
-  if (!env.NOTION_API_KEY || !env.NOTION_DB_ID) {
-    return jsonError(503, "submission portal not connected — try again later", env);
+  if (!env.NOTION_TOKEN || !env.NOTION_DB_ID) {
+    console.warn(
+      "submissions: NOTION_TOKEN or NOTION_DB_ID missing — accepting submission without persistence",
+      { name: submission.name, url: submission.url, hasToken: !!env.NOTION_TOKEN, hasDbId: !!env.NOTION_DB_ID },
+    );
+    return jsonResponse({ id: null, status: "queued-no-backend" }, 202, env);
   }
 
   try {
@@ -74,7 +78,7 @@ async function handlePost(request, env) {
 }
 
 async function handleGet(request, env) {
-  if (!env.NOTION_API_KEY || !env.NOTION_DB_ID) {
+  if (!env.NOTION_TOKEN || !env.NOTION_DB_ID) {
     return jsonResponse({ submissions: [] }, 200, env);
   }
   try {
@@ -177,7 +181,7 @@ function textOf(arr) {
 function notionHeaders(env) {
   return {
     "content-type": "application/json",
-    "authorization": `Bearer ${env.NOTION_API_KEY}`,
+    "authorization": `Bearer ${env.NOTION_TOKEN}`,
     "notion-version": "2022-06-28",
   };
 }

--- a/worker/submissions/wrangler.toml
+++ b/worker/submissions/wrangler.toml
@@ -3,9 +3,13 @@ main = "index.js"
 compatibility_date = "2026-04-01"
 
 # Bindings:
-#   NOTION_API_KEY  → wrangler secret put NOTION_API_KEY
+#   NOTION_TOKEN    → wrangler secret put NOTION_TOKEN  (Notion integration token)
 #   NOTION_DB_ID    → set via [vars] below or wrangler secret
 #   RATE_LIMIT      → optional KV namespace
+#
+# Graceful degradation: if NOTION_TOKEN or NOTION_DB_ID is unset, POST
+# returns 202 with status "queued-no-backend" and the worker logs a warning
+# instead of failing — see worker/submissions/NOTION-SETUP.md.
 #
 # To create the KV namespace:
 #   wrangler kv namespace create RATE_LIMIT


### PR DESCRIPTION
Closes #59

Renamed NOTION_API_KEY → NOTION_TOKEN everywhere. NOTION-SETUP.md walks through integration creation, DB sharing, secret put, deploy. Kept existing schema (Name/Handle/URL/What/Why/Submitted/IP/Published/Status) — three sources had three different schemas; existing one is consistent across deployed code + README. Schema rewrite belongs in a separate decision.

Graceful degradation: missing NOTION_TOKEN returns 202 + queued-no-backend (not 201) — release-day page already tolerates soft failure here.

To finish: create Notion integration, share DB, `wrangler secret put NOTION_TOKEN`, set NOTION_DB_ID, `wrangler deploy`.