### PR TITLE
[codex] Add route nav widget contract checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ python3 -m http.server 7772 --directory assets/generated/slides
 
 Static site, no bundler. Each script reads source files in the repo and writes JSON/XML into `site/`. Re-run after editing the relevant inputs.
 
-Run `npm run eval` before pushing. It checks JavaScript syntax, JSON manifests, the Linear/GitHub roadmap map, local site references, header routes, and static Vercel config without needing credentials or a running server.
+Run `npm run eval` before pushing. It checks JavaScript syntax, JSON manifests, the Linear/GitHub roadmap map, local site references, header routes, advertised widget nav/CSS/JS/clean-URL contracts, and static Vercel config without needing credentials or a running server.
 
 | Command | Output | Inputs |
 |---------|--------|--------|

--- a/scripts/eval.mjs
+++ b/scripts/eval.mjs
@@ -17,6 +17,7 @@ const CHECKS = [
   ["roadmap pipeline", checkRoadmapPipeline],
   ["site references", checkSiteReferences],
   ["header navigation", checkHeaderNavigation],
+  ["route nav widget contracts", checkRouteNavWidgetContracts],
   ["Vercel static config", checkVercelConfig],
 ];
 
@@ -157,6 +158,77 @@ function checkHeaderNavigation() {
   }
 }
 
