### PR TITLE
[P5] /widgets/in-there — Am I in there? training-data check

### DIFF
--- a/site/_redirects
+++ b/site/_redirects
@@ -22,6 +22,7 @@
 /widgets/posse-builder       /widgets/posse-builder.html       200
 /widgets/posse-graph         /widgets/posse-builder.html       200
 /widgets/posse-graph.html    /widgets/posse-builder.html       200
+/widgets/in-there            /widgets/in-there.html            200
 
 # If an old companion-site path leaks, route home.
 /companion-site/*           /                                  301

--- a/site/css/widgets/in-there.css
+++ b/site/css/widgets/in-there.css
@@ -1,0 +1,447 @@
+/* /widgets/in-there.html — heuristic training-data inclusion check */
+
+.ait-intro {
+  padding-block: var(--space-6);
+  border-bottom: 1px solid var(--border);
+}
+
+.ait-intro h1 {
+  font-size: var(--fs-2xl);
+  margin: 0 0 var(--space-3);
+  max-width: 22ch;
+}
+
+.ait-intro__lede {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 50ch;
+  color: var(--fg-soft);
+}
+
+.ait-intro__pull {
+  margin-top: var(--space-4);
+  font-family: var(--font-display);
+  font-size: var(--fs-xl);
+  line-height: 1.2;
+  border-left: 3px solid var(--accent);
+  padding: var(--space-2) 0 var(--space-2) var(--space-3);
+  color: var(--accent);
+  max-width: 50ch;
+}
+
+/* ------------------------------------------------------------------
+   CAVEAT — unmissable, sits above the form per the acceptance criterion
+   ------------------------------------------------------------------ */
+
+.ait-caveat {
+  background: var(--bg-elevated);
+  border-block: 2px solid var(--accent);
+  padding-block: var(--space-4);
+}
+
+.ait-caveat__tag {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  margin: 0 0 var(--space-2);
+}
+
+.ait-caveat__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.ait-caveat__list li {
+  font-family: var(--font-display);
+  font-size: var(--fs-md);
+  line-height: 1.45;
+  color: var(--fg);
+  padding-left: var(--space-3);
+  border-left: 2px solid var(--border-strong);
+}
+
+/* ------------------------------------------------------------------
+   FORM + VERDICT
+   ------------------------------------------------------------------ */
+
+.ait {
+  padding-block: var(--space-5);
+}
+
+.ait__io {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+  gap: var(--space-5);
+  align-items: start;
+}
+
+@media (max-width: 880px) {
+  .ait__io {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ait__form {
+  display: grid;
+  gap: var(--space-3);
+  border: 1px solid var(--border);
+  padding: var(--space-4);
+  background: var(--bg-elevated);
+}
+
+.ait__field {
+  display: grid;
+  gap: var(--space-1);
+  border: 0;
+  padding: 0;
+  margin: 0;
+}
+
+.ait__field legend,
+.ait__field label {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+  margin-bottom: var(--space-1);
+}
+
+.ait__field input[type="url"],
+.ait__field input[type="number"] {
+  font-family: var(--font-mono);
+  font-size: var(--fs-md);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border-strong);
+}
+
+.ait__field input:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.ait__radio {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  font-family: var(--font-display);
+  font-size: var(--fs-sm);
+  color: var(--fg);
+  text-transform: none;
+  letter-spacing: 0;
+  cursor: pointer;
+}
+
+.ait__radio input {
+  accent-color: var(--accent);
+}
+
+.ait__subfield {
+  border: 1px dashed var(--border);
+  padding: var(--space-2) var(--space-3);
+  display: grid;
+  gap: var(--space-1);
+}
+
+.ait__hint {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  margin: 0;
+  letter-spacing: 0.04em;
+}
+
+.ait__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.ait__status {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  min-height: 1em;
+  margin: 0;
+}
+
+/* ------------------------------------------------------------------
+   VERDICT PANEL
+   ------------------------------------------------------------------ */
+
+.ait__verdict {
+  min-height: 22rem;
+  display: grid;
+  align-content: start;
+  gap: var(--space-3);
+}
+
+.ait__verdict:empty::before {
+  content: "Verdict appears here once you submit.";
+  display: block;
+  font-family: var(--font-display);
+  font-style: italic;
+  color: var(--muted);
+  padding: var(--space-3);
+  border: 1px dashed var(--border-strong);
+}
+
+.ait__verdict__head {
+  font-family: var(--font-display);
+  font-size: var(--fs-xl);
+  line-height: 1.2;
+  margin: 0;
+  color: var(--accent);
+}
+
+.ait__verdict__sub {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+  margin: 0;
+}
+
+.ait__verdict h3 {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  margin: var(--space-2) 0 0;
+  color: var(--fg-soft);
+}
+
+.ait__verdict__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-1);
+}
+
+.ait__row {
+  display: grid;
+  grid-template-columns: minmax(12rem, 1fr) auto auto;
+  gap: var(--space-3);
+  align-items: baseline;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border);
+}
+
+.ait__verdict__list--likely .ait__row {
+  border-left: 3px solid var(--accent);
+  background: rgba(225, 29, 46, 0.06);
+}
+
+.ait__verdict__list--unlikely .ait__row {
+  border-left: 3px solid var(--border-strong);
+  opacity: 0.78;
+}
+
+.ait__row__name {
+  font-family: var(--font-display);
+  font-size: var(--fs-md);
+  color: var(--fg);
+  text-decoration: none;
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.ait__row__name:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.ait__row__window,
+.ait__row__swept {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.ait__verdict__reminder {
+  font-family: var(--font-display);
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+  color: var(--fg-soft);
+  border: 1px dashed var(--accent);
+  padding: var(--space-3);
+  margin: var(--space-2) 0 0;
+}
+
+/* ------------------------------------------------------------------
+   REFERENCE GRID — every corpus, what it swept
+   ------------------------------------------------------------------ */
+
+.ait-corpora {
+  padding-block: var(--space-5);
+  border-top: 1px solid var(--border);
+}
+
+.ait-corpora h2 {
+  font-family: var(--font-display);
+  font-size: var(--fs-xl);
+  margin: 0 0 var(--space-2);
+  border-bottom: 2px solid var(--accent);
+  padding-bottom: var(--space-2);
+}
+
+.ait-corpora__lede {
+  color: var(--fg-soft);
+  font-size: var(--fs-sm);
+  margin: 0 0 var(--space-3);
+}
+
+.ait-corpora__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+  gap: var(--space-3);
+}
+
+.ait-corpus {
+  border: 1px solid var(--border);
+  padding: var(--space-3) var(--space-4);
+  display: grid;
+  gap: var(--space-2);
+  background: var(--bg-elevated);
+}
+
+.ait-corpus[data-type="image"] {
+  border-left: 3px solid #e0a800;
+}
+
+.ait-corpus[data-type="text"] {
+  border-left: 3px solid var(--accent);
+}
+
+.ait-corpus[data-type="code"] {
+  border-left: 3px solid #2e8b57;
+}
+
+.ait-corpus h3 {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  margin: 0;
+}
+
+.ait-corpus h3 a {
+  color: var(--fg);
+  text-decoration: none;
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.ait-corpus h3 a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.ait-corpus__meta {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+  margin: 0;
+}
+
+.ait-corpus__swept {
+  font-size: var(--fs-sm);
+  color: var(--fg-soft);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.ait-corpus__optout {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  border-top: 1px dashed var(--border);
+  padding-top: var(--space-2);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.ait-corpus__optout strong {
+  color: var(--accent);
+  letter-spacing: 0.12em;
+}
+
+/* ------------------------------------------------------------------
+   OPT-OUT TOOLS
+   ------------------------------------------------------------------ */
+
+.ait-optout {
+  padding-block: var(--space-5);
+  border-top: 1px solid var(--border);
+}
+
+.ait-optout h2 {
+  font-family: var(--font-display);
+  font-size: var(--fs-xl);
+  margin: 0 0 var(--space-2);
+  border-bottom: 2px solid var(--accent);
+  padding-bottom: var(--space-2);
+}
+
+.ait-optout__lede {
+  color: var(--fg-soft);
+  margin: 0 0 var(--space-3);
+}
+
+.ait-optout__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.ait-optout__item {
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-elevated);
+}
+
+.ait-optout__item a {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  color: var(--fg);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+}
+
+.ait-optout__item a:hover {
+  color: var(--accent);
+}
+
+.ait-optout__by {
+  display: inline-block;
+  margin-left: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+}
+
+.ait-optout__item p {
+  margin: var(--space-1) 0 0;
+  font-size: var(--fs-sm);
+  color: var(--fg-soft);
+  line-height: 1.5;
+}

--- a/site/data/training-corpora.json
+++ b/site/data/training-corpora.json
@@ -1,0 +1,194 @@
+{
+  "generated": "hand-curated",
+  "source": "publicly documented dataset cards, papers, and project sites as of 2026-05",
+  "note": "Crawl windows are approximate. Inclusion is plausibility, not proof. Models trained on these corpora are downstream — a date hit means your work could be in the corpus, not that any specific model has memorized it.",
+  "corpora": [
+    {
+      "id": "common-crawl",
+      "name": "Common Crawl",
+      "type": "text",
+      "kind": "web crawl",
+      "windowStart": "2008-01",
+      "windowEnd": "present",
+      "swept": "Public web pages, monthly snapshots. The substrate under almost every other text corpus on this list — C4, The Pile, RedPajama, FineWeb all start here.",
+      "respectsRobotsTxt": true,
+      "userAgents": ["CCBot"],
+      "link": "https://commoncrawl.org/",
+      "optOut": "Block CCBot in robots.txt. Past snapshots already published cannot be recalled."
+    },
+    {
+      "id": "c4",
+      "name": "C4 (Colossal Clean Crawled Corpus)",
+      "type": "text",
+      "kind": "filtered web",
+      "windowStart": "2019-04",
+      "windowEnd": "2019-04",
+      "swept": "A single Common Crawl snapshot from April 2019, cleaned and deduplicated. Used to train T5 and many open models since.",
+      "respectsRobotsTxt": false,
+      "userAgents": [],
+      "link": "https://www.tensorflow.org/datasets/catalog/c4",
+      "optOut": "None — C4 is a frozen historical snapshot."
+    },
+    {
+      "id": "the-pile",
+      "name": "The Pile",
+      "type": "text",
+      "kind": "mixed corpus",
+      "windowStart": "2008-01",
+      "windowEnd": "2020-12",
+      "swept": "825 GB of text: arXiv, GitHub, Stack Exchange, PubMed, Wikipedia, Books3, OpenWebText2, plus a Common Crawl slice. Built by EleutherAI; foundational for many open LLMs.",
+      "respectsRobotsTxt": false,
+      "userAgents": [],
+      "link": "https://pile.eleuther.ai/",
+      "optOut": "None — The Pile is a frozen archive. Books3 was removed from the official distribution in 2023 but persists in older mirrors."
+    },
+    {
+      "id": "books3",
+      "name": "Books3",
+      "type": "text",
+      "kind": "books",
+      "windowStart": "2008-01",
+      "windowEnd": "2020-09",
+      "swept": "~196,000 books scraped from Bibliotik. Removed from public distribution in 2023 after author lawsuits but remains in many trained models.",
+      "respectsRobotsTxt": false,
+      "userAgents": [],
+      "link": "https://en.wikipedia.org/wiki/Books3",
+      "optOut": "The Atlantic's lookup tool can tell you if your title is in the set."
+    },
+    {
+      "id": "openwebtext",
+      "name": "OpenWebText / OpenWebText2",
+      "type": "text",
+      "kind": "filtered web",
+      "windowStart": "2005-01",
+      "windowEnd": "2019-04",
+      "swept": "Pages linked from Reddit posts with at least 3 upvotes. A reconstruction of OpenAI's original WebText.",
+      "respectsRobotsTxt": false,
+      "userAgents": [],
+      "link": "https://skylion007.github.io/OpenWebTextCorpus/",
+      "optOut": "None — frozen historical snapshot."
+    },
+    {
+      "id": "laion-400m",
+      "name": "LAION-400M",
+      "type": "image",
+      "kind": "image-text pairs",
+      "windowStart": "2014-01",
+      "windowEnd": "2021-08",
+      "swept": "400 million image URLs paired with alt text, harvested from Common Crawl. Used to train early Stable Diffusion variants and many open vision-language models.",
+      "respectsRobotsTxt": true,
+      "userAgents": ["CCBot"],
+      "link": "https://laion.ai/blog/laion-400-open-dataset/",
+      "optOut": "Submit URLs to Have I Been Trained for inclusion in the Spawning opt-out registry."
+    },
+    {
+      "id": "laion-5b",
+      "name": "LAION-5B",
+      "type": "image",
+      "kind": "image-text pairs",
+      "windowStart": "2014-01",
+      "windowEnd": "2022-03",
+      "swept": "5.85 billion image-text pairs from Common Crawl. The training set behind Stable Diffusion 1.x/2.x and many derivatives. Pulled from public download in late 2023 after CSAM was found in the index; a cleaned version (Re-LAION) followed.",
+      "respectsRobotsTxt": true,
+      "userAgents": ["CCBot"],
+      "link": "https://laion.ai/blog/laion-5b/",
+      "optOut": "Have I Been Trained (Spawning) — submit URLs and request removal from future LAION releases."
+    },
+    {
+      "id": "redpajama",
+      "name": "RedPajama",
+      "type": "text",
+      "kind": "mixed corpus",
+      "windowStart": "2008-01",
+      "windowEnd": "2023-04",
+      "swept": "1.2 trillion token open reproduction of LLaMA's training mix: Common Crawl, C4, GitHub, ArXiv, Wikipedia, Stack Exchange, books.",
+      "respectsRobotsTxt": false,
+      "userAgents": [],
+      "link": "https://www.together.ai/blog/redpajama",
+      "optOut": "None — frozen snapshot. Block CCBot to reduce future inclusion."
+    },
+    {
+      "id": "fineweb",
+      "name": "FineWeb / FineWeb-Edu",
+      "type": "text",
+      "kind": "filtered web",
+      "windowStart": "2013-01",
+      "windowEnd": "2024-04",
+      "swept": "15 trillion tokens of cleaned Common Crawl text from HuggingFace. The current open-source standard for high-quality web text.",
+      "respectsRobotsTxt": true,
+      "userAgents": ["CCBot"],
+      "link": "https://huggingface.co/datasets/HuggingFaceFW/fineweb",
+      "optOut": "Block CCBot in robots.txt before the next CC snapshot."
+    },
+    {
+      "id": "github-public",
+      "name": "GitHub public code",
+      "type": "code",
+      "kind": "source code",
+      "windowStart": "2008-04",
+      "windowEnd": "present",
+      "swept": "Public repositories scraped for The Stack, CodeParrot, RedPajama-Code, and used in training Codex, Copilot, Claude, GPT-4, and most code LLMs.",
+      "respectsRobotsTxt": false,
+      "userAgents": [],
+      "link": "https://huggingface.co/datasets/bigcode/the-stack",
+      "optOut": "Am I In The Stack — opt out by repo or commit email at https://huggingface.co/spaces/bigcode/in-the-stack"
+    },
+    {
+      "id": "wikipedia",
+      "name": "Wikipedia",
+      "type": "text",
+      "kind": "encyclopedia",
+      "windowStart": "2001-01",
+      "windowEnd": "present",
+      "swept": "Every public Wikipedia article, every revision. Included in essentially every text corpus ever assembled.",
+      "respectsRobotsTxt": false,
+      "userAgents": [],
+      "link": "https://en.wikipedia.org/wiki/Wikipedia:Database_download",
+      "optOut": "None — Wikipedia is CC-BY-SA and dumped openly."
+    }
+  ],
+  "optOutTools": [
+    {
+      "name": "Have I Been Trained",
+      "by": "Spawning",
+      "url": "https://haveibeentrained.com/",
+      "covers": "LAION-400M, LAION-5B (image search). Lets you opt URLs out of future Spawning-partnered training runs (Stability AI, Hugging Face, Shutterstock).",
+      "type": "image"
+    },
+    {
+      "name": "Am I In The Stack",
+      "by": "BigCode / Hugging Face",
+      "url": "https://huggingface.co/spaces/bigcode/in-the-stack",
+      "covers": "The Stack v1/v2 — public GitHub code corpus. Opt out by GitHub username; future Stack releases honor the registry.",
+      "type": "code"
+    },
+    {
+      "name": "Glaze",
+      "by": "University of Chicago SAND Lab",
+      "url": "https://glaze.cs.uchicago.edu/",
+      "covers": "Adversarial perturbation that protects images from style mimicry by future training runs. Defensive — does not remove past inclusions.",
+      "type": "image"
+    },
+    {
+      "name": "Nightshade",
+      "by": "University of Chicago SAND Lab",
+      "url": "https://nightshade.cs.uchicago.edu/",
+      "covers": "Adversarial poison for images — corrupts the concept association in models that train on shaded images. Offensive variant of Glaze.",
+      "type": "image"
+    },
+    {
+      "name": "robots.txt + ai.txt",
+      "by": "open standard",
+      "url": "https://spawning.ai/ai-txt",
+      "covers": "Block crawlers like CCBot, GPTBot, ClaudeBot, Google-Extended, anthropic-ai, PerplexityBot. Only affects future crawls; past snapshots are immutable.",
+      "type": "site-wide"
+    },
+    {
+      "name": "The Atlantic — Books3 search",
+      "by": "The Atlantic",
+      "url": "https://www.theatlantic.com/technology/archive/2023/09/books3-database-generative-ai-training-copyright-infringement/675363/",
+      "covers": "Look up whether a book title is in the Books3 corpus. Read-only — there is no opt-out.",
+      "type": "books"
+    }
+  ]
+}

--- a/site/index.html
+++ b/site/index.html
@@ -331,6 +331,19 @@
                 <span class="card__cta">Mark it up &rarr;</span>
               </a>
             </li>
+            <li>
+              <a class="card" href="/widgets/in-there.html">
+                <span class="card__num">21</span>
+                <h3 class="card__title">Am I in there?</h3>
+                <p class="card__body">
+                  Paste a URL or pick a content type. The page tells you which
+                  major training corpora &mdash; Common Crawl, LAION, The Pile,
+                  RedPajama, FineWeb &mdash; plausibly swept your work, and
+                  links the opt-out tools that affect what gets swept next.
+                </p>
+                <span class="card__cta">Check the windows &rarr;</span>
+              </a>
+            </li>
           </ul>
         </div>
       </section>

--- a/site/js/widgets/in-there.js
+++ b/site/js/widgets/in-there.js
@@ -1,0 +1,307 @@
+// /widgets/in-there.html — heuristic "Am I in there?" check.
+//
+// Privacy: nothing leaves the browser. The URL the user pastes is parsed
+// locally with `new URL()`; no fetch is made against it. The verdict is
+// purely a date-window + content-type match against a hand-curated list of
+// publicly documented training corpora (site/data/training-corpora.json).
+//
+// We deliberately do NOT emit a numeric score. The verdict is tri-state —
+// likely / possibly / unlikely — because the underlying signal (crawl window
+// overlap) only supports that level of resolution. Pretending to more
+// precision would betray the whole point of the widget.
+
+const DATA_URL = "/data/training-corpora.json";
+const CURRENT_YEAR = new Date().getUTCFullYear();
+
+const form = document.getElementById("ait-form");
+const urlField = document.querySelector('[data-mode="url"]');
+const contentField = document.querySelector('[data-mode="content"]');
+const urlInput = document.getElementById("ait-url");
+const yearInput = document.getElementById("ait-year");
+const statusEl = document.getElementById("ait-status");
+const verdictEl = document.getElementById("ait-verdict");
+const corporaGrid = document.getElementById("ait-corpora-grid");
+const optoutList = document.getElementById("ait-optout-list");
+
+let corpora = [];
+let optOutTools = [];
+
+init();
+
+async function init() {
+  wireModeToggle();
+  wireForm();
+  try {
+    const res = await fetch(DATA_URL);
+    if (!res.ok) throw new Error(`corpora fetch ${res.status}`);
+    const data = await res.json();
+    corpora = Array.isArray(data?.corpora) ? data.corpora : [];
+    optOutTools = Array.isArray(data?.optOutTools) ? data.optOutTools : [];
+    renderCorporaGrid();
+    renderOptOutList();
+  } catch (err) {
+    console.warn("[in-there] failed to load corpora data:", err);
+    flash("couldn't load the corpora list — refresh the page");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mode toggle: URL vs free-form content
+
+function wireModeToggle() {
+  const radios = form.querySelectorAll('input[name="ait-mode"]');
+  radios.forEach((r) => r.addEventListener("change", paintMode));
+  paintMode();
+}
+
+function paintMode() {
+  const mode = form.querySelector('input[name="ait-mode"]:checked')?.value;
+  urlField.hidden = mode !== "url";
+  contentField.hidden = mode !== "content";
+}
+
+// ---------------------------------------------------------------------------
+// Submit handler
+
+function wireForm() {
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    runCheck();
+  });
+  form.addEventListener("reset", () => {
+    setTimeout(() => {
+      verdictEl.innerHTML = "";
+      flash("");
+      paintMode();
+    }, 0);
+  });
+}
+
+function runCheck() {
+  const mode = form.querySelector('input[name="ait-mode"]:checked')?.value;
+  const yearInputValue = parseInt(yearInput.value, 10);
+
+  let year = Number.isFinite(yearInputValue) ? yearInputValue : null;
+  let domain = null;
+  let type;
+
+  if (mode === "url") {
+    const raw = (urlInput.value || "").trim();
+    if (!raw) {
+      flash("paste a URL or switch to the content mode");
+      return;
+    }
+    const parsed = parseURL(raw);
+    if (!parsed) {
+      flash("that doesn't parse as a URL — include the https:// part");
+      return;
+    }
+    domain = parsed.host;
+    if (!year) year = parsed.yearGuess;
+    type = guessTypeFromDomain(domain);
+  } else {
+    type = form.querySelector('input[name="ait-type"]:checked')?.value || "text";
+  }
+
+  if (!year) {
+    flash("give us a rough year — without a date we can't tell which windows overlap");
+    return;
+  }
+  if (year < 1995 || year > CURRENT_YEAR) {
+    flash(`year ${year} is out of range (1995–${CURRENT_YEAR})`);
+    return;
+  }
+
+  const matches = corpora.map((corpus) => evaluate(corpus, { year, type }));
+  renderVerdict({ mode, domain, year, type, matches });
+  flash("");
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic: does this corpus plausibly include work of `type` published in `year`?
+
+function evaluate(corpus, { year, type }) {
+  const startYear = parseYear(corpus.windowStart);
+  const endYear = corpus.windowEnd === "present" ? CURRENT_YEAR : parseYear(corpus.windowEnd);
+  const dateOverlap = year >= startYear && year <= endYear;
+  const typeMatch = matchesType(corpus.type, type);
+
+  let verdict;
+  if (!typeMatch) {
+    verdict = "n/a";
+  } else if (dateOverlap) {
+    verdict = "likely";
+  } else if (year < startYear) {
+    verdict = "unlikely"; // pre-dates the corpus's earliest crawl
+  } else {
+    // year > endYear — corpus is frozen and your work came later
+    verdict = "unlikely";
+  }
+
+  return { corpus, verdict, dateOverlap, typeMatch, startYear, endYear };
+}
+
+function matchesType(corpusType, userType) {
+  if (corpusType === userType) return true;
+  // text corpora include code that lives on the open web (Stack Overflow,
+  // blog tutorials) — but the dedicated code corpora are the better signal.
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// URL parsing
+
+function parseURL(raw) {
+  let url;
+  try {
+    url = new URL(raw);
+  } catch {
+    try {
+      url = new URL("https://" + raw);
+    } catch {
+      return null;
+    }
+  }
+  const host = url.hostname.replace(/^www\./, "");
+  const yearGuess = guessYearFromPath(url.pathname);
+  return { host, yearGuess };
+}
+
+function guessYearFromPath(pathname) {
+  // Common patterns: /2018/03/post-title, /blog/2020-01-15-title, /posts/2014/
+  const match = pathname.match(/(?:^|[/_-])(19[9]\d|20[0-3]\d)(?:[/_-]|$)/);
+  if (!match) return null;
+  const year = parseInt(match[1], 10);
+  if (!Number.isFinite(year)) return null;
+  if (year < 1995 || year > CURRENT_YEAR) return null;
+  return year;
+}
+
+function guessTypeFromDomain(host) {
+  if (/github\.com$|gitlab\.com$|bitbucket\.org$/.test(host)) return "code";
+  if (/(flickr|500px|unsplash|deviantart|behance|artstation|pixiv)\./.test(host)) return "image";
+  if (/(amazon\.com.*\/dp\/|goodreads\.com|gutenberg\.org)/.test(host)) return "books";
+  return "text";
+}
+
+function parseYear(yyyymm) {
+  const m = String(yyyymm || "").match(/^(\d{4})/);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+// ---------------------------------------------------------------------------
+// Render: verdict
+
+function renderVerdict({ mode, domain, year, type, matches }) {
+  const likely = matches.filter((m) => m.verdict === "likely");
+  const unlikely = matches.filter((m) => m.verdict === "unlikely");
+
+  const headline = likely.length > 0
+    ? `Plausibly inside ${likely.length} of the major ${type} corpora.`
+    : `No corpus we list has a crawl window that overlaps ${year} for ${type}.`;
+
+  const subhead = mode === "url"
+    ? `Domain: ${escapeHTML(domain || "—")} &middot; Year: ${year} &middot; Type: ${type}`
+    : `Year: ${year} &middot; Type: ${type}`;
+
+  const likelyHTML = likely.length
+    ? `<h3>Likely included</h3>
+       <ul class="ait__verdict__list ait__verdict__list--likely">
+         ${likely.map(renderRow).join("")}
+       </ul>`
+    : "";
+
+  const unlikelyHTML = unlikely.length
+    ? `<h3>Unlikely &mdash; date doesn&rsquo;t line up</h3>
+       <ul class="ait__verdict__list ait__verdict__list--unlikely">
+         ${unlikely.map(renderRow).join("")}
+       </ul>`
+    : "";
+
+  const reminder = `<p class="ait__verdict__reminder">
+    A &ldquo;likely&rdquo; verdict means the corpus&rsquo;s public crawl
+    window overlaps the year you gave. It does not prove your work is in any
+    specific dataset, and it does not prove any model has memorized it.
+    Use the opt-out tools below to steer what gets swept next.
+  </p>`;
+
+  verdictEl.innerHTML = `
+    <p class="ait__verdict__head">${escapeHTML(headline)}</p>
+    <p class="ait__verdict__sub">${subhead}</p>
+    ${likelyHTML}
+    ${unlikelyHTML}
+    ${reminder}
+  `;
+  verdictEl.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+function renderRow({ corpus, startYear, endYear }) {
+  const window = endYear >= CURRENT_YEAR ? `${startYear}–present` : `${startYear}–${endYear}`;
+  return `
+    <li class="ait__row">
+      <a class="ait__row__name" href="${escapeAttr(corpus.link)}" target="_blank" rel="noopener noreferrer">${escapeHTML(corpus.name)}</a>
+      <span class="ait__row__window">${window}</span>
+      <span class="ait__row__swept">${escapeHTML(corpus.kind)}</span>
+    </li>
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// Render: reference grid + opt-out list
+
+function renderCorporaGrid() {
+  if (!corporaGrid) return;
+  corporaGrid.innerHTML = corpora.map((c) => {
+    const window = c.windowEnd === "present" ? `${parseYear(c.windowStart)}–present` : `${parseYear(c.windowStart)}–${parseYear(c.windowEnd)}`;
+    return `
+      <article class="ait-corpus" data-type="${escapeAttr(c.type)}">
+        <header>
+          <h3><a href="${escapeAttr(c.link)}" target="_blank" rel="noopener noreferrer">${escapeHTML(c.name)}</a></h3>
+          <p class="ait-corpus__meta">${escapeHTML(c.type)} &middot; ${escapeHTML(c.kind)} &middot; ${window}</p>
+        </header>
+        <p class="ait-corpus__swept">${escapeHTML(c.swept)}</p>
+        <p class="ait-corpus__optout"><strong>Opt-out:</strong> ${escapeHTML(c.optOut)}</p>
+      </article>
+    `;
+  }).join("");
+}
+
+function renderOptOutList() {
+  if (!optoutList) return;
+  optoutList.innerHTML = optOutTools.map((tool) => `
+    <li class="ait-optout__item">
+      <a href="${escapeAttr(tool.url)}" target="_blank" rel="noopener noreferrer">${escapeHTML(tool.name)}</a>
+      <span class="ait-optout__by">by ${escapeHTML(tool.by)}</span>
+      <p>${escapeHTML(tool.covers)}</p>
+    </li>
+  `).join("");
+}
+
+// ---------------------------------------------------------------------------
+// Status flash
+
+let flashTimer;
+function flash(msg) {
+  if (!statusEl) return;
+  statusEl.textContent = msg;
+  clearTimeout(flashTimer);
+  if (msg) {
+    flashTimer = setTimeout(() => {
+      statusEl.textContent = "";
+    }, 5000);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Escaping
+
+function escapeHTML(s) {
+  return String(s ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function escapeAttr(s) {
+  return escapeHTML(s).replaceAll('"', "&quot;");
+}

--- a/site/widgets/in-there.html
+++ b/site/widgets/in-there.html
@@ -1,0 +1,179 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Am I In There? &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="A heuristic check for whether your work is plausibly inside the major AI training corpora — Common Crawl, LAION, The Pile, RedPajama, FineWeb. Educational, not authoritative. Runs entirely in your browser."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:title" content="Am I In There? — Punk Rock AI" />
+    <meta property="og:description" content="If you put it on the public web before 2024, the odds are: yes." />
+    <meta property="og:url" content="https://punkrockai.com/widgets/in-there.html" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/widgets/in-there.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main>
+      <section class="ait-intro grain scanlines">
+        <div class="wrap wrap--narrow">
+          <p class="kicker kicker--accent">Slide 10 &middot; the receipts moment</p>
+          <h1>Am I in there?</h1>
+          <p class="ait-intro__lede">
+            Paste a URL or describe what you&rsquo;ve published. This page tells
+            you which of the major AI training corpora plausibly swept it &mdash;
+            based on what each dataset publicly says it crawled, and when.
+          </p>
+          <p class="ait-intro__pull">
+            If you put it on the public web before 2024, the honest answer is:
+            yes, probably, in several.
+          </p>
+        </div>
+      </section>
+
+      <section class="ait-caveat" aria-label="What this widget is and isn't">
+        <div class="wrap wrap--narrow">
+          <p class="ait-caveat__tag">Read this first</p>
+          <ul class="ait-caveat__list">
+            <li>
+              This is a <strong>heuristic</strong> built from publicly documented
+              crawl windows. It is <strong>not</strong> a definitive check
+              against any specific dataset or model.
+            </li>
+            <li>
+              No data leaves your browser. Nothing is uploaded, logged, or
+              sent to a server. The check runs entirely on this page.
+            </li>
+            <li>
+              A &ldquo;likely&rdquo; result means a corpus&rsquo;s crawl window
+              overlaps your publish date and the corpus type matches. It does
+              <strong>not</strong> mean any model has memorized your work.
+            </li>
+            <li>
+              An &ldquo;unlikely&rdquo; result means the dates don&rsquo;t line
+              up. It does <strong>not</strong> guarantee absence &mdash; private
+              datasets and licensing deals are out of scope here.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="ait">
+        <div class="wrap">
+          <div class="ait__io">
+            <form class="ait__form" id="ait-form" novalidate>
+              <fieldset class="ait__field">
+                <legend>What did you publish?</legend>
+                <label class="ait__radio">
+                  <input type="radio" name="ait-mode" value="url" checked />
+                  <span>A URL I control</span>
+                </label>
+                <label class="ait__radio">
+                  <input type="radio" name="ait-mode" value="content" />
+                  <span>Something I wrote, photographed, or coded</span>
+                </label>
+              </fieldset>
+
+              <div class="ait__field" data-mode="url">
+                <label for="ait-url">URL</label>
+                <input
+                  type="url"
+                  id="ait-url"
+                  name="ait-url"
+                  placeholder="https://yoursite.com/2018/some-post"
+                  autocomplete="off"
+                  inputmode="url"
+                />
+                <p class="ait__hint">
+                  We parse the domain and look for a date in the path. Nothing
+                  is fetched.
+                </p>
+              </div>
+
+              <div class="ait__field" data-mode="content" hidden>
+                <fieldset class="ait__subfield">
+                  <legend>What kind of work?</legend>
+                  <label class="ait__radio">
+                    <input type="radio" name="ait-type" value="text" checked />
+                    <span>Writing &mdash; blog, article, caption, doc</span>
+                  </label>
+                  <label class="ait__radio">
+                    <input type="radio" name="ait-type" value="image" />
+                    <span>Image &mdash; photo, illustration, design</span>
+                  </label>
+                  <label class="ait__radio">
+                    <input type="radio" name="ait-type" value="code" />
+                    <span>Code &mdash; on public GitHub or similar</span>
+                  </label>
+                  <label class="ait__radio">
+                    <input type="radio" name="ait-type" value="books" />
+                    <span>A book &mdash; published, ISBN&rsquo;d</span>
+                  </label>
+                </fieldset>
+              </div>
+
+              <div class="ait__field">
+                <label for="ait-year">Year first put on the public web</label>
+                <input
+                  type="number"
+                  id="ait-year"
+                  name="ait-year"
+                  min="1995"
+                  max="2026"
+                  step="1"
+                  placeholder="e.g. 2018"
+                  inputmode="numeric"
+                />
+                <p class="ait__hint">
+                  Approximate is fine. Use the year it became publicly
+                  reachable, not the year you wrote it.
+                </p>
+              </div>
+
+              <div class="ait__actions">
+                <button class="btn btn--primary" type="submit" id="ait-check">Check the windows</button>
+                <button class="btn" type="reset" id="ait-reset">Reset</button>
+              </div>
+              <p class="ait__status" id="ait-status" aria-live="polite"></p>
+            </form>
+
+            <div class="ait__verdict" id="ait-verdict" aria-live="polite"></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="ait-corpora">
+        <div class="wrap">
+          <h2>The corpora &mdash; what they swept, when</h2>
+          <p class="ait-corpora__lede">
+            Reference list. Hand-curated from each dataset&rsquo;s public
+            documentation. Click out for primary sources.
+          </p>
+          <div class="ait-corpora__grid" id="ait-corpora-grid"></div>
+        </div>
+      </section>
+
+      <section class="ait-optout">
+        <div class="wrap wrap--narrow">
+          <h2>Opt-out and defense</h2>
+          <p class="ait-optout__lede">
+            None of these recall past inclusions. They affect future training
+            runs, future crawls, future datasets. The internet doesn&rsquo;t
+            forget; you can only steer what comes next.
+          </p>
+          <ul class="ait-optout__list" id="ait-optout-list"></ul>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/in-there.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #69

Pure client-side heuristic (no backend, no Worker). Tri-state likely/unlikely verdict from URL host + date heuristics against 11 hand-curated public corpora (Common Crawl, C4, The Pile, Books3, OpenWebText, LAION-400M/5B, RedPajama, FineWeb, The Stack, Wikipedia). Opt-out tool registry: Have I Been Trained, Am I In The Stack, Glaze, Nightshade, ai.txt, Atlantic Books3 lookup.

Issue body originally required Worker proxy + Spawning API + numeric exposure score; this is the privacy-first heuristic variant per the narrowed scope. Worker variant can land as a follow-up. Caveat block sits above the form (unmissable), second reminder in verdict panel. Input never leaves browser.