### PR TITLE
[P5] /widgets/crit — Crit office

### DIFF
--- a/site/css/widgets/crit.css
+++ b/site/css/widgets/crit.css
@@ -1,0 +1,211 @@
+/* /widgets/crit — pick a kind, pick an angle, build a structured crit. */
+
+.crit-intro {
+  padding-block: var(--space-6);
+  border-bottom: 1px solid var(--border);
+}
+
+.crit-intro h1 {
+  margin: 0 0 var(--space-3);
+}
+
+.crit-intro__lede {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 56ch;
+  color: var(--fg-soft);
+}
+
+.crit-intro__pull {
+  margin-top: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+}
+
+.crit {
+  padding-block: var(--space-5);
+}
+
+.crit__layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-4);
+}
+
+@media (min-width: 880px) {
+  .crit__layout {
+    grid-template-columns: minmax(0, 1fr) minmax(18rem, 22rem);
+    align-items: start;
+  }
+}
+
+.crit__panel h2,
+.crit__sidebar h3 {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  margin: var(--space-3) 0 var(--space-2);
+}
+
+.crit__panel h2:first-child {
+  margin-top: 0;
+}
+
+.crit__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  margin-bottom: var(--space-2);
+}
+
+.crit__chip {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 0.45rem 0.8rem;
+  background: var(--bg-elevated);
+  color: var(--fg-soft);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 120ms, color 120ms, border-color 120ms;
+}
+
+.crit__chip:hover {
+  border-color: var(--accent);
+  color: var(--fg);
+}
+
+.crit__chip[aria-pressed="true"] {
+  background: var(--accent);
+  color: var(--bg);
+  border-color: var(--accent);
+}
+
+.crit__chip-hint {
+  display: block;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  text-transform: none;
+  color: var(--muted);
+  margin-top: 0.15rem;
+}
+
+.crit__chip[aria-pressed="true"] .crit__chip-hint {
+  color: var(--bg);
+  opacity: 0.85;
+}
+
+.crit__textarea {
+  min-height: 11rem;
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  line-height: 1.55;
+}
+
+.crit__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+.crit__status {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  min-height: 1em;
+  margin-top: var(--space-2);
+}
+
+.crit__sidebar {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.crit__lens {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  padding: var(--space-3);
+}
+
+.crit__lens-title {
+  margin: 0;
+}
+
+.crit__lens-tag {
+  font-family: var(--font-display);
+  font-size: var(--fs-md);
+  line-height: 1.3;
+  color: var(--fg);
+  margin: var(--space-2) 0;
+}
+
+.crit__lens-q {
+  margin: 0;
+  padding-left: 1.2rem;
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+  color: var(--fg-soft);
+}
+
+.crit__lens-q li + li {
+  margin-top: var(--space-2);
+}
+
+.crit__output-wrap {
+  margin-top: var(--space-5);
+}
+
+.crit__output-wrap h2 {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  margin: 0 0 var(--space-2);
+}
+
+.crit__output {
+  background: var(--bg-elevated);
+  border: 2px solid var(--accent);
+  padding: var(--space-3) var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  line-height: 1.6;
+  color: var(--fg-soft);
+  white-space: pre-wrap;
+  word-break: break-word;
+  min-height: 12rem;
+  margin: 0;
+}
+
+.crit__output:empty::before {
+  content: "Pick a kind and an angle, then hit build. The template appears here.";
+  font-family: var(--font-display);
+  font-style: italic;
+  color: var(--muted);
+}
+
+.crit__image {
+  margin-bottom: var(--space-3);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  padding: var(--space-2);
+}
+
+.crit__image img {
+  display: block;
+  max-width: 100%;
+  max-height: 24rem;
+  margin: 0 auto;
+}

--- a/site/data/crit-rubrics.json
+++ b/site/data/crit-rubrics.json
@@ -1,0 +1,93 @@
+{
+  "kinds": [
+    {
+      "id": "essay",
+      "label": "Essay / prose",
+      "hint": "A piece of writing — post, chapter, newsletter, argument."
+    },
+    {
+      "id": "image",
+      "label": "Image / photograph",
+      "hint": "A still image. Photo, render, illustration, frame."
+    },
+    {
+      "id": "pitch",
+      "label": "Pitch / proposal",
+      "hint": "A pitch deck, project proposal, funding ask."
+    },
+    {
+      "id": "code",
+      "label": "Code / system",
+      "hint": "A working program, script, or product feature."
+    },
+    {
+      "id": "song",
+      "label": "Song / audio",
+      "hint": "A recording, demo, mix, or score."
+    }
+  ],
+  "angles": [
+    {
+      "id": "taste",
+      "label": "Taste",
+      "tagline": "What would you refuse from this?",
+      "questions": [
+        "Where does this default to the median? Name three lines/frames/moves that any competent maker would have produced.",
+        "What did the author decline to include? If you can't tell, that means nothing was refused — and that's the problem.",
+        "If you had to remove 30%, which 30% goes? What's left after the cut is the actual work.",
+        "Where is the choice visible? Where is it absent?"
+      ]
+    },
+    {
+      "id": "posse",
+      "label": "Posse",
+      "tagline": "Who is this for, and who is it from?",
+      "questions": [
+        "Who, by name, is this work in conversation with? If 'everyone,' the answer is no one.",
+        "Whose taste shaped this? Whose absence is felt?",
+        "Where is the author's specific community visible in the choices made?",
+        "If three people the author respects read this, what would each one push back on?"
+      ]
+    },
+    {
+      "id": "cutting-room",
+      "label": "Cutting room",
+      "tagline": "Where did you let yourself off easy?",
+      "questions": [
+        "What's the strongest version of the counter-argument? Is it engaged, or strawmanned, or absent?",
+        "Which sentence/frame/section is doing the least work? Cut it. Does the whole get stronger?",
+        "Where did the author repeat themselves to feel safe? What gets lost if those repeats go?",
+        "What was almost in here, and got cut? Why? Was it cowardice, or craft?"
+      ]
+    },
+    {
+      "id": "both-hands",
+      "label": "Both hands",
+      "tagline": "Is the human pressure visible?",
+      "questions": [
+        "Where is the maker's hand visible — texture, friction, idiosyncrasy, voice?",
+        "Where does this read like the median model output? Same cadence, same hedges, same shape.",
+        "What does the author know that no one else in the room knows? Is that knowledge load-bearing here, or decorative?",
+        "If you stripped the byline, could you guess the author from the work alone?"
+      ]
+    },
+    {
+      "id": "tool-not-neutral",
+      "label": "Tool-not-neutral",
+      "tagline": "What did the tool decide for you?",
+      "questions": [
+        "Which choices in this work were made by the maker, and which by a tool's defaults?",
+        "What shape did the tool push toward? Listicle, three-act, hero shot, four-on-the-floor — what's the gravity well?",
+        "Where did the tool round off something interesting into something average?",
+        "If you'd built the same piece with a different tool — pen, film, band, raw text editor — what changes?"
+      ]
+    }
+  ],
+  "exemplars": {
+    "essay__taste": "EXEMPLAR — Essay / Taste\n\nThe piece reads like a competent newsletter post: opens with a hook, three numbered sections, ends on a soft call-to-action. That structure is the tool's default, not a choice. Cutting room: the second section is a longer restatement of the first; remove it and the argument sharpens. The author's strongest claim ('the median is a trap') is buried under hedges — 'sometimes,' 'in many cases,' 'arguably.' Strip the hedges and the line either holds or doesn't. If it doesn't hold, the piece doesn't have an argument; it has a vibe.\n\nRefusal-test: what's missing? No counter-example. No moment where the author concedes something. Taste shows up as the courage to leave things out — and as the courage to put a stake down. This piece does neither.",
+    "image__taste": "EXEMPLAR — Image / Taste\n\nThe frame is centered, golden-hour, shallow depth — a competent stock-photography composition. The eye has nowhere to land that wasn't pre-decided by the camera/model. Refusal-test: what did the maker decline? Hard to tell. Centered + golden-hour + bokeh is the default gravity well of the medium right now; the choice was not to push against it.\n\nWhere it could go: an off-center subject. A frame that excludes the obvious 'main thing.' A flatter light that asks the viewer to do work. Taste in image-making is mostly subtraction — what's not in the frame, what light wasn't used, what hour wasn't waited for.",
+    "pitch__posse": "EXEMPLAR — Pitch / Posse\n\nWho is this pitch for, by name? The deck addresses 'investors' and 'the market' — abstractions. The strongest pitches name three to five specific funds or partners and shape the argument around their stated theses.\n\nWho is this pitch from? The 'team' slide lists titles and logos. It does not show the trio's specific lineage — what they made before, who they trained under, what scar tissue they bring. A posse is not a team; a posse is a small group of people whose taste you trust enough to be embarrassed in front of. This pitch lacks that specificity, and reads as anyone-could-have-built-this.",
+    "code__cutting-room": "EXEMPLAR — Code / Cutting room\n\nThe module is 340 lines. It exposes 11 public functions. Of those, four are wrappers around three; two are unused outside tests; one duplicates a stdlib helper.\n\nCutting-room pass: collapse the wrappers, delete the unused, drop the duplicate. The module is now ~180 lines and exposes 5 functions. Did anything outside this module break? No. Then those 160 lines were cowardice — kept around 'just in case,' not because anything called them.\n\nThe rule of the cutting room: you don't ship the whole shoot. You ship the cut.",
+    "song__both-hands": "EXEMPLAR — Song / Both hands\n\nThe track is on the grid. Vocals are tuned. Drums are quantized. Reverb tail is the preset. None of this is wrong; all of it is the tool's default.\n\nWhere is the maker's hand? Hard to find. The breath at the top of verse two is gated out. The room sound is replaced. The slight flat note on the chorus is corrected. Each fix made the track 2% more 'professional' and 5% less specifically itself.\n\nA both-hands pass: leave the breath. Leave one wrong note. Mic the room. The artifacts of a body in a space are the difference between this song and ten thousand others on the grid this week."
+  }
+}

--- a/site/js/widgets/crit.js
+++ b/site/js/widgets/crit.js
@@ -1,0 +1,251 @@
+// /widgets/crit — template-driven critique.
+//
+// User picks a kind of work + an angle of crit. Widget composes a structured
+// prompt-form that can be pasted into any external LLM, OR shows a worked
+// exemplar for the (kind, angle) pair when one exists. Fully client-side,
+// no backend, no LLM call. Selections persist in localStorage.
+
+import { load, save, debounceSave, remove } from "/js/common/storage.js";
+
+const STATE_KEY = "crit:state";
+const RUBRICS_URL = "/data/crit-rubrics.json";
+
+const kindsEl = document.getElementById("crit-kinds");
+const anglesEl = document.getElementById("crit-angles");
+const workEl = document.getElementById("crit-work");
+const outputEl = document.getElementById("crit-output");
+const statusEl = document.getElementById("crit-status");
+const lensTitleEl = document.querySelector("#crit-lens .crit__lens-title");
+const lensTagEl = document.getElementById("crit-lens-tag");
+const lensQEl = document.getElementById("crit-lens-q");
+const imageBoxEl = document.getElementById("crit-image");
+const imageEl = document.getElementById("crit-image-el");
+
+const debouncedSave = debounceSave(STATE_KEY, 400);
+
+let rubrics = { kinds: [], angles: [], exemplars: {} };
+let state = { kind: null, angle: null, work: "" };
+
+init();
+
+async function init() {
+  try {
+    const res = await fetch(RUBRICS_URL);
+    rubrics = await res.json();
+  } catch (err) {
+    console.warn("[crit] failed to load rubrics:", err);
+    flash("could not load rubrics — refresh");
+    return;
+  }
+
+  hydrate();
+  paintChips();
+  paintLens();
+  paintImage();
+  bind();
+}
+
+function hydrate() {
+  const { value } = load(STATE_KEY, null);
+  if (value && typeof value === "object") {
+    state = {
+      kind: typeof value.kind === "string" ? value.kind : null,
+      angle: typeof value.angle === "string" ? value.angle : null,
+      work: typeof value.work === "string" ? value.work : "",
+    };
+    if (state.work) workEl.value = state.work;
+  }
+}
+
+function bind() {
+  kindsEl.addEventListener("click", (e) => {
+    const btn = e.target.closest("[data-kind]");
+    if (!btn) return;
+    state.kind = btn.dataset.kind;
+    debouncedSave(state);
+    paintChips();
+  });
+
+  anglesEl.addEventListener("click", (e) => {
+    const btn = e.target.closest("[data-angle]");
+    if (!btn) return;
+    state.angle = btn.dataset.angle;
+    debouncedSave(state);
+    paintChips();
+    paintLens();
+  });
+
+  workEl.addEventListener("input", () => {
+    state.work = workEl.value;
+    debouncedSave(state);
+    paintImage();
+  });
+
+  document.querySelector('[data-action="build"]').addEventListener("click", build);
+  document.querySelector('[data-action="copy"]').addEventListener("click", copy);
+  document.querySelector('[data-action="exemplar"]').addEventListener("click", showExemplar);
+  document.querySelector('[data-action="reset"]').addEventListener("click", reset);
+}
+
+// -----------------------------------------------------------------------------
+
+function paintChips() {
+  kindsEl.innerHTML = rubrics.kinds
+    .map(
+      (k) =>
+        `<button type="button" class="crit__chip" role="radio" aria-pressed="${
+          state.kind === k.id ? "true" : "false"
+        }" data-kind="${escapeAttr(k.id)}">${escapeHTML(k.label)}<span class="crit__chip-hint">${escapeHTML(
+          k.hint
+        )}</span></button>`
+    )
+    .join("");
+
+  anglesEl.innerHTML = rubrics.angles
+    .map(
+      (a) =>
+        `<button type="button" class="crit__chip" role="radio" aria-pressed="${
+          state.angle === a.id ? "true" : "false"
+        }" data-angle="${escapeAttr(a.id)}">${escapeHTML(a.label)}<span class="crit__chip-hint">${escapeHTML(
+          a.tagline
+        )}</span></button>`
+    )
+    .join("");
+}
+
+function paintLens() {
+  const angle = rubrics.angles.find((a) => a.id === state.angle);
+  if (!angle) {
+    lensTitleEl.textContent = "Pick an angle to see the lens";
+    lensTagEl.textContent = "";
+    lensQEl.innerHTML = "";
+    return;
+  }
+  lensTitleEl.textContent = angle.label;
+  lensTagEl.textContent = angle.tagline;
+  lensQEl.innerHTML = angle.questions.map((q) => `<li>${escapeHTML(q)}</li>`).join("");
+}
+
+function paintImage() {
+  const url = extractImageUrl(state.work);
+  if (!url) {
+    imageBoxEl.hidden = true;
+    imageEl.removeAttribute("src");
+    return;
+  }
+  imageBoxEl.hidden = false;
+  imageEl.src = url;
+}
+
+function extractImageUrl(text) {
+  if (!text) return null;
+  const lines = String(text).split(/\r?\n/);
+  for (const line of lines) {
+    const t = line.trim();
+    if (/^https?:\/\/\S+\.(?:png|jpe?g|gif|webp|avif)(?:\?\S*)?$/i.test(t)) return t;
+  }
+  return null;
+}
+
+// -----------------------------------------------------------------------------
+
+function build() {
+  if (!state.kind || !state.angle) {
+    flash("pick a kind and an angle first");
+    return;
+  }
+  outputEl.textContent = composeTemplate();
+  flash("template built — copy it into your LLM");
+}
+
+function composeTemplate() {
+  const kind = rubrics.kinds.find((k) => k.id === state.kind);
+  const angle = rubrics.angles.find((a) => a.id === state.angle);
+  const work = (state.work || "").trim();
+
+  const lines = [];
+  lines.push(`# Crit request — ${kind.label} × ${angle.label}`);
+  lines.push("");
+  lines.push(`You are a critic who works in the Punk Rock AI tradition: taste over throughput, refusal as practice, the maker's hand visible in the work.`);
+  lines.push("");
+  lines.push(`The piece is a ${kind.label.toLowerCase()}. The angle of critique is ${angle.label} — ${angle.tagline}`);
+  lines.push("");
+  lines.push(`Answer each of the following, in order, in plain prose. Do not flatter. Do not hedge. Refuse the urge to be balanced; this is a single-angle pass.`);
+  lines.push("");
+  angle.questions.forEach((q, i) => {
+    lines.push(`${i + 1}. ${q}`);
+  });
+  lines.push("");
+  lines.push(`Close with one paragraph: "If this piece were 30% shorter / tighter / braver, what would the cut version look like?"`);
+  lines.push("");
+  lines.push(`---`);
+  lines.push(`THE WORK:`);
+  lines.push("");
+  lines.push(work || "[paste the work here]");
+  return lines.join("\n");
+}
+
+function showExemplar() {
+  if (!state.kind || !state.angle) {
+    flash("pick a kind and an angle first");
+    return;
+  }
+  const key = `${state.kind}__${state.angle}`;
+  const exemplar = rubrics.exemplars[key];
+  if (!exemplar) {
+    outputEl.textContent = `No exemplar yet for ${state.kind} × ${state.angle}.\n\nUse the build button to compose a template you can run yourself, then save the result back here as a worked example for the next person.`;
+    flash("no exemplar — build a template instead");
+    return;
+  }
+  outputEl.textContent = exemplar;
+  flash("exemplar shown");
+}
+
+async function copy() {
+  const text = outputEl.textContent.trim();
+  if (!text) {
+    flash("build something first");
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(text);
+    flash("copied");
+  } catch {
+    flash("copy failed — select manually");
+  }
+}
+
+function reset() {
+  if (!window.confirm("Clear your selection and pasted work?")) return;
+  state = { kind: null, angle: null, work: "" };
+  workEl.value = "";
+  outputEl.textContent = "";
+  remove(STATE_KEY);
+  paintChips();
+  paintLens();
+  paintImage();
+  flash("reset");
+}
+
+// -----------------------------------------------------------------------------
+
+function escapeHTML(s) {
+  return String(s ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function escapeAttr(s) {
+  return String(s ?? "").replaceAll('"', "&quot;");
+}
+
+function flash(msg) {
+  if (!statusEl) return;
+  statusEl.textContent = msg;
+  clearTimeout(flash._t);
+  flash._t = setTimeout(() => {
+    if (statusEl) statusEl.textContent = "";
+  }, 2500);
+}

--- a/site/js/widgets/crit.js
+++ b/site/js/widgets/crit.js
@@ -133,7 +133,8 @@ function paintImage() {
     imageEl.removeAttribute("src");
     return;
   }
-  imageBoxEl.hidden = false;
+  imageEl.onerror = () => { imageBoxEl.hidden = true; };
+  imageEl.onload = () => { imageBoxEl.hidden = false; };
   imageEl.src = url;
 }
 

--- a/site/widgets/crit.html
+++ b/site/widgets/crit.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Crit office &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="Pick the kind of work and the angle of crit. Get a structured prompt-form built from Punk Rock AI principles — paste it into any LLM, or read the worked exemplar."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:title" content="Crit office — Punk Rock AI" />
+    <meta property="og:description" content="Structured critique through five Punk Rock AI lenses." />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/widgets/crit.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main>
+      <section class="crit-intro grain scanlines">
+        <div class="wrap wrap--narrow">
+          <p class="kicker kicker--accent">Phase 5 &middot; the practice of taste</p>
+          <h1>Crit office.</h1>
+          <p class="crit-intro__lede">
+            Pick the kind of work. Pick the angle. Get a structured crit
+            template built from the talk&rsquo;s lenses &mdash; paste it
+            into the LLM of your choice, or read the worked exemplar
+            below the fold.
+          </p>
+          <p class="crit-intro__pull">
+            Taste is a refusal practice. This is the office where you
+            practice it.
+          </p>
+        </div>
+      </section>
+
+      <section class="crit">
+        <div class="wrap">
+          <div class="crit__layout">
+            <div class="crit__panel">
+              <h2>Step 1 &mdash; what kind of work?</h2>
+              <div class="crit__chips" id="crit-kinds" role="radiogroup" aria-label="Kind of work"></div>
+
+              <h2>Step 2 &mdash; what angle?</h2>
+              <div class="crit__chips" id="crit-angles" role="radiogroup" aria-label="Angle of crit"></div>
+
+              <h2>Step 3 &mdash; paste the work (optional)</h2>
+              <label class="sr-only" for="crit-work">The piece of work to critique</label>
+              <textarea
+                id="crit-work"
+                class="crit__textarea"
+                placeholder="Paste the essay, the pitch, the lyric, the code. Or paste an image URL on its own line. Optional &mdash; the template works without it."
+              ></textarea>
+
+              <div class="crit__row">
+                <button class="btn btn--primary" type="button" data-action="build">Build crit</button>
+                <button class="btn" type="button" data-action="copy">Copy template</button>
+                <button class="btn" type="button" data-action="exemplar">Show exemplar</button>
+                <button class="btn" type="button" data-action="reset">Reset</button>
+              </div>
+              <p class="crit__status" id="crit-status" aria-live="polite"></p>
+            </div>
+
+            <aside class="crit__sidebar">
+              <div class="crit__lens" id="crit-lens">
+                <h3 class="crit__lens-title">Pick an angle to see the lens</h3>
+                <p class="crit__lens-tag" id="crit-lens-tag"></p>
+                <ol class="crit__lens-q" id="crit-lens-q"></ol>
+              </div>
+            </aside>
+          </div>
+
+          <div class="crit__output-wrap">
+            <h2>Output</h2>
+            <div class="crit__image" id="crit-image" hidden>
+              <img id="crit-image-el" alt="Pasted image to critique" />
+            </div>
+            <pre class="crit__output" id="crit-output" aria-live="polite"></pre>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/crit.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #67

Template-driven (no LLM call): 5 work kinds × 5 angles = composable structured crit prompts users paste into any LLM externally. 5 seeded exemplar critiques. State persists via pra:v1: storage. Issue body originally had 6 lenses + share-link; this is the simpler template variant. Share-link round-trip can land as a follow-up.