+function checkRouteNavWidgetContracts() {
+  const homeFile = "site/index.html";
+  const headerFile = "site/partials/header.html";
+  const redirectsFile = "site/_redirects";
+
+  const homeWidgetRoutes = new Set(extractWidgetRoutes(homeFile));
+  const headerAnchors = extractAnchors(readFileSync(abs(headerFile), "utf8"));
+  const headerWidgetRoutes = new Set(
+    headerAnchors
+      .map((anchor) => anchor.href)
+      .filter((href) => isCanonicalWidgetRoute(href)),
+  );
+  const redirectContracts = parseRedirectContracts(redirectsFile);
+
+  for (const anchor of headerAnchors) {
+    if (!anchor.href?.startsWith("/widgets/")) continue;
+    if (anchor.href !== anchor.dataRoute) {
+      failures.push(`${headerFile}: widget nav href ${anchor.href} must match data-route`);
+    }
+  }
+
+  for (const route of homeWidgetRoutes) {
+    const target = resolveSiteRef(route, homeFile);
+    if (!target || !existsSync(abs(target))) {
+      failures.push(`${homeFile}: advertised widget route missing file ${route} -> ${target}`);
+    } else {
+      checkWidgetAssetContract(route, target);
+    }
+    if (!headerWidgetRoutes.has(route)) {
+      failures.push(`${headerFile}: missing widget nav route ${route}`);
+    }
+
+    const cleanRoute = route.replace(/\.html$/, "");
+    const hasCleanRedirect = redirectContracts.some((contract) => (
+      contract.source === cleanRoute &&
+      contract.target === route &&
+      contract.status === "200"
+    ));
+    if (!hasCleanRedirect) {
+      failures.push(`${redirectsFile}: missing clean widget redirect ${cleanRoute} ${route} 200`);
+    }
+  }
+
+  for (const route of headerWidgetRoutes) {
+    if (!homeWidgetRoutes.has(route)) {
+      failures.push(`${homeFile}: widget nav route not advertised ${route}`);
+    }
+  }
+
+  for (const contract of redirectContracts) {
+    const target = resolveSiteRef(contract.target, redirectsFile);
+    if (!target || !existsSync(abs(target))) {
+      failures.push(`${redirectsFile}: widget redirect target missing ${contract.source} -> ${contract.target}`);
+    }
+  }
+}
+
+function checkWidgetAssetContract(route, file) {
+  const refs = extractAttributeRefs(readFileSync(abs(file), "utf8"));
+  const slug = path.basename(route, ".html");
+  const expectedCss = `/css/widgets/${slug}.css`;
+  const expectedJs = `/js/widgets/${slug}.js`;
+
+  if (!refs.includes(expectedCss)) {
+    failures.push(`${file}: missing widget CSS contract ${expectedCss}`);
+  }
+  if (!refs.includes(expectedJs)) {
+    failures.push(`${file}: missing widget JS contract ${expectedJs}`);
+  }
+}
+
 function checkVercelConfig() {
   const file = "vercel.json";
   let config;
@@ -184,6 +256,52 @@ function extractAttributeRefs(source) {
   let match;
   while ((match = pattern.exec(source))) refs.push(match[1]);
   return refs;
+}
+
+function extractAnchors(source) {
+  const anchors = [];
+  const pattern = /<a\b([^>]*)>/g;
+  let match;
+  while ((match = pattern.exec(source))) {
+    const attrs = match[1];
+    anchors.push({
+      href: extractAttribute(attrs, "href"),
+      dataRoute: extractAttribute(attrs, "data-route"),
+    });
+  }
+  return anchors;
+}
+
+function extractAttribute(source, name) {
+  const pattern = new RegExp(`\\b${name}=["']([^"']+)["']`);
+  return pattern.exec(source)?.[1] || "";
+}
+
+function extractWidgetRoutes(file) {
+  return extractAttributeRefs(readFileSync(abs(file), "utf8"))
+    .filter(isCanonicalWidgetRoute)
+    .sort();
+}
+
+function isCanonicalWidgetRoute(ref) {
+  return /^\/widgets\/[a-z0-9-]+\.html$/.test(ref);
+}
+
+function parseRedirectContracts(file) {
+  const source = readFileSync(abs(file), "utf8");
+  const contracts = [];
+
+  for (const line of source.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const [sourceRoute, target, status] = trimmed.split(/\s+/);
+    if (sourceRoute?.startsWith("/widgets/") && target?.startsWith("/widgets/")) {
+      contracts.push({ source: sourceRoute, target, status });
+    }
+  }
+
+  return contracts;
 }
 
 function extractCssUrlRefs(source) {

--- a/site/_redirects
+++ b/site/_redirects
@@ -10,19 +10,33 @@
 /workshop         /workshop.html         200
 /widgets/three-documents     /widgets/three-documents.html     200
 /widgets/both-hands          /widgets/both-hands.html          200
+/widgets/cut-up              /widgets/cut-up.html              200
+/widgets/selector            /widgets/selector.html            200
+/widgets/voice-clone-booth   /widgets/voice-clone-booth.html   200
+/widgets/manifesto           /widgets/manifesto.html           200
+/widgets/sig                 /widgets/sig.html                 200
+/widgets/receipt-print       /widgets/receipt-print.html       200
+/widgets/detournement        /widgets/detournement.html        200
+/widgets/bias-bingo          /widgets/bias-bingo.html          200
 /widgets/name-what-you-see   /widgets/name-what-you-see.html   200
+/widgets/word-ban            /widgets/word-ban.html            200
+/widgets/tool-not-neutral    /widgets/tool-not-neutral.html    200
+/widgets/in-there            /widgets/in-there.html            200
 /widgets/taste-audit         /widgets/taste-audit.html         200
+/widgets/cutting-room        /widgets/cutting-room.html        200
 /widgets/pattern-finder      /widgets/pattern-finder.html      200
 /widgets/junior-pipeline     /widgets/junior-pipeline.html     200
 /widgets/pattern-graph       /widgets/pattern-graph.html       200
 /widgets/chainsaws           /widgets/chainsaws.html           200
 /widgets/mastery-gym         /widgets/mastery-gym.html         200
 /widgets/receipt             /widgets/receipt.html             200
-/widgets/detournement        /widgets/detournement.html        200
 /widgets/posse-builder       /widgets/posse-builder.html       200
+/widgets/both-hands-gallery  /widgets/both-hands-gallery.html  200
+/widgets/releases-wall       /widgets/releases-wall.html       200
+/widgets/crit                /widgets/crit.html                200
 /widgets/posse-graph         /widgets/posse-builder.html       200
 /widgets/posse-graph.html    /widgets/posse-builder.html       200
-/widgets/in-there            /widgets/in-there.html            200
+/widgets/action              /widgets/action.html              200
 
 # If an old companion-site path leaks, route home.
 /companion-site/*           /                                  301


### PR DESCRIPTION
Closes #137

## What changed
- Added a route/nav/widget contract check to `npm run eval`.
- Validates advertised widget routes against homepage cards, header nav `data-route` entries, widget HTML files, named widget CSS/JS assets, and clean `_redirects` aliases.
- Added missing clean URL aliases for advertised widgets and documented the expanded local gate.

## Validation
- `npm run eval`

Draft PR for swarm review; not ready for merge.