### PR TITLE
BC-17 Verify Linear GitHub PR linking

### DIFF
--- a/docs/LINEAR-GITHUB-PIPELINE.md
+++ b/docs/LINEAR-GITHUB-PIPELINE.md
@@ -43,6 +43,8 @@ Linear project: [Punk Rock AI Portal](https://linear.app/bc-ai/project/punk-rock
 5. Implement the change, run `npm run eval`, and open a PR with the repo template.
 6. When the PR lands, update [`docs/PROJECT-ROADMAP.md`](./PROJECT-ROADMAP.md) and [`SESSION-HANDOFF.md`](../SESSION-HANDOFF.md) if the change altered scope, status, or blockers.
 
+Branch names should keep the repo prefix and include the Linear key, for example `codex/bc-17-verify-linear-github-pr-linking`.
+
 ## Commands
 
 ```sh


### PR DESCRIPTION
## Summary

Smoke test for Linear's GitHub integration. This PR intentionally includes `BC-17` in the branch, title, and body so Linear should attach it to [BC-17](https://linear.app/bc-ai/issue/BC-17/verify-linear-github-pr-linking).

## Tracking

- Linear issue: [BC-17](https://linear.app/bc-ai/issue/BC-17/verify-linear-github-pr-linking)
- Parent setup PR: #120

## What Changed

- Documents the repo's branch naming convention for Linear-linked work: keep the `codex/` prefix and include the Linear issue key.

## Eval

- [x] `npm run eval`

## Integration Check

- [x] Confirm this PR appears on BC-17 in Linear.