### PR TITLE
[P5] /widgets/action — post-talk action chooser

### DIFF
--- a/site/css/widgets/action.css
+++ b/site/css/widgets/action.css
@@ -1,0 +1,199 @@
+/* /widgets/action — five questions, one move toward Release Day */
+
+.act-intro {
+  padding-block: var(--space-6);
+  border-bottom: 1px solid var(--border);
+}
+
+.act-intro h1 {
+  margin: 0 0 var(--space-3);
+}
+
+.act-intro__lede {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 50ch;
+  color: var(--fg-soft);
+}
+
+.act {
+  padding-block: var(--space-5);
+}
+
+.act__stage {
+  display: block;
+}
+
+.act__status {
+  margin-top: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  min-height: 1.4em;
+}
+
+.act-card {
+  border: 1px solid var(--border);
+  background: var(--bg-soft, var(--bg));
+  padding: var(--space-4);
+  border-radius: 4px;
+}
+
+@media (min-width: 720px) {
+  .act-card {
+    padding: var(--space-5);
+  }
+}
+
+.act-card__meta {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--muted);
+  margin: 0 0 var(--space-2);
+}
+
+.act-card__meta--accent {
+  color: var(--accent);
+}
+
+.act-card__title {
+  font-family: var(--font-display);
+  font-size: var(--fs-xl);
+  line-height: 1.15;
+  margin: 0 0 var(--space-2);
+}
+
+.act-card__title--big {
+  font-size: var(--fs-2xl, 2.2rem);
+}
+
+.act-card__hint {
+  color: var(--fg-soft);
+  font-size: var(--fs-sm);
+  margin: 0 0 var(--space-3);
+}
+
+.act-card__rationale {
+  color: var(--fg-soft);
+  font-size: var(--fs-md);
+  line-height: 1.5;
+  margin: 0 0 var(--space-4);
+  max-width: 60ch;
+}
+
+.act-card__options {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-2);
+}
+
+@media (min-width: 720px) {
+  .act-card__options {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.act-option {
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  font-family: var(--font-display);
+  font-size: var(--fs-md);
+  line-height: 1.3;
+  color: var(--fg);
+  background: transparent;
+  border: 1px solid var(--border);
+  padding: var(--space-3);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: border-color 0.12s, background 0.12s, transform 0.06s;
+}
+
+.act-option:hover,
+.act-option:focus-visible {
+  border-color: var(--accent);
+  background: var(--bg-soft, rgba(255, 255, 255, 0.02));
+  outline: none;
+}
+
+.act-option:active {
+  transform: translateY(1px);
+}
+
+.act-card__back {
+  margin-top: var(--space-3);
+  background: transparent;
+  border: 0;
+  color: var(--muted);
+  font: inherit;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  cursor: pointer;
+  padding: 0;
+}
+
+.act-card__back:hover,
+.act-card__back:focus-visible {
+  color: var(--accent);
+  outline: none;
+}
+
+.act-card__cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.act-card__blurb {
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  margin: 0 0 var(--space-3);
+  max-width: 60ch;
+}
+
+.act-card__trail {
+  margin-top: var(--space-3);
+  font-size: var(--fs-sm);
+  color: var(--fg-soft);
+}
+
+.act-card__trail summary {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.act-card__trail summary:hover {
+  color: var(--accent);
+}
+
+.act-card__trail ol {
+  margin: var(--space-2) 0 0;
+  padding-left: 1.4em;
+}
+
+.act-card__trail li {
+  margin-bottom: var(--space-1);
+}
+
+.act-empty {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  text-align: center;
+  padding: var(--space-5) 0;
+}

--- a/site/data/action-tree.json
+++ b/site/data/action-tree.json
@@ -1,0 +1,123 @@
+{
+  "title": "Action chooser",
+  "intro": "The talk ended on Release Day — May 29. Five quick questions. One concrete next move. No homework, no inbox course, no maybe-later list. Pick the truer answer over the prettier one.",
+  "root": "q-role",
+  "actions": {
+    "write-doc": {
+      "title": "Write your three documents.",
+      "rationale": "Your AI keeps sounding like everyone else's AI because you've never told it who you are. Spend 20 minutes on the worldview / style / refuse-list trio. Save them. Reuse them in every prompt from now on.",
+      "cta": "Open /three-documents",
+      "href": "/widgets/three-documents.html",
+      "kind": "portal"
+    },
+    "audit-taste": {
+      "title": "Run a taste audit on your last ten outputs.",
+      "rationale": "You're shipping fast but the room is starting to blur. Pull the last ten things the model made for you. Score each one against your style guide. Cut the bot tells. The hero of the dancehall is the one with taste.",
+      "cta": "Open /taste-audit",
+      "href": "/widgets/taste-audit.html",
+      "kind": "portal"
+    },
+    "both-hands": {
+      "title": "Map your work onto Both Hands.",
+      "rationale": "You're stuck because you're working with one hand. List what only you can do (the human hand) next to what the model can do (the machine hand). The seam between them is the work.",
+      "cta": "Open /both-hands",
+      "href": "/widgets/both-hands.html",
+      "kind": "portal"
+    },
+    "build-set": {
+      "title": "Build a Selector set on what you actually believe.",
+      "rationale": "You don't have a distribution problem — you have a position problem. Drag the talk's quotes, your favourite beats, the slides that hit. Order them. That order is your point of view. Ship that.",
+      "cta": "Open /selector",
+      "href": "/widgets/selector.html",
+      "kind": "portal"
+    },
+    "ship-zine": {
+      "title": "Cut up something old. Ship a zine by Release Day.",
+      "rationale": "Stop generating new. Take what's already in your drafts folder, run it through the cut-up tool, print one page, hand it to one person. That's a release. May 29 is the deadline you set yourself by being in the room.",
+      "cta": "Open /cut-up",
+      "href": "/widgets/cut-up.html",
+      "kind": "portal"
+    },
+    "find-posse": {
+      "title": "Find your posse of three.",
+      "rationale": "You're trying to do this alone and it's why you keep stalling. Pick three people from the room — one ahead of you, one beside you, one behind you. Send each of them a sentence today. The work gets easier when somebody's watching.",
+      "cta": "Open /posse",
+      "href": "/posse.html",
+      "kind": "portal"
+    },
+    "release-day": {
+      "title": "Commit to Release Day. Pick the thing.",
+      "rationale": "You don't need another framework. You need a deadline with a public on the other side. Open the Release Day page, name what you're shipping by May 29, paste the link to a friend before you close the tab.",
+      "cta": "Open /release-day",
+      "href": "/release-day.html",
+      "kind": "portal"
+    },
+    "meetup": {
+      "title": "Show up at the next BC AI meetup.",
+      "rationale": "You learn this in rooms, not feeds. The Vancouver scene meets in person, on purpose, on the regular. Bring the half-finished thing. Trade notes with someone whose work you admire. Repeat.",
+      "cta": "Open BC AI Community",
+      "href": "https://bcaicommunity.com/",
+      "kind": "external"
+    }
+  },
+  "nodes": {
+    "q-role": {
+      "question": "Are you mostly making or mostly managing?",
+      "hint": "Pick where you spent the most hours last week.",
+      "options": [
+        { "label": "Making — words, images, code, sound", "next": "q-maker-block" },
+        { "label": "Managing — people, projects, decisions", "next": "q-manager-pain" },
+        { "label": "Both, honestly", "next": "q-both-priority" }
+      ]
+    },
+    "q-maker-block": {
+      "question": "What stops you most often?",
+      "hint": "First instinct, not the polished answer.",
+      "options": [
+        { "label": "The output sounds like every other AI", "next": "q-voice-doc" },
+        { "label": "I can't tell which draft is good", "next": "audit-taste" },
+        { "label": "I can ship — nobody sees it", "next": "build-set" },
+        { "label": "I have ten half-finished things", "next": "ship-zine" }
+      ]
+    },
+    "q-manager-pain": {
+      "question": "Where's the friction?",
+      "hint": "What's costing your team the most this month.",
+      "options": [
+        { "label": "No shared rules — everyone uses AI differently", "next": "write-doc" },
+        { "label": "Outputs are shipping but the quality is sliding", "next": "audit-taste" },
+        { "label": "I'm doing it alone and burning out", "next": "find-posse" },
+        { "label": "We can't decide what's human vs. what's machine", "next": "both-hands" }
+      ]
+    },
+    "q-both-priority": {
+      "question": "If you only had two hours this week, where do they go?",
+      "hint": "Two hours, no meetings, your call.",
+      "options": [
+        { "label": "Sharpen my voice", "next": "q-voice-doc" },
+        { "label": "Finish one thing", "next": "ship-zine" },
+        { "label": "Find collaborators", "next": "find-posse" },
+        { "label": "Audit what I've already made", "next": "audit-taste" }
+      ]
+    },
+    "q-voice-doc": {
+      "question": "Have you written your style guide yet?",
+      "hint": "The actual document, not a vibe.",
+      "options": [
+        { "label": "No — never sat down to do it", "next": "write-doc" },
+        { "label": "Sort of — a few notes somewhere", "next": "write-doc" },
+        { "label": "Yes — and I still hate the outputs", "next": "q-have-style" }
+      ]
+    },
+    "q-have-style": {
+      "question": "When did you last update it?",
+      "hint": "Style guides rot. Yours probably has too.",
+      "options": [
+        { "label": "Months ago, maybe longer", "next": "audit-taste" },
+        { "label": "Recently — the model still ignores it", "next": "both-hands" },
+        { "label": "Honestly, I copy-pasted somebody else's", "next": "write-doc" }
+      ]
+    }
+  },
+  "leafBlurb": "Save this. The result lives in your browser — come back to it when you finish, or shuffle and pick again."
+}

--- a/site/js/widgets/action.js
+++ b/site/js/widgets/action.js
@@ -1,0 +1,231 @@
+// /widgets/action — post-talk decision tree. Five quick questions route to
+// ONE assigned action with a deep-link back into the portal. The result
+// persists in localStorage so re-entry shows the assignment without forcing
+// the user to walk the tree again.
+
+import { load, save, remove } from "/js/common/storage.js";
+
+const STORAGE_KEY = "action:result";
+
+const stageEl = document.getElementById("act-stage");
+const statusEl = document.getElementById("act-status");
+const introLede = document.getElementById("act-intro-lede");
+
+let tree = null;
+let path = []; // sequence of { nodeId, choiceLabel }
+
+main();
+
+async function main() {
+  try {
+    const res = await fetch("/data/action-tree.json");
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    tree = await res.json();
+  } catch (err) {
+    stageEl.innerHTML = `<p class="act-empty">tree unavailable: ${escapeHTML(
+      err.message || err
+    )}</p>`;
+    return;
+  }
+
+  if (introLede && tree.intro) introLede.textContent = tree.intro;
+
+  const stored = load(STORAGE_KEY, null);
+  if (stored.ok && stored.value && stored.value.actionId && tree.actions[stored.value.actionId]) {
+    renderResult(stored.value.actionId, stored.value.path || [], { fromStorage: true });
+  } else {
+    renderQuestion(tree.root);
+  }
+}
+
+function renderQuestion(nodeId) {
+  const node = tree.nodes[nodeId];
+  if (!node) {
+    stageEl.innerHTML = `<p class="act-empty">missing node: ${escapeHTML(nodeId)}</p>`;
+    return;
+  }
+
+  const idx = path.length + 1;
+  const total = estimateDepth(nodeId) + path.length;
+
+  stageEl.innerHTML = "";
+  const card = document.createElement("section");
+  card.className = "act-card";
+  card.dataset.kind = "question";
+
+  const meta = document.createElement("p");
+  meta.className = "act-card__meta";
+  meta.textContent = `Question ${idx}${total > idx ? ` of ~${total}` : ""}`;
+  card.appendChild(meta);
+
+  const h2 = document.createElement("h2");
+  h2.className = "act-card__title";
+  h2.textContent = node.question;
+  card.appendChild(h2);
+
+  if (node.hint) {
+    const hint = document.createElement("p");
+    hint.className = "act-card__hint";
+    hint.textContent = node.hint;
+    card.appendChild(hint);
+  }
+
+  const list = document.createElement("ul");
+  list.className = "act-card__options";
+  node.options.forEach((opt) => {
+    const li = document.createElement("li");
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "act-option";
+    btn.textContent = opt.label;
+    btn.addEventListener("click", () => choose(nodeId, opt));
+    li.appendChild(btn);
+    list.appendChild(li);
+  });
+  card.appendChild(list);
+
+  if (path.length > 0) {
+    const back = document.createElement("button");
+    back.type = "button";
+    back.className = "act-card__back";
+    back.textContent = "← Back one question";
+    back.addEventListener("click", goBack);
+    card.appendChild(back);
+  }
+
+  stageEl.appendChild(card);
+}
+
+function choose(nodeId, opt) {
+  path.push({ nodeId, label: opt.label, next: opt.next });
+
+  if (tree.actions[opt.next]) {
+    renderResult(opt.next, path.slice());
+    return;
+  }
+  renderQuestion(opt.next);
+}
+
+function goBack() {
+  if (!path.length) return;
+  const last = path.pop();
+  renderQuestion(last.nodeId);
+}
+
+function renderResult(actionId, takenPath, opts = {}) {
+  const action = tree.actions[actionId];
+  if (!action) {
+    stageEl.innerHTML = `<p class="act-empty">missing action: ${escapeHTML(actionId)}</p>`;
+    return;
+  }
+
+  save(STORAGE_KEY, { actionId, path: takenPath, savedAt: Date.now() });
+
+  stageEl.innerHTML = "";
+  const card = document.createElement("section");
+  card.className = "act-card";
+  card.dataset.kind = "result";
+
+  const meta = document.createElement("p");
+  meta.className = "act-card__meta act-card__meta--accent";
+  meta.textContent = opts.fromStorage ? "Your saved move" : "Your move";
+  card.appendChild(meta);
+
+  const h2 = document.createElement("h2");
+  h2.className = "act-card__title act-card__title--big";
+  h2.textContent = action.title;
+  card.appendChild(h2);
+
+  const rationale = document.createElement("p");
+  rationale.className = "act-card__rationale";
+  rationale.textContent = action.rationale;
+  card.appendChild(rationale);
+
+  const ctaWrap = document.createElement("div");
+  ctaWrap.className = "act-card__cta-row";
+
+  const cta = document.createElement("a");
+  cta.className = "btn btn--primary";
+  cta.href = action.href;
+  cta.textContent = `Do it now → ${action.cta}`;
+  if (action.kind === "external") {
+    cta.target = "_blank";
+    cta.rel = "noopener";
+  }
+  ctaWrap.appendChild(cta);
+
+  const restart = document.createElement("button");
+  restart.type = "button";
+  restart.className = "btn";
+  restart.textContent = "Run again";
+  restart.addEventListener("click", reset);
+  ctaWrap.appendChild(restart);
+
+  card.appendChild(ctaWrap);
+
+  if (tree.leafBlurb) {
+    const blurb = document.createElement("p");
+    blurb.className = "act-card__blurb";
+    blurb.textContent = tree.leafBlurb;
+    card.appendChild(blurb);
+  }
+
+  if (takenPath.length) {
+    const trail = document.createElement("details");
+    trail.className = "act-card__trail";
+    const sum = document.createElement("summary");
+    sum.textContent = "How you got here";
+    trail.appendChild(sum);
+    const ol = document.createElement("ol");
+    takenPath.forEach((step) => {
+      const node = tree.nodes[step.nodeId];
+      const li = document.createElement("li");
+      li.innerHTML = `<strong>${escapeHTML(node ? node.question : step.nodeId)}</strong> — ${escapeHTML(
+        step.label
+      )}`;
+      ol.appendChild(li);
+    });
+    trail.appendChild(ol);
+    card.appendChild(trail);
+  }
+
+  stageEl.appendChild(card);
+  flash(opts.fromStorage ? "loaded your last result" : "saved — come back any time");
+}
+
+function reset() {
+  path = [];
+  remove(STORAGE_KEY);
+  renderQuestion(tree.root);
+  flash("");
+}
+
+function estimateDepth(nodeId, seen = new Set()) {
+  if (seen.has(nodeId)) return 0;
+  seen.add(nodeId);
+  const node = tree.nodes[nodeId];
+  if (!node) return 0;
+  let max = 0;
+  for (const opt of node.options) {
+    if (tree.actions[opt.next]) continue;
+    const d = 1 + estimateDepth(opt.next, new Set(seen));
+    if (d > max) max = d;
+  }
+  return max;
+}
+
+function flash(msg) {
+  if (!statusEl) return;
+  statusEl.textContent = msg;
+  clearTimeout(flash._t);
+  flash._t = setTimeout(() => {
+    if (statusEl) statusEl.textContent = "";
+  }, 2400);
+}
+
+function escapeHTML(s) {
+  return String(s ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}

--- a/site/widgets/action.html
+++ b/site/widgets/action.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Action chooser &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="Five quick questions. One concrete next move toward Release Day. The post-talk action chooser routes you straight back into the portal's tools."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/widgets/action.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main>
+      <section class="act-intro grain scanlines">
+        <div class="wrap wrap--narrow">
+          <p class="kicker kicker--accent">Post-talk &middot; pick one move toward Release Day</p>
+          <h1>What now?</h1>
+          <p class="act-intro__lede" id="act-intro-lede">
+            The talk ended on a deadline. Five quick questions. One concrete
+            next move. No homework, no inbox course, no maybe-later list.
+          </p>
+        </div>
+      </section>
+
+      <section class="act">
+        <div class="wrap wrap--narrow">
+          <div class="act__stage" id="act-stage" aria-live="polite"></div>
+          <p class="act__status" id="act-status" aria-live="polite"></p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/action.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #70

Decision-tree walker (vanilla ES module). 6 question nodes, 8 leaf actions, max depth 4. Routes to portal widgets (/three-documents, /taste-audit, /both-hands, /selector, /cut-up, /posse, /release-day) and external (BC AI community). Mobile-first; grid collapses to 1 col under 720px. State persists via existing storage.js helper. Tree integrity validated — no dangling next refs.