### PR TITLE
Set up Linear GitHub delivery pipeline

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap-feature.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-feature.md
@@ -1,0 +1,41 @@
+---
+name: Roadmap feature
+about: Add or refine feature work that should be tracked from the roadmap into Linear and GitHub.
+title: ""
+labels: ["kind:feature", "eval:required"]
+assignees: ""
+---
+
+## Summary
+
+Describe the user-facing or delivery outcome in one paragraph.
+
+## Roadmap
+
+- Roadmap ID:
+- Phase:
+- Linear issue:
+
+## Acceptance Criteria
+
+- [ ]
+- [ ]
+- [ ]
+
+## Eval Commands
+
+- [ ] `npm run eval`
+
+## Tests
+
+- [ ]
+- [ ]
+
+## Relevant Paths
+
+- [ ]
+
+## Definition Of Done
+
+- [ ]
+- [ ]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+## Tracking
+
+- GitHub issue:
+- Linear issue:
+- Roadmap ID:
+
+## What Changed
+
+- 
+
+## Eval
+
+- [ ] `npm run eval`
+- [ ] Manual checks listed in the issue are covered
+
+## Docs And Handoff
+
+- [ ] Updated roadmap or session handoff docs if scope or blockers changed
+- [ ] Added notes reviewers need in the PR body
+
+## Risks
+
+- 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run eval suite
+        run: npm run eval

--- a/.github/workflows/roadmap-sync.yml
+++ b/.github/workflows/roadmap-sync.yml
@@ -1,0 +1,43 @@
+name: Roadmap Sync
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "ops/roadmap/**"
+      - "scripts/lib/roadmap.mjs"
+      - "scripts/sync-roadmap-issues.mjs"
+      - ".github/workflows/roadmap-sync.yml"
+  workflow_dispatch:
+    inputs:
+      roadmap_id:
+        description: "Optional roadmap item id to sync"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Validate roadmap registry
+        run: npm run check:roadmap
+
+      - name: Sync roadmap issues
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ROADMAP_ID: ${{ inputs.roadmap_id }}
+        run: node scripts/sync-roadmap-issues.mjs --write

--- a/SESSION-HANDOFF.md
+++ b/SESSION-HANDOFF.md
@@ -226,3 +226,41 @@ Continuing from these commits. Documentation lands first (this entry +
 [`docs/PROJECT-ROADMAP.md`](./docs/PROJECT-ROADMAP.md)). Then the eight remaining
 issues — see `docs/PROJECT-ROADMAP.md#portal-phase` for the running ledger of what
 shipped and what's still blocked.
+
+---
+
+## Linear + Agentic Pipeline Setup — May 3, 2026
+
+Linear project seeded: **Punk Rock AI Portal** in team `Bc-ai`.
+
+Repo-side automation:
+- Backlog registry: `ops/roadmap/features.json`
+- Operating guide: `docs/LINEAR-GITHUB-PIPELINE.md`
+- PR gate: `.github/workflows/ci.yml` running `npm run eval`
+- Roadmap issue sync: `.github/workflows/roadmap-sync.yml`
+- Issue template: `.github/ISSUE_TEMPLATE/roadmap-feature.md`
+- PR template: `.github/pull_request_template.md`
+
+Linear issues created:
+
+| Linear | GitHub | State | Notes |
+|--------|--------|-------|-------|
+| `BC-8` | `#8` | Backlog | Cloudflare Pages project and staging URL |
+| `BC-9` | `#9` | In Progress | Taste Audit / Cutting Room Floor |
+| `BC-10` | `#10` | In Progress | Name What You See |
+| `BC-11` | `#11` | Todo + `status:blocked` | Audio sync; GitHub issue is already closed as completed, external audio/R2 work remains tracked as blocker context |
+| `BC-12` | `#12` | In Progress | `/library` searchable; GitHub issue is already closed as completed |
+| `BC-13` | `#13` | Todo + `status:blocked` | Pattern Finder LLM; GitHub issue is already closed as completed, API/deploy credentials remain blocked |
+| `BC-14` | `#14` | Todo + `status:blocked` | Release Day portal; GitHub issue is already closed as completed, Notion/deploy credentials remain blocked |
+| `BC-15` | `#15` | In Progress | `/posse` audience map; GitHub issue is already closed as completed |
+| `BC-16` | `#16` | In Progress | Decisions log; GitHub issue is already closed as completed |
+
+Verification:
+- `npm run eval` passes locally.
+- GitHub issues `#8` through `#16` have roadmap bodies with Linear links.
+- Linear labels were created for area, kind, phase, priority, blocked status, and eval requirements.
+
+Still external / account-level:
+- Enable Linear's GitHub integration in the Linear UI for `WalksWithASwagger/cmvan-keynote`.
+- Re-authenticate local `gh`; current local token is invalid.
+- Provide Cloudflare, Anthropic, Notion, and ElevenLabs credentials to unblock deployed worker/audio work.

--- a/docs/LINEAR-GITHUB-PIPELINE.md
+++ b/docs/LINEAR-GITHUB-PIPELINE.md
@@ -1,0 +1,62 @@
+# Linear + GitHub delivery pipeline
+
+This repo now has a machine-readable backlog at [`ops/roadmap/features.json`](../ops/roadmap/features.json). The narrative roadmap in [`docs/PROJECT-ROADMAP.md`](./PROJECT-ROADMAP.md) remains the human-facing source; the JSON file is the queue that automation reads.
+
+Linear project: [Punk Rock AI Portal](https://linear.app/bc-ai/project/punk-rock-ai-portal-e9aec6edd886), team `Bc-ai`.
+
+## What is automated
+
+- **Roadmap Sync**: [`.github/workflows/roadmap-sync.yml`](../.github/workflows/roadmap-sync.yml) syncs backlog items into GitHub issues whenever the roadmap registry changes on `main`, or on manual dispatch.
+- **Issue bodies**: `scripts/sync-roadmap-issues.mjs` renders acceptance criteria, eval commands, tests, blockers, and relevant paths into each issue so Linear mirrors complete implementation context.
+- **PR gate**: [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) runs `npm run eval` on every PR and push to `main`.
+- **Eval surface**: `npm run eval` validates the roadmap registry, site data contracts, JavaScript syntax, and the static site contract test suite.
+- **Linear seed**: Linear project issues `BC-8` through `BC-16` have been created with labels, priorities, states, and links back to the GitHub issue numbers already referenced by the roadmap.
+
+## Seeded Linear Work
+
+| Linear | GitHub | Status | Title |
+|--------|--------|--------|-------|
+| [BC-8](https://linear.app/bc-ai/issue/BC-8/cloudflare-pages-project-and-staging-url) | [#8](https://github.com/WalksWithASwagger/cmvan-keynote/issues/8) | Backlog | Cloudflare Pages project and staging URL |
+| [BC-9](https://linear.app/bc-ai/issue/BC-9/taste-audit-cutting-room-floor) | [#9](https://github.com/WalksWithASwagger/cmvan-keynote/issues/9) | In Progress | Taste Audit / Cutting Room Floor |
+| [BC-10](https://linear.app/bc-ai/issue/BC-10/name-what-you-see) | [#10](https://github.com/WalksWithASwagger/cmvan-keynote/issues/10) | In Progress | Name What You See |
+| [BC-11](https://linear.app/bc-ai/issue/BC-11/audio-sync) | [#11](https://github.com/WalksWithASwagger/cmvan-keynote/issues/11) | Todo, blocked | Audio sync |
+| [BC-12](https://linear.app/bc-ai/issue/BC-12/library-searchable) | [#12](https://github.com/WalksWithASwagger/cmvan-keynote/issues/12) | In Progress | /library searchable |
+| [BC-13](https://linear.app/bc-ai/issue/BC-13/pattern-finder-llm) | [#13](https://github.com/WalksWithASwagger/cmvan-keynote/issues/13) | Todo, blocked | Pattern Finder LLM |
+| [BC-14](https://linear.app/bc-ai/issue/BC-14/release-day-portal) | [#14](https://github.com/WalksWithASwagger/cmvan-keynote/issues/14) | Todo, blocked | Release Day portal |
+| [BC-15](https://linear.app/bc-ai/issue/BC-15/posse-audience-map) | [#15](https://github.com/WalksWithASwagger/cmvan-keynote/issues/15) | In Progress | /posse audience map |
+| [BC-16](https://linear.app/bc-ai/issue/BC-16/decisions-log) | [#16](https://github.com/WalksWithASwagger/cmvan-keynote/issues/16) | In Progress | Decisions log |
+
+## One-time setup outside the repo
+
+1. In Linear, connect the GitHub integration to `WalksWithASwagger/cmvan-keynote`.
+2. Enable PR, commit, and review linking in Linear so branch and PR activity stays attached to the same work item.
+3. If you enable GitHub issue import later, map imported issues to the existing `BC-8` through `BC-16` work instead of creating duplicates.
+4. In GitHub, enable Actions for this repository if they are not already enabled.
+5. Re-authenticate local GitHub CLI access if you want to run sync commands from this machine. Right now `gh auth status` reports an invalid token.
+
+## Working loop
+
+1. Add or refine a backlog item in [`ops/roadmap/features.json`](../ops/roadmap/features.json).
+2. Merge that change to `main` or dispatch `Roadmap Sync` manually.
+3. Update or create the matching Linear issue in the `Punk Rock AI Portal` project.
+4. Branch from the synced work item. Prefer the Linear issue key if one exists; otherwise use a `codex/issue-<n>-...` branch.
+5. Implement the change, run `npm run eval`, and open a PR with the repo template.
+6. When the PR lands, update [`docs/PROJECT-ROADMAP.md`](./PROJECT-ROADMAP.md) and [`SESSION-HANDOFF.md`](../SESSION-HANDOFF.md) if the change altered scope, status, or blockers.
+
+## Commands
+
+```sh
+npm run check:roadmap
+npm run sync:github:dry
+npm run sync:github
+npm run eval
+```
+
+`npm run sync:github` needs `GITHUB_TOKEN`. The GitHub Action already provides that token automatically for the repo workflow.
+
+## Current external blockers
+
+- Local `gh` authentication is invalid on this machine.
+- No Linear CLI or local Linear API token is configured.
+- The Linear plugin is connected in Codex and was used to seed the project, but Linear's account-level GitHub integration still has to be enabled in the Linear UI.
+- Cloudflare, Anthropic, ElevenLabs, and Notion credentials are still required for the blocked roadmap items.

--- a/docs/PROJECT-ROADMAP.md
+++ b/docs/PROJECT-ROADMAP.md
@@ -106,6 +106,8 @@ https://github.com/WalksWithASwagger/kk-kb/pull/new/chore/cmvan-2026-creative-mo
 
 The interactive learning portal that turns the talk into a working set of widgets. Vanilla HTML/CSS/JS, zero runtime deps. Tracked as epic [#1](https://github.com/WalksWithASwagger/cmvan-keynote/issues/1). Dev onboarding lives at [`site/README.md`](../site/README.md).
 
+Machine-readable delivery queue: [`ops/roadmap/features.json`](../ops/roadmap/features.json). Linear/GitHub operating model: [`docs/LINEAR-GITHUB-PIPELINE.md`](./LINEAR-GITHUB-PIPELINE.md). Linear project: [Punk Rock AI Portal](https://linear.app/bc-ai/project/punk-rock-ai-portal-e9aec6edd886), seeded as `BC-8` through `BC-16`.
+
 ### Phase 1 — Foundation + four widgets (shipped)
 
 | Issue | Title | Commit | Notes |

--- a/ops/roadmap/features.json
+++ b/ops/roadmap/features.json
@@ -1,0 +1,544 @@
+{
+  "version": 1,
+  "project": {
+    "name": "Punk Rock AI Portal",
+    "githubRepository": "WalksWithASwagger/cmvan-keynote",
+    "defaultEvalCommand": "npm run eval",
+    "linearProject": "Punk Rock AI Portal",
+    "linearProjectId": "1ea775ca-1e85-4bf1-81f8-7a7444ed1093",
+    "linearProjectUrl": "https://linear.app/bc-ai/project/punk-rock-ai-portal-e9aec6edd886",
+    "linearTeam": "Bc-ai"
+  },
+  "labelCatalog": [
+    {
+      "name": "area:infra",
+      "color": "5319e7",
+      "description": "Deployment and infrastructure work."
+    },
+    {
+      "name": "area:site",
+      "color": "1d76db",
+      "description": "Static site pages, widgets, and data contracts."
+    },
+    {
+      "name": "area:workers",
+      "color": "0e8a16",
+      "description": "Cloudflare Worker and API integration work."
+    },
+    {
+      "name": "kind:feature",
+      "color": "0052cc",
+      "description": "User-facing feature delivery."
+    },
+    {
+      "name": "kind:ops",
+      "color": "6f42c1",
+      "description": "Operational or platform setup."
+    },
+    {
+      "name": "phase:portal-1",
+      "color": "d4c5f9",
+      "description": "Portal Phase 1 work."
+    },
+    {
+      "name": "phase:portal-2",
+      "color": "bfd4f2",
+      "description": "Portal Phase 2 work."
+    },
+    {
+      "name": "phase:portal-3",
+      "color": "c2e0c6",
+      "description": "Portal Phase 3 work."
+    },
+    {
+      "name": "priority:p1",
+      "color": "b60205",
+      "description": "Highest-priority delivery work."
+    },
+    {
+      "name": "priority:p2",
+      "color": "d93f0b",
+      "description": "Second-priority delivery work."
+    },
+    {
+      "name": "status:blocked",
+      "color": "000000",
+      "description": "Work is blocked by an external dependency."
+    },
+    {
+      "name": "eval:required",
+      "color": "fbca04",
+      "description": "PR must include explicit eval and test coverage."
+    }
+  ],
+  "items": [
+    {
+      "id": "portal-phase-1-cloudflare-pages",
+      "title": "Cloudflare Pages project and staging URL",
+      "phase": "Portal Phase 1",
+      "type": "ops",
+      "priority": "p1",
+      "status": "planned",
+      "summary": "Create the Cloudflare Pages project for the static site and document the staging URL so the portal has a durable deploy target.",
+      "github": {
+        "issue": 8,
+        "labels": [
+          "area:infra",
+          "kind:ops",
+          "phase:portal-1",
+          "priority:p1",
+          "eval:required"
+        ]
+      },
+      "linear": {
+        "project": "Punk Rock AI Portal",
+        "team": "Bc-ai",
+        "issue": "BC-8",
+        "url": "https://linear.app/bc-ai/issue/BC-8/cloudflare-pages-project-and-staging-url",
+        "state": "Backlog"
+      },
+      "paths": [
+        "site",
+        "site/_headers",
+        "site/_redirects",
+        "site/README.md",
+        "wrangler.toml"
+      ],
+      "acceptanceCriteria": [
+        "A Cloudflare Pages project is connected to the repository and serves `site/` as the output directory.",
+        "The staging URL is documented in repo docs so agents can test against a shared target.",
+        "Headers and redirects behave the same on the deployed target as they do locally."
+      ],
+      "evals": [
+        "npm run eval"
+      ],
+      "tests": [
+        "Verify `/`, `/talk.html`, `/lineage.html`, and widget routes return 200 on the deployed Pages URL.",
+        "Verify `site/_headers` and `site/_redirects` behavior on the staging deployment."
+      ],
+      "blockedBy": [
+        "Cloudflare account access and Pages project creation."
+      ],
+      "definitionOfDone": [
+        "The staging URL is recorded in repo docs.",
+        "A human or agent can validate the portal against the same deployment target without guessing settings."
+      ]
+    },
+    {
+      "id": "portal-phase-2-taste-audit",
+      "title": "Taste Audit / Cutting Room Floor",
+      "phase": "Portal Phase 2",
+      "type": "feature",
+      "priority": "p1",
+      "status": "in_progress",
+      "summary": "Ship the taste-audit widget as a durable local-first exercise that turns refusal patterns into usable prompts and exported notes.",
+      "github": {
+        "issue": 9,
+        "labels": [
+          "area:site",
+          "kind:feature",
+          "phase:portal-2",
+          "priority:p1",
+          "eval:required"
+        ]
+      },
+      "linear": {
+        "project": "Punk Rock AI Portal",
+        "team": "Bc-ai",
+        "issue": "BC-9",
+        "url": "https://linear.app/bc-ai/issue/BC-9/taste-audit-cutting-room-floor",
+        "state": "In Progress"
+      },
+      "paths": [
+        "site/widgets/taste-audit.html",
+        "site/js/widgets/taste-audit.js",
+        "site/css/widgets/taste-audit.css",
+        "site/data/taste-prompts.json"
+      ],
+      "acceptanceCriteria": [
+        "Users can capture kept, refused, and undecided work items without leaving the page.",
+        "The widget converts refusal patterns into prompt-ready synthesis and exportable notes.",
+        "Autosave and reset flows are explicit, predictable, and local-first."
+      ],
+      "evals": [
+        "npm run eval"
+      ],
+      "tests": [
+        "Verify autosave survives a reload and reset clears only the taste-audit namespace.",
+        "Verify exported prompt copy reflects the current refusal pattern state."
+      ],
+      "blockedBy": [],
+      "definitionOfDone": [
+        "The page is usable without any network dependency beyond committed JSON.",
+        "The issue body, PR, and docs describe how the widget externalizes taste rather than just collecting text."
+      ]
+    },
+    {
+      "id": "portal-phase-2-name-what-you-see",
+      "title": "Name What You See",
+      "phase": "Portal Phase 2",
+      "type": "feature",
+      "priority": "p1",
+      "status": "in_progress",
+      "summary": "Turn the anti-bias section into a concrete walkthrough with hand-curated cases and language that names the specific harm being shown.",
+      "github": {
+        "issue": 10,
+        "labels": [
+          "area:site",
+          "kind:feature",
+          "phase:portal-2",
+          "priority:p1",
+          "eval:required"
+        ]
+      },
+      "linear": {
+        "project": "Punk Rock AI Portal",
+        "team": "Bc-ai",
+        "issue": "BC-10",
+        "url": "https://linear.app/bc-ai/issue/BC-10/name-what-you-see",
+        "state": "In Progress"
+      },
+      "paths": [
+        "site/widgets/name-what-you-see.html",
+        "site/js/widgets/name-what-you-see.js",
+        "site/css/widgets/name-what-you-see.css",
+        "site/data/cases.json",
+        "site/data/bingo.json"
+      ],
+      "acceptanceCriteria": [
+        "The widget walks through the curated case studies without flattening them into generic `bias` language.",
+        "A user can move from headline to precise harm statement to prompt-ready framing.",
+        "The page remains legible and intentional on desktop and mobile."
+      ],
+      "evals": [
+        "npm run eval"
+      ],
+      "tests": [
+        "Walk through all curated cases and verify each one renders a precise harm statement and supporting citation.",
+        "Verify the bingo or checklist state behaves predictably across reload and reset."
+      ],
+      "blockedBy": [],
+      "definitionOfDone": [
+        "Five case studies are reviewable from the same route without broken citations or empty states.",
+        "The final UX makes the naming move feel concrete rather than sermon-like."
+      ]
+    },
+    {
+      "id": "portal-phase-2-audio-sync",
+      "title": "Audio sync",
+      "phase": "Portal Phase 2",
+      "type": "feature",
+      "priority": "p2",
+      "status": "blocked",
+      "summary": "Thread timed audio cues and hosted mp3 assets through the talk reel so slide playback can align with the rehearsal script.",
+      "github": {
+        "issue": 11,
+        "labels": [
+          "area:site",
+          "kind:feature",
+          "phase:portal-2",
+          "priority:p2",
+          "status:blocked",
+          "eval:required"
+        ]
+      },
+      "linear": {
+        "project": "Punk Rock AI Portal",
+        "team": "Bc-ai",
+        "issue": "BC-11",
+        "url": "https://linear.app/bc-ai/issue/BC-11/audio-sync",
+        "state": "Todo",
+        "blocked": true
+      },
+      "paths": [
+        "dress-rehearsal/elevenlabs-full-script.md",
+        "scripts/build-audio-cues.mjs",
+        "site/js/common/audio-player.js",
+        "site/js/widgets/slide-reel.js",
+        "site/data/audio-cues.json"
+      ],
+      "acceptanceCriteria": [
+        "Cue generation produces a stable `audio-cues.json` contract keyed by slide id.",
+        "When hosted audio exists, the talk reel can play, pause, and seek against the cue map.",
+        "The page degrades cleanly when audio files are not yet available."
+      ],
+      "evals": [
+        "npm run eval",
+        "node scripts/build-audio-cues.mjs"
+      ],
+      "tests": [
+        "Verify cue timestamps are monotonic and cover every mapped slide section.",
+        "With `R2_PUBLIC_BASE` set, verify per-slide `mp3Url` fields render and player controls work end to end."
+      ],
+      "blockedBy": [
+        "ElevenLabs audio generation and hosted mp3 assets in R2."
+      ],
+      "definitionOfDone": [
+        "A reviewer can hear the slide reel progress against real or stubbed cue data.",
+        "Missing audio never breaks the talk page."
+      ]
+    },
+    {
+      "id": "portal-phase-2-library-search",
+      "title": "/library searchable",
+      "phase": "Portal Phase 2",
+      "type": "feature",
+      "priority": "p1",
+      "status": "in_progress",
+      "summary": "Keep the markdown corpus searchable in-browser with a generated JSON index and a fast client-side search experience.",
+      "github": {
+        "issue": 12,
+        "labels": [
+          "area:site",
+          "kind:feature",
+          "phase:portal-2",
+          "priority:p1",
+          "eval:required"
+        ]
+      },
+      "linear": {
+        "project": "Punk Rock AI Portal",
+        "team": "Bc-ai",
+        "issue": "BC-12",
+        "url": "https://linear.app/bc-ai/issue/BC-12/library-searchable",
+        "state": "In Progress"
+      },
+      "paths": [
+        "site/library.html",
+        "site/js/widgets/library.js",
+        "site/css/widgets/library.css",
+        "site/data/library.json",
+        "scripts/build-library-index.mjs"
+      ],
+      "acceptanceCriteria": [
+        "The library page can search across the committed markdown collections without a server.",
+        "Generated index data stays small enough to ship while still surfacing useful excerpts.",
+        "The search UX highlights why a result matched, not just that it matched."
+      ],
+      "evals": [
+        "npm run eval",
+        "node scripts/build-library-index.mjs"
+      ],
+      "tests": [
+        "Verify search returns hits from `script/`, `source-material/`, `dress-rehearsal/`, and `research/`.",
+        "Verify large documents stay truncated without breaking search or page performance."
+      ],
+      "blockedBy": [],
+      "definitionOfDone": [
+        "The generated index remains the only runtime contract the page needs.",
+        "A reviewer can find a known line or concept from each source collection."
+      ]
+    },
+    {
+      "id": "portal-phase-3-pattern-finder-llm",
+      "title": "Pattern Finder LLM",
+      "phase": "Portal Phase 3",
+      "type": "feature",
+      "priority": "p2",
+      "status": "blocked",
+      "summary": "Connect the Pattern Finder widget to a Cloudflare Worker-backed model endpoint with rate limiting, prompt caching, and a strong fallback when the worker is unavailable.",
+      "github": {
+        "issue": 13,
+        "labels": [
+          "area:workers",
+          "kind:feature",
+          "phase:portal-3",
+          "priority:p2",
+          "status:blocked",
+          "eval:required"
+        ]
+      },
+      "linear": {
+        "project": "Punk Rock AI Portal",
+        "team": "Bc-ai",
+        "issue": "BC-13",
+        "url": "https://linear.app/bc-ai/issue/BC-13/pattern-finder-llm",
+        "state": "Todo",
+        "blocked": true
+      },
+      "paths": [
+        "site/widgets/pattern-finder.html",
+        "site/js/widgets/pattern-finder.js",
+        "site/css/widgets/pattern-finder.css",
+        "worker/pattern-finder",
+        "worker/pattern-finder/index.js"
+      ],
+      "acceptanceCriteria": [
+        "The front-end can call a deployed worker route and handle both success and degraded fallback states.",
+        "The worker enforces rate limiting and bounded prompt size before forwarding model traffic.",
+        "The system prompt and response shape are stable enough for review and iteration."
+      ],
+      "evals": [
+        "npm run eval"
+      ],
+      "tests": [
+        "From `worker/pattern-finder/`, run `wrangler dev` and verify the widget can round-trip a sample corpus.",
+        "Verify rate limiting and offline fallback copy both behave as designed."
+      ],
+      "blockedBy": [
+        "Anthropic API key and Cloudflare Workers account access."
+      ],
+      "definitionOfDone": [
+        "The widget is useful with or without the worker being reachable.",
+        "The worker contract is documented well enough that agents can continue iterating safely."
+      ]
+    },
+    {
+      "id": "portal-phase-3-release-day-portal",
+      "title": "Release Day portal",
+      "phase": "Portal Phase 3",
+      "type": "feature",
+      "priority": "p2",
+      "status": "blocked",
+      "summary": "Finish the submission portal flow so people can post work into a moderated gallery backed by Notion and surfaced on the static site.",
+      "github": {
+        "issue": 14,
+        "labels": [
+          "area:workers",
+          "kind:feature",
+          "phase:portal-3",
+          "priority:p2",
+          "status:blocked",
+          "eval:required"
+        ]
+      },
+      "linear": {
+        "project": "Punk Rock AI Portal",
+        "team": "Bc-ai",
+        "issue": "BC-14",
+        "url": "https://linear.app/bc-ai/issue/BC-14/release-day-portal",
+        "state": "Todo",
+        "blocked": true
+      },
+      "paths": [
+        "site/release-day.html",
+        "site/js/widgets/release-day.js",
+        "site/css/widgets/release-day.css",
+        "site/data/submissions.json",
+        "worker/submissions",
+        "worker/submissions/index.js"
+      ],
+      "acceptanceCriteria": [
+        "The public page can submit entries to a moderation queue and render approved submissions back out.",
+        "The worker validates and sanitizes fields before touching Notion.",
+        "The page still gives the user a usable fallback when the worker is not wired yet."
+      ],
+      "evals": [
+        "npm run eval"
+      ],
+      "tests": [
+        "From `worker/submissions/`, run `wrangler dev` against a test database and verify POST plus moderated GET flows.",
+        "Verify missing-worker fallback copy is visible and actionable on the page."
+      ],
+      "blockedBy": [
+        "Notion database, integration token, and deployment target for the worker."
+      ],
+      "definitionOfDone": [
+        "Submission moderation is explicit and documented.",
+        "The static site can hydrate from committed `submissions.json` or the worker response without code changes."
+      ]
+    },
+    {
+      "id": "portal-phase-3-posse-audience-map",
+      "title": "/posse audience map",
+      "phase": "Portal Phase 3",
+      "type": "feature",
+      "priority": "p2",
+      "status": "in_progress",
+      "summary": "Render the audience dossier as a navigable map of people, relationships, and why each connection matters for the talk and the broader project.",
+      "github": {
+        "issue": 15,
+        "labels": [
+          "area:site",
+          "kind:feature",
+          "phase:portal-3",
+          "priority:p2",
+          "eval:required"
+        ]
+      },
+      "linear": {
+        "project": "Punk Rock AI Portal",
+        "team": "Bc-ai",
+        "issue": "BC-15",
+        "url": "https://linear.app/bc-ai/issue/BC-15/posse-audience-map",
+        "state": "In Progress"
+      },
+      "paths": [
+        "site/posse.html",
+        "site/js/widgets/posse.js",
+        "site/css/widgets/posse.css",
+        "site/data/posse.json",
+        "research/audience-rsvp-may1.md"
+      ],
+      "acceptanceCriteria": [
+        "The page presents the highlighted audience profiles without exposing anything that should stay private.",
+        "Users can scan by name, role, or stance and understand why each person matters.",
+        "The experience remains readable on mobile and feels like a map, not a spreadsheet."
+      ],
+      "evals": [
+        "npm run eval"
+      ],
+      "tests": [
+        "Verify every highlighted profile renders its links, stance, and relevance fields.",
+        "Verify the page handles an empty or reduced profile set without layout breakage."
+      ],
+      "blockedBy": [],
+      "definitionOfDone": [
+        "The page turns the dossier into a usable pre-talk tool, not just a data dump.",
+        "Profile data can continue to be curated from repo markdown without introducing a database."
+      ]
+    },
+    {
+      "id": "portal-phase-3-decisions-log",
+      "title": "Decisions log",
+      "phase": "Portal Phase 3",
+      "type": "feature",
+      "priority": "p2",
+      "status": "in_progress",
+      "summary": "Expose the project decision trail directly on the site so open questions, handoff notes, and resolved calls stay legible without a separate CMS.",
+      "github": {
+        "issue": 16,
+        "labels": [
+          "area:site",
+          "kind:feature",
+          "phase:portal-3",
+          "priority:p2",
+          "eval:required"
+        ]
+      },
+      "linear": {
+        "project": "Punk Rock AI Portal",
+        "team": "Bc-ai",
+        "issue": "BC-16",
+        "url": "https://linear.app/bc-ai/issue/BC-16/decisions-log",
+        "state": "In Progress"
+      },
+      "paths": [
+        "site/decisions.html",
+        "site/js/widgets/decisions.js",
+        "site/css/widgets/decisions.css",
+        "OPEN-QUESTIONS.md",
+        "SESSION-HANDOFF.md",
+        "scripts/build-decisions.mjs"
+      ],
+      "acceptanceCriteria": [
+        "The decisions page renders both open questions and handoff history from committed markdown.",
+        "Formatting failures in the source docs surface as build-time errors instead of silent blank states.",
+        "The page makes it obvious which questions are open versus resolved."
+      ],
+      "evals": [
+        "npm run eval",
+        "node scripts/build-decisions.mjs"
+      ],
+      "tests": [
+        "Verify resolved and open questions render into separate, readable sections.",
+        "Verify the markdown-to-HTML transform preserves links, lists, and code fences without injecting raw HTML."
+      ],
+      "blockedBy": [],
+      "definitionOfDone": [
+        "The public-facing decision trail stays in sync with the repo docs that agents already edit.",
+        "A reviewer can trace a decision from source markdown to rendered page without manual copy-paste."
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,14 @@
     "build:library": "node scripts/build-library-index.mjs",
     "build:audio": "node scripts/build-audio-cues.mjs",
     "build:decisions": "node scripts/build-decisions.mjs",
-    "ingest:slides": "node scripts/ingest-slides.mjs"
+    "ingest:slides": "node scripts/ingest-slides.mjs",
+    "check:roadmap": "node scripts/check-roadmap.mjs",
+    "check:data": "node scripts/check-site-data.mjs",
+    "check:js": "node scripts/check-js.mjs",
+    "test": "node --test tests/site-contract.test.mjs tests/roadmap-contract.test.mjs",
+    "eval": "node scripts/run-evals.mjs",
+    "sync:github:dry": "node scripts/sync-roadmap-issues.mjs",
+    "sync:github": "node scripts/sync-roadmap-issues.mjs --write"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.700.0",

--- a/scripts/check-js.mjs
+++ b/scripts/check-js.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import { readdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, "..");
+const JS_EXTENSIONS = new Set([".js", ".mjs"]);
+const SKIP_DIRS = new Set([".git", "node_modules", "assets/generated"]);
+
+const files = [];
+await walk(ROOT);
+
+for (const file of files) {
+  const result = spawnSync(process.execPath, ["--check", file], {
+    cwd: ROOT,
+    encoding: "utf8"
+  });
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr);
+    process.exit(result.status ?? 1);
+  }
+}
+
+console.log(`ok - node --check passed for ${files.length} JavaScript file(s)`);
+
+async function walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = resolve(dir, entry.name);
+    const rel = full.slice(ROOT.length + 1);
+    if (entry.isDirectory()) {
+      if (shouldSkipDir(rel, entry.name)) continue;
+      await walk(full);
+      continue;
+    }
+
+    if (!entry.isFile()) continue;
+    const ext = entry.name.includes(".") ? `.${entry.name.split(".").pop()}` : "";
+    if (JS_EXTENSIONS.has(ext)) {
+      files.push(full);
+    }
+  }
+}
+
+function shouldSkipDir(rel, name) {
+  if (name.startsWith(".")) return true;
+  if (SKIP_DIRS.has(name)) return true;
+  return [...SKIP_DIRS].some((prefix) => rel.startsWith(prefix));
+}

--- a/scripts/check-roadmap.mjs
+++ b/scripts/check-roadmap.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+import { loadRoadmap, roadmapSummary, validateRoadmap } from "./lib/roadmap.mjs";
+
+const roadmap = await loadRoadmap();
+const errors = await validateRoadmap(roadmap);
+
+if (errors.length) {
+  console.error(`roadmap validation failed with ${errors.length} issue(s):`);
+  for (const error of errors) {
+    console.error(`  - ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(`ok - ${roadmap.items.length} roadmap item(s) validated`);
+console.log(roadmapSummary(roadmap));

--- a/scripts/check-site-data.mjs
+++ b/scripts/check-site-data.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+import { readFile, readdir } from "node:fs/promises";
+import { basename, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, "..");
+const DATA_DIR = resolve(ROOT, "site/data");
+
+const EXPECTED_KEYS = {
+  "audio-cues.json": ["cues"],
+  "bingo.json": ["cells"],
+  "cases.json": ["cases"],
+  "chainsaws.json": ["tools"],
+  "decisions.json": ["openQuestions", "sessions"],
+  "junior-pipeline.json": ["rungs"],
+  "library.json": ["docs"],
+  "lineage.json": ["beats"],
+  "moves.json": ["moves"],
+  "posse.json": ["profiles"],
+  "punk-stack.json": ["layers"],
+  "quotes.json": ["quotes"],
+  "recap-media.json": ["slots"],
+  "slides.json": ["slides"],
+  "submissions.json": ["submissions"],
+  "taste-prompts.json": ["framework", "promptsForExport"]
+};
+
+const entries = (await readdir(DATA_DIR)).filter((entry) => entry.endsWith(".json")).sort();
+const errors = [];
+
+for (const entry of entries) {
+  const file = resolve(DATA_DIR, entry);
+  let data;
+  try {
+    data = JSON.parse(await readFile(file, "utf8"));
+  } catch (error) {
+    errors.push(`${entry} is not valid JSON: ${error.message}`);
+    continue;
+  }
+
+  if (!data || Array.isArray(data) || typeof data !== "object") {
+    errors.push(`${entry} must parse to an object`);
+    continue;
+  }
+
+  for (const key of EXPECTED_KEYS[entry] ?? []) {
+    if (!(key in data)) {
+      errors.push(`${entry} missing top-level key: ${key}`);
+      continue;
+    }
+    const value = data[key];
+    if (Array.isArray(value) && value.length === 0 && entry !== "submissions.json") {
+      errors.push(`${entry} has an empty array at ${key}`);
+    }
+    if (!Array.isArray(value) && (value == null || typeof value !== "object")) {
+      errors.push(`${entry} has invalid value at ${key}`);
+    }
+  }
+}
+
+if (errors.length) {
+  console.error(`site/data validation failed with ${errors.length} issue(s):`);
+  for (const error of errors) {
+    console.error(`  - ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(`ok - ${entries.length} JSON data contract(s) validated in ${basename(DATA_DIR)}`);

--- a/scripts/lib/roadmap.mjs
+++ b/scripts/lib/roadmap.mjs
@@ -1,0 +1,189 @@
+import { readFile, stat } from "node:fs/promises";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+export const ROOT = resolve(HERE, "../..");
+export const ROADMAP_FILE = resolve(ROOT, "ops/roadmap/features.json");
+
+const ALLOWED_TYPES = new Set(["feature", "ops"]);
+const ALLOWED_STATUS = new Set(["planned", "in_progress", "blocked", "done"]);
+const ALLOWED_PRIORITY = new Set(["p1", "p2", "p3"]);
+
+export async function loadRoadmap() {
+  const raw = await readFile(ROADMAP_FILE, "utf8");
+  return JSON.parse(raw);
+}
+
+export async function validateRoadmap(roadmap) {
+  const errors = [];
+
+  if (!Number.isInteger(roadmap?.version)) {
+    errors.push("top-level `version` must be an integer");
+  }
+
+  if (!roadmap?.project?.githubRepository) {
+    errors.push("top-level `project.githubRepository` is required");
+  }
+
+  if (!Array.isArray(roadmap?.labelCatalog) || roadmap.labelCatalog.length === 0) {
+    errors.push("top-level `labelCatalog` must be a non-empty array");
+  }
+
+  if (!Array.isArray(roadmap?.items) || roadmap.items.length === 0) {
+    errors.push("top-level `items` must be a non-empty array");
+  }
+
+  const labelNames = new Set();
+  for (const label of roadmap?.labelCatalog ?? []) {
+    if (!label?.name) {
+      errors.push("every label in `labelCatalog` must have a name");
+      continue;
+    }
+    if (labelNames.has(label.name)) {
+      errors.push(`duplicate label in catalog: ${label.name}`);
+    }
+    labelNames.add(label.name);
+    if (!/^[0-9a-fA-F]{6}$/.test(label.color ?? "")) {
+      errors.push(`label ${label.name} must have a 6-char hex color`);
+    }
+  }
+
+  const seenIds = new Set();
+  const seenIssues = new Set();
+
+  for (const item of roadmap?.items ?? []) {
+    const prefix = item?.id ? `item ${item.id}` : "item <missing-id>";
+
+    if (!item?.id) errors.push("every item must have an `id`");
+    if (!item?.title) errors.push(`${prefix} missing title`);
+    if (!item?.phase) errors.push(`${prefix} missing phase`);
+    if (!item?.summary) errors.push(`${prefix} missing summary`);
+
+    if (seenIds.has(item?.id)) {
+      errors.push(`duplicate roadmap item id: ${item.id}`);
+    }
+    seenIds.add(item?.id);
+
+    if (!ALLOWED_TYPES.has(item?.type)) {
+      errors.push(`${prefix} has invalid type: ${item?.type}`);
+    }
+
+    if (!ALLOWED_STATUS.has(item?.status)) {
+      errors.push(`${prefix} has invalid status: ${item?.status}`);
+    }
+
+    if (!ALLOWED_PRIORITY.has(item?.priority)) {
+      errors.push(`${prefix} has invalid priority: ${item?.priority}`);
+    }
+
+    if (!Number.isInteger(item?.github?.issue) || item.github.issue <= 0) {
+      errors.push(`${prefix} must include a positive integer github.issue`);
+    } else if (seenIssues.has(item.github.issue)) {
+      errors.push(`duplicate github issue number in roadmap: #${item.github.issue}`);
+    } else {
+      seenIssues.add(item.github.issue);
+    }
+
+    if (!Array.isArray(item?.github?.labels) || item.github.labels.length === 0) {
+      errors.push(`${prefix} must include one or more github labels`);
+    } else {
+      for (const label of item.github.labels) {
+        if (!labelNames.has(label)) {
+          errors.push(`${prefix} references unknown label: ${label}`);
+        }
+      }
+    }
+
+    if (item?.linear?.issue && !/^https:\/\/linear\.app\//.test(item?.linear?.url ?? "")) {
+      errors.push(`${prefix} has a linear.issue but is missing a valid linear.url`);
+    }
+
+    requireStringArray(errors, item?.acceptanceCriteria, `${prefix} acceptanceCriteria`);
+    requireStringArray(errors, item?.evals, `${prefix} evals`);
+    requireStringArray(errors, item?.tests, `${prefix} tests`);
+    requireStringArray(errors, item?.paths, `${prefix} paths`);
+    requireStringArray(errors, item?.definitionOfDone, `${prefix} definitionOfDone`);
+
+    for (const relPath of item?.paths ?? []) {
+      const absPath = resolve(ROOT, relPath);
+      try {
+        await stat(absPath);
+      } catch {
+        errors.push(`${prefix} references missing path: ${relPath}`);
+      }
+    }
+  }
+
+  return errors;
+}
+
+export function renderIssueBody(item, roadmap) {
+  const lines = [
+    `<!-- roadmap-id: ${item.id} -->`,
+    "## Roadmap Sync",
+    `- Roadmap ID: \`${item.id}\``,
+    `- Phase: \`${item.phase}\``,
+    `- Type: \`${item.type}\``,
+    `- Priority: \`${item.priority}\``,
+    `- Status: \`${pretty(item.status)}\``,
+    `- Linear project: \`${item.linear?.project ?? roadmap.project?.linearProject ?? "TBD"}\``,
+    item.linear?.issue ? `- Linear issue: [${item.linear.issue}](${item.linear.url})` : null,
+    `- Linear state: \`${item.linear?.state ?? "Backlog"}\``,
+    item.linear?.blocked ? "- Linear blocked marker: `status:blocked` label" : null,
+    "",
+    "## Summary",
+    item.summary,
+    "",
+    "## Acceptance Criteria",
+    ...item.acceptanceCriteria.map((entry) => `- ${entry}`),
+    "",
+    "## Eval Commands",
+    ...item.evals.map((entry) => `- \`${entry}\``),
+    "",
+    "## Tests",
+    ...item.tests.map((entry) => `- ${entry}`),
+    "",
+    "## Relevant Paths",
+    ...item.paths.map((entry) => `- \`${entry}\``)
+  ].filter((line) => line !== null);
+
+  if (item.blockedBy?.length) {
+    lines.push("", "## Blockers", ...item.blockedBy.map((entry) => `- ${entry}`));
+  }
+
+  lines.push("", "## Definition Of Done", ...item.definitionOfDone.map((entry) => `- ${entry}`));
+  return lines.join("\n") + "\n";
+}
+
+export function roadmapSummary(roadmap) {
+  const counts = new Map();
+  for (const item of roadmap.items ?? []) {
+    counts.set(item.status, (counts.get(item.status) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([status, count]) => `${pretty(status)}: ${count}`)
+    .join(", ");
+}
+
+export function relFromRoot(path) {
+  return relative(ROOT, path);
+}
+
+function requireStringArray(errors, value, label) {
+  if (!Array.isArray(value) || value.length === 0) {
+    errors.push(`${label} must be a non-empty array`);
+    return;
+  }
+  for (const entry of value) {
+    if (typeof entry !== "string" || entry.trim() === "") {
+      errors.push(`${label} must contain only non-empty strings`);
+      return;
+    }
+  }
+}
+
+function pretty(value) {
+  return String(value ?? "").replaceAll("_", " ");
+}

--- a/scripts/run-evals.mjs
+++ b/scripts/run-evals.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, "..");
+
+const STEPS = [
+  {
+    label: "roadmap contract",
+    args: [resolve(ROOT, "scripts/check-roadmap.mjs")]
+  },
+  {
+    label: "site data contract",
+    args: [resolve(ROOT, "scripts/check-site-data.mjs")]
+  },
+  {
+    label: "javascript syntax",
+    args: [resolve(ROOT, "scripts/check-js.mjs")]
+  },
+  {
+    label: "node test suite",
+    args: [
+      "--test",
+      resolve(ROOT, "tests/site-contract.test.mjs"),
+      resolve(ROOT, "tests/roadmap-contract.test.mjs")
+    ]
+  }
+];
+
+for (const step of STEPS) {
+  console.log(`\n==> ${step.label}`);
+  const result = spawnSync(process.execPath, step.args, {
+    cwd: ROOT,
+    stdio: "inherit"
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+console.log(`\nok - ${STEPS.length} eval step(s) passed`);

--- a/scripts/sync-roadmap-issues.mjs
+++ b/scripts/sync-roadmap-issues.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import { writeFile } from "node:fs/promises";
+import { URLSearchParams } from "node:url";
+import { ROADMAP_FILE, loadRoadmap, relFromRoot, renderIssueBody, validateRoadmap } from "./lib/roadmap.mjs";
+
+const args = process.argv.slice(2);
+const write = args.includes("--write");
+const writeBack = args.includes("--write-back");
+const itemId = readFlag("--id") ?? process.env.ROADMAP_ID ?? null;
+
+const roadmap = await loadRoadmap();
+const errors = await validateRoadmap(roadmap);
+if (errors.length) {
+  console.error("roadmap validation failed; refusing to sync issues");
+  for (const error of errors) {
+    console.error(`  - ${error}`);
+  }
+  process.exit(1);
+}
+
+const items = roadmap.items.filter((item) => !itemId || item.id === itemId);
+if (itemId && items.length === 0) {
+  console.error(`no roadmap item found for id: ${itemId}`);
+  process.exit(1);
+}
+
+if (!write) {
+  for (const item of items) {
+    console.log(`${item.github.issue ? `update #${item.github.issue}` : "create"} :: ${item.id} :: ${item.title}`);
+    console.log(renderIssueBody(item, roadmap));
+  }
+  process.exit(0);
+}
+
+const token = process.env.GITHUB_TOKEN;
+if (!token) {
+  console.error("GITHUB_TOKEN is required when running with --write");
+  process.exit(1);
+}
+
+const repository = process.env.GITHUB_REPOSITORY ?? roadmap.project.githubRepository;
+const [owner, repo] = repository.split("/");
+if (!owner || !repo) {
+  console.error(`invalid GitHub repository: ${repository}`);
+  process.exit(1);
+}
+
+const labelsToSync = new Map();
+for (const label of roadmap.labelCatalog) {
+  labelsToSync.set(label.name, label);
+}
+
+for (const item of items) {
+  for (const labelName of item.github.labels) {
+    const label = labelsToSync.get(labelName);
+    if (label) {
+      await ensureLabel({ owner, repo, token, label });
+    }
+  }
+}
+
+let changed = false;
+for (const item of items) {
+  const payload = {
+    title: item.title,
+    body: renderIssueBody(item, roadmap),
+    labels: item.github.labels
+  };
+
+  if (item.github.issue) {
+    const issue = await github(`PATCH /repos/${owner}/${repo}/issues/${item.github.issue}`, {
+      token,
+      body: payload
+    });
+    console.log(`updated #${issue.number} :: ${item.id}`);
+    continue;
+  }
+
+  const issue = await github(`POST /repos/${owner}/${repo}/issues`, {
+    token,
+    body: payload
+  });
+  console.log(`created #${issue.number} :: ${item.id}`);
+  item.github.issue = issue.number;
+  changed = true;
+}
+
+if (writeBack && changed) {
+  await writeFile(ROADMAP_FILE, JSON.stringify(roadmap, null, 2) + "\n");
+  console.log(`wrote ${relFromRoot(ROADMAP_FILE)}`);
+}
+
+function readFlag(name) {
+  const entry = args.find((arg) => arg.startsWith(`${name}=`));
+  return entry ? entry.slice(name.length + 1) : null;
+}
+
+async function ensureLabel({ owner, repo, token, label }) {
+  try {
+    await github(`POST /repos/${owner}/${repo}/labels`, {
+      token,
+      body: label
+    });
+    console.log(`created label ${label.name}`);
+  } catch (error) {
+    if (error.status !== 422) throw error;
+    const encoded = new URLSearchParams({ name: label.name }).get("name");
+    await github(`PATCH /repos/${owner}/${repo}/labels/${encoded}`, {
+      token,
+      body: {
+        new_name: label.name,
+        color: label.color,
+        description: label.description
+      }
+    });
+    console.log(`updated label ${label.name}`);
+  }
+}
+
+async function github(route, { token, body } = {}) {
+  const [method, path] = route.split(" ", 2);
+  const response = await fetch(`https://api.github.com${path}`, {
+    method,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "User-Agent": "cmvan-keynote-roadmap-sync"
+    },
+    body: body ? JSON.stringify(body) : undefined
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    const error = new Error(`${method} ${path} failed: ${response.status} ${text}`);
+    error.status = response.status;
+    throw error;
+  }
+
+  return response.status === 204 ? null : response.json();
+}

--- a/tests/roadmap-contract.test.mjs
+++ b/tests/roadmap-contract.test.mjs
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loadRoadmap, renderIssueBody, validateRoadmap } from "../scripts/lib/roadmap.mjs";
+
+test("roadmap registry is valid", async () => {
+  const roadmap = await loadRoadmap();
+  const errors = await validateRoadmap(roadmap);
+  assert.deepEqual(errors, []);
+});
+
+test("rendered roadmap issue bodies include stable metadata and delivery sections", async (t) => {
+  const roadmap = await loadRoadmap();
+
+  for (const item of roadmap.items) {
+    await t.test(item.id, () => {
+      const body = renderIssueBody(item, roadmap);
+      assert.match(body, new RegExp(`roadmap-id: ${item.id}`));
+      assert.match(body, /## Acceptance Criteria/);
+      assert.match(body, /## Eval Commands/);
+      assert.match(body, /## Tests/);
+      assert.match(body, /## Relevant Paths/);
+      for (const command of item.evals) {
+        assert.match(body, new RegExp(escapeRegExp(command)));
+      }
+    });
+  }
+});
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/tests/site-contract.test.mjs
+++ b/tests/site-contract.test.mjs
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, "..");
+const SITE = resolve(ROOT, "site");
+
+test("static site routes resolve to committed files", async (t) => {
+  const routes = await collectRoutes();
+  for (const route of routes) {
+    await t.test(route, async () => {
+      const filePath = routeToFile(route);
+      const fileStat = await stat(filePath);
+      assert.ok(fileStat.isFile());
+    });
+  }
+});
+
+test("html references resolve to committed local assets", async (t) => {
+  const htmlFiles = await collectHtmlFiles();
+
+  for (const htmlFile of htmlFiles) {
+    await t.test(htmlFile, async () => {
+      const content = await readFile(resolve(SITE, htmlFile), "utf8");
+
+      for (const ref of extractLocalRefs(content)) {
+        const filePath = routeToFile(ref);
+        if (!filePath) continue;
+        const response = await readFile(filePath, "utf8").catch(() => null);
+        assert.ok(response !== null, `${ref} referenced by ${htmlFile} is missing`);
+      }
+
+      for (const partial of extractPartials(content)) {
+        const partialPath = resolve(SITE, "partials", `${partial}.html`);
+        const response = await readFile(partialPath, "utf8").catch(() => null);
+        assert.ok(response !== null, `partial ${partial}.html referenced by ${htmlFile} is missing`);
+      }
+    });
+  }
+});
+
+async function collectRoutes() {
+  const rootHtml = await readdir(SITE);
+  const widgetHtml = await readdir(resolve(SITE, "widgets"));
+  const dataFiles = await readdir(resolve(SITE, "data"));
+  const partialFiles = await readdir(resolve(SITE, "partials"));
+
+  return [
+    "/",
+    ...rootHtml.filter((name) => name.endsWith(".html") && name !== "index.html").map((name) => `/${name}`),
+    ...widgetHtml.filter((name) => name.endsWith(".html")).map((name) => `/widgets/${name}`),
+    ...dataFiles.filter((name) => name.endsWith(".json")).map((name) => `/data/${name}`),
+    ...partialFiles.filter((name) => name.endsWith(".html")).map((name) => `/partials/${name}`)
+  ].sort();
+}
+
+async function collectHtmlFiles() {
+  const rootHtml = (await readdir(SITE)).filter((name) => name.endsWith(".html")).map((name) => name);
+  const widgetHtml = (await readdir(resolve(SITE, "widgets")))
+    .filter((name) => name.endsWith(".html"))
+    .map((name) => `widgets/${name}`);
+  return [...rootHtml, ...widgetHtml].sort();
+}
+
+function extractLocalRefs(content) {
+  const refs = new Set();
+  const regex = /\b(?:src|href)=["'](\/[^"'?#]+)["']/g;
+  for (const match of content.matchAll(regex)) {
+    refs.add(match[1]);
+  }
+  return [...refs];
+}
+
+function extractPartials(content) {
+  const partials = new Set();
+  const regex = /data-include=["']([^"']+)["']/g;
+  for (const match of content.matchAll(regex)) {
+    partials.add(match[1]);
+  }
+  return [...partials];
+}
+
+function routeToFile(route) {
+  if (route === "/") return resolve(SITE, "index.html");
+  return resolve(SITE, `.${route}`);
+}


### PR DESCRIPTION
## Summary

Sets up the repo-side Linear/GitHub delivery pipeline for the Punk Rock AI portal.

## Tracking

- Linear project: [Punk Rock AI Portal](https://linear.app/bc-ai/project/punk-rock-ai-portal-e9aec6edd886)
- Seeded Linear issues: `BC-8` through `BC-16`
- GitHub issues updated: `#8` through `#16`

## What Changed

- Added `ops/roadmap/features.json` as the machine-readable backlog with acceptance criteria, eval commands, tests, blockers, GitHub issue numbers, and Linear issue IDs.
- Added `npm run eval` plus roadmap, site data, JS syntax, and static route/link contract checks.
- Added GitHub Actions for CI and roadmap issue sync.
- Added GitHub issue and PR templates for eval-driven delivery.
- Documented the operating model in `docs/LINEAR-GITHUB-PIPELINE.md`, `docs/PROJECT-ROADMAP.md`, and `SESSION-HANDOFF.md`.

## Eval

- [x] `npm run eval`
- [x] `npm run sync:github:dry -- --id=portal-phase-2-taste-audit`
- [x] Linear project and issues created via Codex Linear plugin
- [x] GitHub issue bodies refreshed for `#8` through `#16`

## Remaining Account Setup

- Enable Linear's account-level GitHub integration for `WalksWithASwagger/cmvan-keynote` in Linear's UI.
- Re-auth local `gh` if local CLI-based GitHub sync is needed.
- Provide Cloudflare, Anthropic, Notion, and ElevenLabs credentials for blocked deployed worker/audio items.