### PR TITLE
[codex] Batch issue swarm widgets and release ops

### DIFF
--- a/OPEN-QUESTIONS.md
+++ b/OPEN-QUESTIONS.md
@@ -52,12 +52,20 @@ The load-bearing close was **Release Day / May 29** — ship something, punkrock
 
 ---
 
-## 6. Adobe involvement? — **NEEDS POST-TALK UPDATE**
+## 6. Adobe involvement? — **BLOCKED ON NAMED CONFIRMATION (2026-05-08)**
 
-Talk happened May 1. Fill in what actually played out with Mark re: Adobe's role.
+Talk happened May 1. The repo should not claim Adobe sponsorship, recording
+support, distribution, or approval until Mark Busse or another named Creative
+Mornings Vancouver contact confirms the actual role. Until then, use neutral
+phrasing such as "CreativeMornings Vancouver talk" and avoid Adobe-specific
+public copy.
 
 ---
 
-## 7. Recording rights — **NEEDS POST-TALK UPDATE**
+## 7. Recording rights — **BLOCKED ON NAMED CONFIRMATION (2026-05-08)**
 
-Talk happened May 1. Fill in: Was it recorded? Who owns it? Release timeline? Can you use clips now?
+Talk happened May 1. The repo does not yet have confirmed recording owner,
+release timeline, or clip permissions. Do not publish talk video clips, voice
+audio, or recording-derived transcripts until the owner and permitted uses are
+named. Photo-forward recap and slide/source-backed publishing can continue
+without implying recording rights.

--- a/docs/LINEAR-GITHUB-PIPELINE.md
+++ b/docs/LINEAR-GITHUB-PIPELINE.md
@@ -27,13 +27,13 @@ planning. The current execution project is:
 
 | Wave | GitHub | Linear | Priority | Status |
 | --- | --- | --- | --- | --- |
-| Wave 0 | [#133](https://github.com/WalksWithASwagger/cmvan-keynote/issues/133) | [BC-50](https://linear.app/bc-ai/issue/BC-50/roadmap-p0-reconcile-vercel-production-and-cloudflare-fallback-docs) | P0 | In review |
-| Wave 1 | [#135](https://github.com/WalksWithASwagger/cmvan-keynote/issues/135) | [BC-51](https://linear.app/bc-ai/issue/BC-51/roadmap-p0-smoke-test-release-day-submissions-end-to-end) | P0 | Todo |
+| Wave 0 | [#133](https://github.com/WalksWithASwagger/cmvan-keynote/issues/133) | [BC-50](https://linear.app/bc-ai/issue/BC-50/roadmap-p0-reconcile-vercel-production-and-cloudflare-fallback-docs) | P0 | Done |
+| Wave 1 | [#135](https://github.com/WalksWithASwagger/cmvan-keynote/issues/135) | [BC-51](https://linear.app/bc-ai/issue/BC-51/roadmap-p0-smoke-test-release-day-submissions-end-to-end) | P0 | In review |
 | Wave 1 | [#136](https://github.com/WalksWithASwagger/cmvan-keynote/issues/136) | [BC-52](https://linear.app/bc-ai/issue/BC-52/roadmap-p0-resolve-adobe-involvement-and-recording-rights) | P0 | Needs human |
-| Wave 1 | [#134](https://github.com/WalksWithASwagger/cmvan-keynote/issues/134) | [BC-53](https://linear.app/bc-ai/issue/BC-53/roadmap-p1-publish-moderation-to-gallery-loop-for-release-day) | P1 | Todo |
-| Wave 0 | [#137](https://github.com/WalksWithASwagger/cmvan-keynote/issues/137) | [BC-54](https://linear.app/bc-ai/issue/BC-54/roadmap-p1-add-route-nav-widget-contract-checker) | P1 | In review |
-| Wave 2 | [#138](https://github.com/WalksWithASwagger/cmvan-keynote/issues/138) | [BC-55](https://linear.app/bc-ai/issue/BC-55/roadmap-p1-browser-qa-and-lighthouse-pass-for-core-flows) | P1 | Todo |
-| Wave 3 | [#139](https://github.com/WalksWithASwagger/cmvan-keynote/issues/139) | [BC-56](https://linear.app/bc-ai/issue/BC-56/roadmap-p1-decide-pattern-finder-production-backend-path) | P1 | Needs human |
+| Wave 1 | [#134](https://github.com/WalksWithASwagger/cmvan-keynote/issues/134) | [BC-53](https://linear.app/bc-ai/issue/BC-53/roadmap-p1-publish-moderation-to-gallery-loop-for-release-day) | P1 | In review |
+| Wave 0 | [#137](https://github.com/WalksWithASwagger/cmvan-keynote/issues/137) | [BC-54](https://linear.app/bc-ai/issue/BC-54/roadmap-p1-add-route-nav-widget-contract-checker) | P1 | Done |
+| Wave 2 | [#138](https://github.com/WalksWithASwagger/cmvan-keynote/issues/138) | [BC-55](https://linear.app/bc-ai/issue/BC-55/roadmap-p1-browser-qa-and-lighthouse-pass-for-core-flows) | P1 | In review |
+| Wave 3 | [#139](https://github.com/WalksWithASwagger/cmvan-keynote/issues/139) | [BC-56](https://linear.app/bc-ai/issue/BC-56/roadmap-p1-decide-pattern-finder-production-backend-path) | P1 | In review |
 
 ## Branch and PR rules
 

--- a/docs/PROJECT-AUDIT-2026-05-08.md
+++ b/docs/PROJECT-AUDIT-2026-05-08.md
@@ -46,8 +46,9 @@ roadmap config, static-site contracts, and package/config files.
   human answer before copy can be finalized.
 - `BC-55` / GitHub #138: browser/Lighthouse evidence is still a separate QA
   pass.
-- `BC-56` / GitHub #139: Pattern Finder backend choice needs a hosting/API
-  decision before implementation.
+- `BC-56` / GitHub #139: Pattern Finder is decision-ready as fallback-only
+  for Release Day; a future live backend still needs explicit hosting/API,
+  model-budget, rate-limit, privacy, and abuse-control acceptance.
 
 ## Verification
 

--- a/docs/PROJECT-ROADMAP.md
+++ b/docs/PROJECT-ROADMAP.md
@@ -141,7 +141,7 @@ Phase 1 outputs verified: every route returns 200, every JS module passes `node 
 
 | Issue | Title | Status | Notes |
 |-------|-------|--------|-------|
-| [#13](https://github.com/WalksWithASwagger/cmvan-keynote/issues/13) | Pattern Finder LLM | 🟡 scaffold | Cloudflare Worker + Anthropic. Blocked on API key + CF account |
+| [#13](https://github.com/WalksWithASwagger/cmvan-keynote/issues/13) | Pattern Finder LLM | 🟡 fallback-only | Release Day path is copy-paste/local-only; Cloudflare Worker remains a later opt-in once model budget, rate limits, privacy copy, and abuse controls are accepted |
 | [#14](https://github.com/WalksWithASwagger/cmvan-keynote/issues/14) | Release Day portal | 🟡 live path, smoke needed | Vercel `/api/submissions` writes to Notion when env vars are configured; end-to-end production smoke test tracked in #135 / BC-51 |
 | [#15](https://github.com/WalksWithASwagger/cmvan-keynote/issues/15) | `/posse` audience map | 🔄 | 20 hand-curated profiles from `research/audience-rsvp-may1.md` |
 | [#16](https://github.com/WalksWithASwagger/cmvan-keynote/issues/16) | Decisions log | 🔄 | Renders `OPEN-QUESTIONS.md` + `SESSION-HANDOFF.md` |
@@ -150,7 +150,7 @@ Phase 1 outputs verified: every route returns 200, every JS module passes `node 
 
 - **R2 + slide imagery:** Cloudflare account with R2, an Object R/W token, bucket name, public URL prefix. Path to local slide source folder set as `SLIDES_SRC`. Once landed: `npm run ingest:slides`.
 - **ElevenLabs run:** `python3 dress-rehearsal/generate-audio.py` to generate mp3s, upload per-slide clips to R2, re-run `npm run build:audio`. The `/talk` page wires up automatically.
-- **Pattern Finder backend decision:** choose Cloudflare Worker, Vercel function, or fallback-only path before deploying live calls (#139 / BC-56).
+- **Pattern Finder backend decision:** fallback-only for the Release Day push; revisit Cloudflare Worker or Vercel function only after accepting model budget, rate limits, privacy copy, and abuse controls (#139 / BC-56).
 - **OPEN-QUESTIONS.md Q6 + Q7** — fill in Adobe involvement and recording rights post-talk.
 - **punk.ceo / plump.co** — decide routing per domains table and configure at registrar.
 

--- a/docs/RELEASE-DAY-OPERATIONS.md
+++ b/docs/RELEASE-DAY-OPERATIONS.md
@@ -1,0 +1,81 @@
+# Release Day Operations
+
+Current as of 2026-05-08.
+
+## Submission Path
+
+Production uses the Vercel function at `/api/submissions`.
+
+Required Vercel environment variables:
+
+- `NOTION_TOKEN`
+- `NOTION_DB_ID`
+
+Expected browser-to-Notion flow:
+
+1. A visitor submits the `/release-day` form.
+2. `api/submissions.js` validates `name`, `url`, and `what`.
+3. A valid submission creates a Notion page with `Published: false` and
+   `Status: pending`.
+4. The operator reviews the Notion row.
+5. When the work is ready to show, set `Status: approved` and `Published: true`.
+6. `/release-day` reads published rows from `GET /api/submissions`.
+
+If the Vercel env vars are missing, `POST /api/submissions` returns
+`202` with `status: queued-no-backend`; the browser adds the submission to
+the local pending queue and leaves the draft available for retry.
+If the live gallery API returns no rows, the page falls back to
+`site/data/submissions.json`.
+
+## Smoke Test
+
+Run this against a Vercel preview or production URL after confirming the env
+vars are configured:
+
+```sh
+curl -i https://punkrockai.com/api/submissions \
+  -H 'content-type: application/json' \
+  -d '{"name":"Smoke Test","url":"https://example.com/release-day-smoke","what":"Smoke-test artifact","why":"Verifies the moderation queue."}'
+```
+
+Expected result:
+
+- HTTP 200 with `status: pending` and a Notion page id.
+- The Notion row has `Published: false`.
+- Invalid `name`, `url`, or `what` values return HTTP 400.
+
+Record the exact smoke-test date, environment, and Notion row result in issue
+#135 before closing it.
+
+## Gallery Publishing
+
+The chosen publishing path is live Notion read through the existing Vercel API,
+with static JSON as a fallback.
+
+Operator checklist:
+
+1. Review new rows in the Release Day Notion database.
+2. Fix obvious title/link formatting if needed.
+3. Confirm the linked work is public and appropriate for the gallery.
+4. Set `Status: approved`.
+5. Set `Published: true`.
+6. Refresh `/release-day` and confirm the card appears.
+
+Rollback / unpublish:
+
+1. Set `Published: false` on the Notion row.
+2. Optionally set `Status: hidden`, `rejected`, or another operator-visible
+   non-public state.
+3. Refresh `/release-day` and confirm the card disappears from the gallery.
+
+Static fallback:
+
+- Use `site/data/submissions.json` only when the API is unavailable or when a
+  static export is intentionally preferred for a campaign day.
+- Keep `generated` and `moderation` fields current when editing the file.
+
+## Known Blockers
+
+- #135 still needs a real smoke test in preview or production with configured
+  Vercel env vars.
+- #136 still needs named answers for Adobe involvement and recording rights.

--- a/docs/ROADMAP-2026-05-07.md
+++ b/docs/ROADMAP-2026-05-07.md
@@ -61,9 +61,9 @@ The next phase is healthy when:
 
 ### What is still open
 
-- Release Day operations are not fully proven. `site/data/submissions.json`
-  is empty, and the moderation-to-gallery publishing loop is still described
-  as future cron/manual work.
+- Release Day operations are not fully proven. The chosen gallery path is live
+  `GET /api/submissions` with `site/data/submissions.json` as fallback, but a
+  real published-row smoke and rollback proof are still outstanding.
 - `OPEN-QUESTIONS.md` still needs post-talk updates for Adobe involvement and
   recording rights.
 - `docs/PROJECT-ROADMAP.md` still includes historical phase tables; use the
@@ -119,9 +119,9 @@ Target: now through May 29, 2026.
    - Write the exact moderation flow: pending -> published -> gallery.
 
 2. Publish the gallery loop.
-   - Choose one path: live GET from Notion via API, scheduled static pull into
-     `site/data/submissions.json`, or manual export during Release Week.
-   - Add an operator checklist for "publish today's submissions".
+   - Chosen path: live GET from Notion via Vercel API, with
+     `site/data/submissions.json` as a static fallback.
+   - Operator checklist lives in `docs/RELEASE-DAY-OPERATIONS.md`.
    - Decide what the empty-state should say before first public submission.
 
 3. Finish public-copy verification.
@@ -170,11 +170,10 @@ Target: after Wave 0, parallel with Release Day.
 Target: after Release Day ops are reliable.
 
 1. Decide Pattern Finder production path.
-   - Option A: deploy the Cloudflare Worker and wire `/api/pattern-finder`.
-   - Option B: rewrite as a Vercel function for one hosting model.
-   - Option C: keep it as copy-paste only and label it honestly.
-   - Verify the model name, cost controls, rate limits, cache, and privacy copy
-     before enabling live calls.
+   - Chosen path for Release Day: keep it copy-paste/fallback-only and label it
+     honestly.
+   - Revisit a live endpoint only after accepting model cost, rate limits,
+     cache, abuse controls, and privacy copy.
 
 2. Finish audio and slide media.
    - Generate per-slide cues with ElevenLabs only after voice/rights are clear.
@@ -239,10 +238,10 @@ Target: once the product push calms down.
 | P0 | Smoke test Release Day submission in production or preview. | New Notion row created with `Published: false`; invalid form cases fail cleanly. |
 | P0 | Update docs to Vercel-first, Cloudflare-fallback reality. | README, roadmap, deployment docs agree on host/API ownership. |
 | P0 | Resolve Adobe role and recording rights. | `OPEN-QUESTIONS.md` Q6/Q7 updated with dated answers. |
-| P1 | Build moderation-to-gallery publishing loop. | A published Notion item appears on `/release-day` gallery. |
+| P1 | Build moderation-to-gallery publishing loop. | A published Notion item appears on `/release-day` gallery via `GET /api/submissions`; static JSON remains fallback. |
 | P1 | Route/nav/widget contract check. | Script reports no missing targets or orphaned core assets. |
 | P1 | Lighthouse/accessibility pass on main flows. | Results captured with fixes or accepted exceptions. |
-| P1 | Decide Pattern Finder backend path. | Live endpoint works, or UI is relabeled fallback-only. |
+| P1 | Decide Pattern Finder backend path. | UI is relabeled fallback-only; live endpoint remains deferred. |
 | P2 | Audio cue generation and hosting. | `/talk` plays per-slide cues and degrades without audio. |
 | P2 | Long article and zine/PDF archive. | Public artifact shipped with citations and rights notes. |
 | P2 | Domain decisions for `punk.ceo` and `plump.co`. | DNS/routing documented and verified. |

--- a/ops/roadmap/features.json
+++ b/ops/roadmap/features.json
@@ -47,7 +47,7 @@
       "id": "vercel-cloudflare-docs",
       "priority": "P0",
       "wave": "Wave 0 - Repo trust and workflow",
-      "status": "in-review",
+      "status": "done",
       "github": {
         "number": 133,
         "title": "[Roadmap P0] Reconcile Vercel production and Cloudflare fallback docs",
@@ -60,7 +60,7 @@
       "pullRequest": {
         "number": 140,
         "url": "https://github.com/WalksWithASwagger/cmvan-keynote/pull/140",
-        "draft": true
+        "draft": false
       },
       "labels": [
         "repo:cmvan-keynote",
@@ -80,7 +80,7 @@
       "id": "release-day-submission-smoke",
       "priority": "P0",
       "wave": "Wave 1 - Release Day operations",
-      "status": "todo",
+      "status": "in-review",
       "github": {
         "number": 135,
         "title": "[Roadmap P0] Smoke test Release Day submissions end to end",
@@ -89,6 +89,11 @@
       "linear": {
         "identifier": "BC-51",
         "url": "https://linear.app/bc-ai/issue/BC-51/roadmap-p0-smoke-test-release-day-submissions-end-to-end"
+      },
+      "pullRequest": {
+        "number": 143,
+        "url": "https://github.com/WalksWithASwagger/cmvan-keynote/pull/143",
+        "draft": true
       },
       "labels": [
         "repo:cmvan-keynote",
@@ -137,7 +142,7 @@
       "id": "moderation-gallery-loop",
       "priority": "P1",
       "wave": "Wave 1 - Release Day operations",
-      "status": "todo",
+      "status": "in-review",
       "github": {
         "number": 134,
         "title": "[Roadmap P1] Publish moderation-to-gallery loop for Release Day",
@@ -167,7 +172,7 @@
       "id": "route-nav-widget-contract-checker",
       "priority": "P1",
       "wave": "Wave 0 - Repo trust and workflow",
-      "status": "in-review",
+      "status": "done",
       "github": {
         "number": 137,
         "title": "[Roadmap P1] Add route nav widget contract checker",
@@ -180,7 +185,7 @@
       "pullRequest": {
         "number": 140,
         "url": "https://github.com/WalksWithASwagger/cmvan-keynote/pull/140",
-        "draft": true
+        "draft": false
       },
       "labels": [
         "repo:cmvan-keynote",
@@ -202,7 +207,7 @@
       "id": "browser-qa-lighthouse",
       "priority": "P1",
       "wave": "Wave 2 - Portal hardening",
-      "status": "todo",
+      "status": "in-review",
       "github": {
         "number": 138,
         "title": "[Roadmap P1] Browser QA and Lighthouse pass for core flows",
@@ -211,6 +216,11 @@
       "linear": {
         "identifier": "BC-55",
         "url": "https://linear.app/bc-ai/issue/BC-55/roadmap-p1-browser-qa-and-lighthouse-pass-for-core-flows"
+      },
+      "pullRequest": {
+        "number": 142,
+        "url": "https://github.com/WalksWithASwagger/cmvan-keynote/pull/142",
+        "draft": true
       },
       "labels": [
         "repo:cmvan-keynote",
@@ -231,7 +241,7 @@
       "id": "pattern-finder-backend-decision",
       "priority": "P1",
       "wave": "Wave 3 - Connected intelligence and media",
-      "status": "needs-human",
+      "status": "in-review",
       "github": {
         "number": 139,
         "title": "[Roadmap P1] Decide Pattern Finder production backend path",
@@ -247,12 +257,12 @@
         "kind:ops",
         "area:workers",
         "area:infra",
-        "agent:needs-human"
+        "agent:ready"
       ],
       "acceptanceChecks": [
-        "A recommended backend path is documented with tradeoffs and owner.",
-        "Required env/deploy changes are named.",
-        "Follow-up implementation work is linked if this issue remains decision-only."
+        "Release Day fallback-only path is documented with tradeoffs and owner.",
+        "Future live-backend env/deploy changes are named.",
+        "Follow-up implementation work is linked if live calls become approved."
       ]
     }
   ]

--- a/site/_redirects
+++ b/site/_redirects
@@ -18,12 +18,15 @@
 /widgets/both-hands          /widgets/both-hands.html          200
 /widgets/both-hands-gallery  /widgets/both-hands-gallery.html  200
 /widgets/conductor           /widgets/conductor.html           200
+/widgets/conductor-ratio     /widgets/conductor-ratio.html     200
 /widgets/crit                /widgets/crit.html                200
 /widgets/cut-up              /widgets/cut-up.html              200
 /widgets/cutting-room        /widgets/cutting-room.html        200
+/widgets/cutting-room-buckets /widgets/cutting-room-buckets.html 200
 /widgets/name-what-you-see   /widgets/name-what-you-see.html   200
 /widgets/manifesto           /widgets/manifesto.html           200
 /widgets/receipt-print       /widgets/receipt-print.html       200
+/widgets/receipt-tells       /widgets/receipt-tells.html       200
 /widgets/taste-audit         /widgets/taste-audit.html         200
 /widgets/pattern-finder      /widgets/pattern-finder.html      200
 /widgets/junior-pipeline     /widgets/junior-pipeline.html     200
@@ -39,6 +42,7 @@
 /widgets/posse-graph         /widgets/posse-builder.html       200
 /widgets/posse-graph.html    /widgets/posse-builder.html       200
 /widgets/tool-not-neutral    /widgets/tool-not-neutral.html    200
+/widgets/tool-not-neutral-matrix /widgets/tool-not-neutral-matrix.html 200
 /widgets/voice-clone-booth   /widgets/voice-clone-booth.html   200
 /widgets/word-ban            /widgets/word-ban.html            200
 /widgets/in-there            /widgets/in-there.html            200

--- a/site/css/signal.css
+++ b/site/css/signal.css
@@ -64,7 +64,39 @@
   color: var(--muted);
   letter-spacing: 0.12em;
   text-transform: uppercase;
+  margin: 0 0 var(--space-4);
+}
+
+.signal__nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
   margin: 0 0 var(--space-6);
+}
+
+.signal__nav-link {
+  display: inline-grid;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  place-items: center;
+  border: 1px solid var(--border);
+  background: rgba(10, 10, 10, 0.7);
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.signal__nav-link:hover,
+.signal__nav-link:focus-visible,
+.signal__nav-link[aria-current] {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.signal__nav-link--today {
+  padding-inline: var(--space-3);
 }
 
 .signal__cta {

--- a/site/css/widgets/conductor-ratio.css
+++ b/site/css/widgets/conductor-ratio.css
@@ -1,0 +1,310 @@
+.cratio-hero {
+  position: relative;
+  overflow: hidden;
+  padding-block: var(--space-7) var(--space-5);
+  border-bottom: 3px solid var(--accent);
+}
+
+.cratio-hero .section-slide-bg {
+  opacity: 0.08;
+  mix-blend-mode: screen;
+}
+
+.cratio-hero .wrap {
+  position: relative;
+  z-index: 1;
+}
+
+.cratio-hero h1 {
+  font-size: var(--fs-2xl);
+  margin-bottom: var(--space-3);
+}
+
+.cratio-hero p:not(.kicker) {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.35;
+  max-width: 58ch;
+  color: var(--fg-soft);
+}
+
+.cratio-board {
+  padding-block: var(--space-5) var(--space-7);
+}
+
+.cratio-board__head {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--space-3);
+  align-items: end;
+  margin-bottom: var(--space-5);
+}
+
+.cratio-board__head h2 {
+  font-size: var(--fs-xl);
+  max-width: 20ch;
+}
+
+.cratio-board__readout {
+  border: 2px solid var(--accent);
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: var(--space-2) var(--space-3);
+  min-width: 25ch;
+  text-align: center;
+}
+
+.cratio-slider {
+  position: relative;
+  padding-block: var(--space-5) var(--space-6);
+  margin-bottom: var(--space-4);
+}
+
+.cratio-slider__track {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(var(--space-5) + 18px);
+  height: 12px;
+  background: var(--border);
+  overflow: hidden;
+}
+
+.cratio-slider__fill {
+  display: block;
+  width: 50%;
+  height: 100%;
+  background: var(--accent);
+  transition: width 80ms linear;
+}
+
+.cratio-slider__input {
+  position: relative;
+  z-index: 2;
+  display: block;
+  width: 100%;
+  height: 48px;
+  margin: 0;
+  appearance: none;
+  background: transparent;
+  cursor: grab;
+  touch-action: pan-y;
+}
+
+.cratio-slider__input:active {
+  cursor: grabbing;
+}
+
+.cratio-slider__input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 8px;
+}
+
+.cratio-slider__input::-webkit-slider-runnable-track {
+  height: 12px;
+  background: transparent;
+}
+
+.cratio-slider__input::-moz-range-track {
+  height: 12px;
+  background: transparent;
+}
+
+.cratio-slider__input::-webkit-slider-thumb {
+  appearance: none;
+  width: 36px;
+  height: 36px;
+  margin-top: -12px;
+  border: 3px solid var(--accent);
+  background: var(--bg);
+  box-shadow: 5px 5px 0 var(--fg);
+}
+
+.cratio-slider__input::-moz-range-thumb {
+  width: 30px;
+  height: 30px;
+  border: 3px solid var(--accent);
+  border-radius: 0;
+  background: var(--bg);
+  box-shadow: 5px 5px 0 var(--fg);
+}
+
+.cratio-slider__anchors {
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 46px;
+}
+
+.cratio-anchor {
+  position: absolute;
+  left: var(--x);
+  top: 0;
+  transform: translateX(-50%);
+  display: grid;
+  gap: var(--space-1);
+  justify-items: center;
+  min-width: 56px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.cratio-anchor__tick {
+  width: 2px;
+  height: 18px;
+  background: currentColor;
+}
+
+.cratio-anchor:hover,
+.cratio-anchor:focus-visible,
+.cratio-anchor[aria-current] {
+  color: var(--accent);
+}
+
+.cratio-anchor:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.cratio-card {
+  border: 1px solid var(--border);
+  background: var(--bg-soft, #111);
+  padding: var(--space-4);
+  display: grid;
+  gap: var(--space-4);
+}
+
+.cratio-card__main {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.cratio-card__tag,
+.cratio-card__source {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.cratio-card h3 {
+  font-size: var(--fs-xl);
+  margin: 0;
+}
+
+.cratio-card p {
+  margin: 0;
+  max-width: 68ch;
+  line-height: 1.5;
+}
+
+.cratio-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-2);
+  margin: 0;
+}
+
+.cratio-metrics div {
+  border-top: 1px dashed var(--border);
+  padding-top: var(--space-2);
+}
+
+.cratio-metrics dt {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.cratio-metrics dd {
+  margin: var(--space-1) 0 0;
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+}
+
+.cratio-metrics span {
+  display: block;
+  width: var(--w);
+  height: 6px;
+  margin-bottom: var(--space-1);
+  background: var(--accent);
+}
+
+.cratio-tradeoffs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.cratio-tradeoffs section {
+  border-left: 2px solid var(--accent);
+  padding-left: var(--space-3);
+}
+
+.cratio-tradeoffs h4 {
+  margin: 0 0 var(--space-1);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--accent);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.cratio-final {
+  padding-block: var(--space-6) var(--space-7);
+  border-top: 3px solid var(--accent);
+}
+
+.cratio-final h2 {
+  font-size: var(--fs-xl);
+  margin-bottom: var(--space-3);
+}
+
+.cratio-final__cite {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  margin-block: var(--space-3);
+}
+
+.cratio-final__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+@media (max-width: 760px) {
+  .cratio-board__head,
+  .cratio-metrics,
+  .cratio-tradeoffs {
+    grid-template-columns: 1fr;
+  }
+
+  .cratio-board__readout {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .cratio-anchor {
+    min-width: 44px;
+    font-size: 0.72rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cratio-slider__fill {
+    transition: none;
+  }
+}

--- a/site/css/widgets/cutting-room-buckets.css
+++ b/site/css/widgets/cutting-room-buckets.css
@@ -1,0 +1,279 @@
+.crb-intro {
+  position: relative;
+  overflow: hidden;
+  padding-block: var(--space-7) var(--space-5);
+  border-bottom: 3px solid var(--accent);
+}
+
+.crb-intro .wrap {
+  position: relative;
+  z-index: 1;
+}
+
+.crb-intro h1 {
+  margin: 0 0 var(--space-3);
+  max-width: 16ch;
+}
+
+.crb-intro__lede {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 52ch;
+  color: var(--fg-soft);
+  margin: 0 0 var(--space-3);
+}
+
+.crb-intro__neighbor {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.crb-intro__neighbor a {
+  color: var(--accent);
+}
+
+.crb-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 6;
+  padding-block: var(--space-3);
+  background: var(--bg);
+  border-bottom: 1px dashed var(--border-strong, rgba(255, 255, 255, 0.18));
+}
+
+.crb-toolbar .wrap {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.crb-counts,
+.crb-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.crb-counts {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+}
+
+.crb-counts strong {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  color: var(--accent);
+  letter-spacing: 0;
+}
+
+.crb-board {
+  display: grid;
+  grid-template-columns: minmax(18rem, 24rem) 1fr;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-3) var(--space-7);
+  max-width: 100rem;
+  margin-inline: auto;
+}
+
+.crb-pool,
+.crb-bucket {
+  background: var(--bg-elevated);
+  border: 1px solid var(--muted);
+  min-width: 0;
+}
+
+.crb-pool {
+  align-self: start;
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  max-height: calc(100vh - 9rem);
+  overflow: auto;
+}
+
+.crb-pool.is-over,
+.crb-bucket__drop.is-over {
+  outline: 3px solid var(--accent);
+  outline-offset: -3px;
+}
+
+.crb-pool__head {
+  display: grid;
+  gap: var(--space-1);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px dashed var(--border-strong, rgba(255, 255, 255, 0.18));
+}
+
+.crb-pool__head p {
+  margin: 0;
+}
+
+.crb-buckets {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.crb-bucket {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-height: 34rem;
+}
+
+.crb-bucket header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-bottom: 3px solid var(--accent);
+}
+
+.crb-bucket h2 {
+  margin: 0;
+  font-size: var(--fs-xl);
+}
+
+.crb-bucket__mark {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.18em;
+  color: var(--accent);
+}
+
+.crb-bucket__drop {
+  display: grid;
+  align-content: start;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  min-height: 20rem;
+}
+
+.crb-card {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  background: var(--bg);
+  border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.18));
+  cursor: grab;
+}
+
+.crb-card:hover,
+.crb-card:focus-within {
+  border-color: var(--accent);
+}
+
+.crb-card.is-dragging {
+  opacity: 0.48;
+}
+
+.crb-card__head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--accent);
+}
+
+.crb-card h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: var(--fs-md);
+  line-height: 1.15;
+}
+
+.crb-card p {
+  margin: 0;
+  color: var(--fg-soft);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+}
+
+.crb-card__moves {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.35rem;
+}
+
+.crb-card__moves button {
+  min-width: 0;
+  padding: 0.35rem 0.25rem;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-soft);
+  background: transparent;
+  border: 1px solid var(--muted);
+  cursor: pointer;
+}
+
+.crb-card__moves button:hover,
+.crb-card__moves button:focus-visible,
+.crb-card__moves button[aria-pressed="true"] {
+  color: var(--accent-ink);
+  background: var(--accent);
+  border-color: var(--accent);
+  outline: none;
+}
+
+.crb-empty {
+  margin: 0;
+  padding: var(--space-3);
+  border: 1px dashed var(--muted);
+  font-family: var(--font-display);
+  font-style: italic;
+  color: var(--muted);
+}
+
+@media (max-width: 70rem) {
+  .crb-board {
+    grid-template-columns: 1fr;
+  }
+
+  .crb-pool {
+    max-height: none;
+  }
+}
+
+@media (max-width: 48rem) {
+  .crb-toolbar {
+    position: static;
+  }
+
+  .crb-toolbar .wrap,
+  .crb-actions {
+    align-items: stretch;
+  }
+
+  .crb-actions,
+  .crb-actions .btn {
+    width: 100%;
+  }
+
+  .crb-buckets {
+    grid-template-columns: 1fr;
+  }
+
+  .crb-bucket {
+    min-height: 0;
+  }
+
+  .crb-card {
+    cursor: default;
+  }
+}

--- a/site/css/widgets/receipt-tells.css
+++ b/site/css/widgets/receipt-tells.css
@@ -1,0 +1,367 @@
+/* /widgets/receipt-tells.html — training-corpus heuristic receipt */
+
+.rctl-intro {
+  padding-block: var(--space-6);
+  border-bottom: 1px solid var(--border);
+}
+
+.rctl-intro h1 {
+  margin: 0 0 var(--space-3);
+  max-width: 18ch;
+}
+
+.rctl-intro__lede {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.3;
+  max-width: 52ch;
+  color: var(--fg-soft);
+}
+
+.rctl-intro__hint {
+  margin-top: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  max-width: 66ch;
+}
+
+.rctl-caveat {
+  background: var(--bg-elevated);
+  border-block: 2px solid var(--accent);
+  padding-block: var(--space-4);
+}
+
+.rctl-caveat__tag {
+  margin: 0 0 var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.rctl-caveat p {
+  font-family: var(--font-display);
+  font-size: var(--fs-md);
+  line-height: 1.45;
+  color: var(--fg);
+}
+
+.rctl-app {
+  padding-block: var(--space-5);
+}
+
+.rctl-layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-5);
+  align-items: start;
+}
+
+@media (min-width: 880px) {
+  .rctl-layout {
+    grid-template-columns: minmax(0, 1fr) minmax(20rem, 0.82fr);
+    gap: var(--space-6);
+  }
+}
+
+.rctl-panel {
+  font-family: var(--font-mono);
+}
+
+.rctl-h2 {
+  margin: 0 0 var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.rctl-textarea {
+  width: 100%;
+  min-height: 16rem;
+  padding: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+  background: #0d0d0d;
+  color: var(--fg);
+  border: 1px solid var(--border-strong);
+  border-radius: 0;
+  resize: vertical;
+}
+
+.rctl-textarea:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.rctl-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+}
+
+.rctl-status {
+  min-height: 1.2em;
+  margin-top: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.rctl-stage {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-block: var(--space-3);
+}
+
+.rctl-printer {
+  width: 100%;
+  max-width: 22rem;
+  height: 4.5rem;
+  background: linear-gradient(#2a2a2a, #1a1a1a);
+  border-radius: 6px 6px 2px 2px;
+  position: relative;
+  box-shadow:
+    inset 0 -2px 0 rgba(0, 0, 0, 0.6),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 4px 0 rgba(0, 0, 0, 0.4);
+  z-index: 2;
+}
+
+.rctl-printer::before {
+  content: "";
+  position: absolute;
+  top: 0.5rem;
+  left: 0.75rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: #d3504a;
+  box-shadow: 0 0 6px rgba(211, 80, 74, 0.6);
+}
+
+.rctl-printer__slot {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0;
+  height: 0.55rem;
+  background: #050505;
+  border-top: 1px solid #000;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.8);
+}
+
+.rctl-receipt {
+  --edge: polygon(
+    0 6px,
+    3% 0,
+    9% 5px,
+    16% 1px,
+    24% 5px,
+    33% 0,
+    41% 5px,
+    50% 1px,
+    59% 5px,
+    68% 0,
+    77% 5px,
+    86% 1px,
+    94% 5px,
+    100% 0,
+    100% calc(100% - 6px),
+    96% 100%,
+    89% calc(100% - 5px),
+    80% calc(100% - 1px),
+    71% calc(100% - 5px),
+    62% 100%,
+    53% calc(100% - 5px),
+    44% calc(100% - 1px),
+    35% calc(100% - 5px),
+    26% 100%,
+    17% calc(100% - 5px),
+    8% calc(100% - 1px),
+    2% calc(100% - 5px),
+    0 100%
+  );
+  width: 100%;
+  max-width: 22rem;
+  min-height: 28rem;
+  margin-top: -0.4rem;
+  padding: var(--space-4) var(--space-3) var(--space-3);
+  font-family: var(--font-mono);
+  color: #1a1a1a;
+  background-color: #f6f1e6;
+  background-image:
+    repeating-linear-gradient(
+      0deg,
+      rgba(0, 0, 0, 0.02) 0,
+      rgba(0, 0, 0, 0.02) 1px,
+      transparent 1px,
+      transparent 3px
+    );
+  clip-path: var(--edge);
+  box-shadow:
+    0 1px 0 rgba(0, 0, 0, 0.3),
+    6px 10px 0 rgba(0, 0, 0, 0.35);
+}
+
+.rctl-receipt p,
+.rctl-receipt li {
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-mono);
+  color: #1a1a1a;
+  font-size: 0.78rem;
+  line-height: 1.55;
+}
+
+.rctl-receipt__head {
+  text-align: center;
+  margin-bottom: var(--space-2);
+}
+
+.rctl-receipt__brand {
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  font-size: 0.85rem;
+}
+
+.rctl-receipt__sub {
+  letter-spacing: 0.14em;
+  font-size: 0.7rem;
+  opacity: 0.75;
+}
+
+.rctl-receipt__rule {
+  margin-block: 0.25rem;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  user-select: none;
+}
+
+.rctl-receipt__meta,
+.rctl-total,
+.rctl-line {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.rctl-ticket-section {
+  padding-block: var(--space-2);
+  border-top: 1px dashed rgba(26, 26, 26, 0.5);
+}
+
+.rctl-ticket-section:first-child {
+  border-top: 0;
+}
+
+.rctl-ticket-section--verdict {
+  margin-top: var(--space-1);
+  padding: var(--space-2);
+  border: 1px solid rgba(26, 26, 26, 0.7);
+}
+
+.rctl-label {
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.rctl-list {
+  list-style: none;
+  display: grid;
+  gap: 0.15rem;
+  margin: 0.2rem 0 0;
+  padding: 0;
+}
+
+.rctl-line span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.rctl-line strong,
+.rctl-total strong {
+  min-width: 2ch;
+  text-align: right;
+}
+
+.rctl-score {
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.rctl-note,
+.rctl-receipt__placeholder {
+  opacity: 0.72;
+}
+
+.rctl-receipt__foot {
+  margin-top: var(--space-2);
+  text-align: center;
+}
+
+.rctl-receipt__barcode {
+  margin-top: var(--space-1);
+  font-size: 1.25rem;
+  letter-spacing: 0.08em;
+  transform: scaleY(1.8);
+  transform-origin: center;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .rctl-ticket-section {
+    opacity: 0;
+    transform: translateY(-0.35rem);
+    animation: rctl-feed 180ms var(--ease-snap, ease-out) forwards;
+  }
+
+  .rctl-ticket-section:nth-child(2) {
+    animation-delay: 50ms;
+  }
+
+  .rctl-ticket-section:nth-child(3) {
+    animation-delay: 100ms;
+  }
+
+  .rctl-ticket-section:nth-child(4) {
+    animation-delay: 150ms;
+  }
+
+  .rctl-ticket-section:nth-child(5) {
+    animation-delay: 200ms;
+  }
+
+  .rctl-ticket-section:nth-child(6) {
+    animation-delay: 250ms;
+  }
+}
+
+@keyframes rctl-feed {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 560px) {
+  .rctl-receipt {
+    max-width: 100%;
+  }
+
+  .rctl-row .btn {
+    width: 100%;
+  }
+}

--- a/site/css/widgets/tool-not-neutral-matrix.css
+++ b/site/css/widgets/tool-not-neutral-matrix.css
@@ -1,0 +1,324 @@
+/* /widgets/tool-not-neutral-matrix.html */
+
+.tnnm-hero {
+  position: relative;
+  overflow: hidden;
+  padding-block: var(--space-6);
+  border-bottom: 1px solid var(--border);
+}
+
+.tnnm-hero .section-slide-bg {
+  opacity: 0.16;
+  background-position: center;
+}
+
+.tnnm-hero .wrap {
+  position: relative;
+  z-index: 1;
+}
+
+.tnnm-hero h1 {
+  margin: 0 0 var(--space-3);
+  max-width: 15ch;
+  color: var(--accent-pink);
+  font-size: var(--fs-2xl);
+}
+
+.tnnm-hero p:not(.kicker) {
+  max-width: 54ch;
+  color: var(--fg-soft);
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.35;
+}
+
+.tnnm {
+  padding-block: var(--space-5);
+}
+
+.tnnm__head {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+  border-bottom: 2px solid var(--accent);
+  padding-bottom: var(--space-2);
+}
+
+.tnnm__head h2 {
+  margin: 0;
+  font-size: var(--fs-xl);
+}
+
+.tnnm__hint,
+.tnnm__status {
+  margin: 0;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tnnm__status {
+  min-height: 1.4em;
+  margin-bottom: var(--space-2);
+  color: var(--accent);
+}
+
+.tnnm__matrix {
+  display: grid;
+  grid-template-columns: minmax(7.5rem, 0.85fr) repeat(5, minmax(8.5rem, 1fr));
+  gap: 1px;
+  overflow-x: auto;
+  border: 1px solid var(--border-strong);
+  background: var(--border-strong);
+}
+
+.tnnm__corner,
+.tnnm__axis-head,
+.tnnm__tool-head,
+.tnnm-cell,
+.tnnm__empty {
+  min-height: 7rem;
+  background: var(--bg);
+}
+
+.tnnm__corner,
+.tnnm__axis-head,
+.tnnm__tool-head {
+  display: grid;
+  align-content: center;
+  gap: 0.25rem;
+  padding: var(--space-2);
+}
+
+.tnnm__corner {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.tnnm__axis-head span,
+.tnnm__tool-head span {
+  color: var(--fg);
+  font-family: var(--font-display);
+  font-size: var(--fs-base);
+  line-height: 1.1;
+}
+
+.tnnm__axis-head small,
+.tnnm__tool-head small {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+
+.tnnm__tool-head {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  border-right: 2px solid var(--accent);
+}
+
+.tnnm-cell {
+  display: grid;
+  align-content: start;
+  gap: 0.35rem;
+  width: 100%;
+  border: 0;
+  border-left: 3px solid transparent;
+  padding: var(--space-2);
+  color: var(--fg-soft);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.16s ease, color 0.16s ease, border-color 0.16s ease, transform 0.16s ease;
+}
+
+.tnnm-cell:hover,
+.tnnm-cell:focus-visible,
+.tnnm-cell.is-active {
+  outline: none;
+  border-left-color: var(--accent);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--fg);
+  transform: translateY(-1px);
+}
+
+.tnnm-cell.is-active {
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.tnnm-cell__axis,
+.tnnm-cell__tool {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.1em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.tnnm-cell strong {
+  color: var(--fg);
+  font-family: var(--font-display);
+  font-size: var(--fs-base);
+  line-height: 1.15;
+}
+
+.tnnm-cell span:last-child {
+  display: -webkit-box;
+  overflow: hidden;
+  font-size: var(--fs-sm);
+  line-height: 1.3;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.tnnm-cell.is-active span:last-child,
+.tnnm-cell:hover span:last-child,
+.tnnm-cell:focus-visible span:last-child {
+  -webkit-line-clamp: 6;
+}
+
+.tnnm__detail {
+  display: grid;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+  border: 1px solid var(--border-strong);
+  border-left: 4px solid var(--accent);
+  background: var(--surface, rgba(255, 255, 255, 0.02));
+  padding: var(--space-4);
+  min-height: 18rem;
+  touch-action: pan-y;
+}
+
+.tnnm__detail h3 {
+  margin: 0;
+  font-size: var(--fs-xl);
+  line-height: 1.15;
+}
+
+.tnnm__detail dl {
+  display: grid;
+  gap: var(--space-3);
+  margin: 0;
+}
+
+.tnnm__detail dl div {
+  display: grid;
+  grid-template-columns: minmax(8rem, 12rem) 1fr;
+  gap: var(--space-3);
+  border: 1px dashed var(--border-strong);
+  border-left: 3px solid var(--fg-soft);
+  padding: var(--space-3);
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.tnnm__detail dt {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.tnnm__detail dd {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.35;
+}
+
+.tnnm__precise,
+.tnnm__cite {
+  margin: 0;
+  color: var(--fg-soft);
+  line-height: 1.45;
+}
+
+.tnnm__cite {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  word-break: break-word;
+}
+
+.tnnm__cite a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
+.tnnm__cite a:hover,
+.tnnm__cite a:focus-visible {
+  color: var(--accent);
+  outline: none;
+}
+
+.tnnm-coda {
+  padding-block: var(--space-6);
+  border-top: 1px solid var(--border);
+}
+
+.tnnm-coda p {
+  margin: 0;
+  max-width: 58ch;
+  color: var(--fg-soft);
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  line-height: 1.35;
+}
+
+@media (max-width: 860px) {
+  .tnnm__head {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .tnnm__matrix {
+    grid-template-columns: minmax(6rem, 0.75fr) repeat(5, minmax(7.25rem, 1fr));
+  }
+
+  .tnnm__corner,
+  .tnnm__axis-head,
+  .tnnm__tool-head,
+  .tnnm-cell,
+  .tnnm__empty {
+    min-height: 6.5rem;
+  }
+
+  .tnnm-cell span:last-child {
+    -webkit-line-clamp: 2;
+  }
+}
+
+@media (max-width: 640px) {
+  .tnnm__detail dl div {
+    grid-template-columns: 1fr;
+    gap: var(--space-2);
+  }
+
+  .tnnm__detail dd {
+    font-size: var(--fs-base);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tnnm-cell,
+  .tnnm__cite a {
+    transition: none;
+  }
+
+  .tnnm-cell:hover,
+  .tnnm-cell:focus-visible,
+  .tnnm-cell.is-active {
+    transform: none;
+  }
+}

--- a/site/css/widgets/word-ban.css
+++ b/site/css/widgets/word-ban.css
@@ -193,6 +193,35 @@
   margin-top: 0;
 }
 
+.wban__preset-mode {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-1);
+  margin: var(--space-2) 0 0;
+  padding: 0;
+  border: 0;
+}
+
+.wban__preset-mode label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: 2rem;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--fg-soft);
+}
+
+.wban__preset-mode label:has(input:checked) {
+  border-color: var(--accent);
+  color: var(--fg);
+}
+
 .wban__preset-blurb {
   font-family: var(--font-mono);
   font-size: var(--fs-xs);

--- a/site/data/ai-tells.json
+++ b/site/data/ai-tells.json
@@ -1,0 +1,79 @@
+{
+  "generated": "hand-curated",
+  "note": "Heuristic marker lists for /widgets/receipt-tells.html. Matches are non-definitive and should never be treated as authorship proof.",
+  "sample": "Certainly! In today's rapidly evolving digital landscape, it is important to leverage innovative strategies that optimize outcomes while ensuring a seamless user experience. This comprehensive guide will delve into the key considerations, explore best practices, and provide actionable insights. It is worth noting that every organization is unique, and results may vary depending on context.",
+  "phraseMatches": [
+    {
+      "id": "rapidly-evolving",
+      "label": "rapidly evolving landscape",
+      "pattern": "\\brapidly evolving (?:digital )?landscape\\b"
+    },
+    {
+      "id": "in-todays",
+      "label": "in today's ... landscape",
+      "pattern": "\\bin today'?s [\\w\\s-]{0,36}?landscape\\b"
+    },
+    {
+      "id": "it-is-important",
+      "label": "it is important to",
+      "pattern": "\\bit is important to\\b"
+    },
+    {
+      "id": "seamless",
+      "label": "seamless experience",
+      "pattern": "\\bseamless (?:user |customer )?experience\\b"
+    },
+    {
+      "id": "comprehensive-guide",
+      "label": "comprehensive guide",
+      "pattern": "\\bcomprehensive guide\\b"
+    },
+    {
+      "id": "key-considerations",
+      "label": "key considerations",
+      "pattern": "\\bkey considerations\\b"
+    },
+    {
+      "id": "actionable-insights",
+      "label": "actionable insights",
+      "pattern": "\\bactionable insights\\b"
+    },
+    {
+      "id": "best-practices",
+      "label": "best practices",
+      "pattern": "\\bbest practices\\b"
+    },
+    {
+      "id": "results-may-vary",
+      "label": "results may vary",
+      "pattern": "\\bresults may vary\\b"
+    },
+    {
+      "id": "worth-noting",
+      "label": "it is worth noting",
+      "pattern": "\\bit'?s? worth noting\\b|\\bit is worth noting\\b"
+    }
+  ],
+  "hedges": [
+    "may",
+    "might",
+    "could",
+    "can help",
+    "often",
+    "generally",
+    "typically",
+    "in many cases",
+    "it depends",
+    "depending on",
+    "worth noting",
+    "important to note",
+    "not necessarily",
+    "potentially",
+    "arguably"
+  ],
+  "watchedTerms": [
+    "delve",
+    "leverage",
+    "optimize"
+  ]
+}

--- a/site/data/conductor-tradeoffs.json
+++ b/site/data/conductor-tradeoffs.json
@@ -1,0 +1,60 @@
+{
+  "source": "source-material/kevin-friel-pixel-wizard/kevin-friel-full-feature-kk.md",
+  "title": "Conductor craft ratio",
+  "lede": "Move the baton between volume and taste. AI can flood the room with takes. The conductor decides how much craft survives the flood.",
+  "anchors": [
+    {
+      "value": 90,
+      "label": "90% machine throughput",
+      "tag": "Flood the room",
+      "throughput": "Maximum generation. More shots, drafts, alternates, and tests arrive before your coffee gets cold.",
+      "craft": "The human work shifts to triage: naming the brief, rejecting cheap-looking frames, and refusing to confuse abundance with finish.",
+      "cost": "Costs collapse toward the Kevin Friel receipt: six-figure video energy pushed toward a $200, 2.5-day experiment.",
+      "loss": "The loss is sameness. If the prompt is vague or the selector is tired, the pile gets bigger while the point gets thinner.",
+      "sourceNote": "Kevin's line: $100,000 budgets to $200 in 2.5 days, same quality, real project."
+    },
+    {
+      "value": 50,
+      "label": "50 / 50 studio",
+      "tag": "Trade passes",
+      "throughput": "The stack does the heavy lift: Midjourney frames, Runway motion, ElevenLabs audio, ComfyUI glue, Topaz polish.",
+      "craft": "The human stays in the loop for taste, timing, continuity, disclosure, and the final no. Tools get parts; you keep direction.",
+      "cost": "Budget and schedule still drop hard, but the savings fund iteration instead of replacing judgment.",
+      "loss": "The risk is workflow theatre: fancy nodes that break momentum, or too many passes that sand the idea flat.",
+      "sourceNote": "Kevin frames the work as chain thinking, not one app and pray."
+    },
+    {
+      "value": 10,
+      "label": "10% machine assist",
+      "tag": "Hands on the work",
+      "throughput": "Fewer outputs arrive, but each one carries more direct human intention and context.",
+      "craft": "Craft is high-touch: story, shot choice, edit rhythm, texture, and meaning are argued by people before tools are asked to help.",
+      "cost": "The budget climbs because human time returns to the center. Use this when the relationship, material, or risk demands it.",
+      "loss": "The loss is access. Some people and projects stay locked out when every step requires old-world time, gear, or specialist labor.",
+      "sourceNote": "Kevin's access argument: the barrier to entry disappeared; now ideas matter more than equipment."
+    }
+  ],
+  "metrics": {
+    "throughput": {
+      "low": "slow",
+      "high": "flood"
+    },
+    "craft": {
+      "low": "thin",
+      "high": "held"
+    },
+    "cost": {
+      "low": "cheap",
+      "high": "expensive"
+    },
+    "loss": {
+      "low": "low",
+      "high": "high"
+    }
+  },
+  "closing": {
+    "title": "The slider is not moral. The conductor is.",
+    "body": "A 90% machine pass can be generous when it gives access. A 10% machine pass can be necessary when the material needs hands. The craft is knowing which room you are in.",
+    "cite": "Kevin Friel material: source-material/kevin-friel-pixel-wizard/kevin-friel-full-feature-kk.md"
+  }
+}

--- a/site/data/decisions.json
+++ b/site/data/decisions.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-08T01:10:57.291Z",
+  "generated": "2026-05-08T04:30:17.153Z",
   "sources": {
     "openQuestions": "OPEN-QUESTIONS.md",
     "sessionHandoff": "SESSION-HANDOFF.md",
@@ -59,21 +59,21 @@
     },
     {
       "n": 6,
-      "id": "q-6-adobe-involvement-needs-post-talk-update",
-      "question": "Adobe involvement? — **NEEDS POST-TALK UPDATE**",
+      "id": "q-6-adobe-involvement-blocked-on-named-confirmation-2026-05-08",
+      "question": "Adobe involvement? — **BLOCKED ON NAMED CONFIRMATION (2026-05-08)**",
       "status": "open",
       "statusNote": null,
-      "body": "Talk happened May 1. Fill in what actually played out with Mark re: Adobe's role.",
-      "bodyHtml": "<p>Talk happened May 1. Fill in what actually played out with Mark re: Adobe's role.</p>"
+      "body": "Talk happened May 1. The repo should not claim Adobe sponsorship, recording\nsupport, distribution, or approval until Mark Busse or another named Creative\nMornings Vancouver contact confirms the actual role. Until then, use neutral\nphrasing such as \"CreativeMornings Vancouver talk\" and avoid Adobe-specific\npublic copy.",
+      "bodyHtml": "<p>Talk happened May 1. The repo should not claim Adobe sponsorship, recording<br>support, distribution, or approval until Mark Busse or another named Creative<br>Mornings Vancouver contact confirms the actual role. Until then, use neutral<br>phrasing such as \"CreativeMornings Vancouver talk\" and avoid Adobe-specific<br>public copy.</p>"
     },
     {
       "n": 7,
-      "id": "q-7-recording-rights-needs-post-talk-update",
-      "question": "Recording rights — **NEEDS POST-TALK UPDATE**",
+      "id": "q-7-recording-rights-blocked-on-named-confirmation-2026-05-08",
+      "question": "Recording rights — **BLOCKED ON NAMED CONFIRMATION (2026-05-08)**",
       "status": "open",
       "statusNote": null,
-      "body": "Talk happened May 1. Fill in: Was it recorded? Who owns it? Release timeline? Can you use clips now?",
-      "bodyHtml": "<p>Talk happened May 1. Fill in: Was it recorded? Who owns it? Release timeline? Can you use clips now?</p>"
+      "body": "Talk happened May 1. The repo does not yet have confirmed recording owner,\nrelease timeline, or clip permissions. Do not publish talk video clips, voice\naudio, or recording-derived transcripts until the owner and permitted uses are\nnamed. Photo-forward recap and slide/source-backed publishing can continue\nwithout implying recording rights.",
+      "bodyHtml": "<p>Talk happened May 1. The repo does not yet have confirmed recording owner,<br>release timeline, or clip permissions. Do not publish talk video clips, voice<br>audio, or recording-derived transcripts until the owner and permitted uses are<br>named. Photo-forward recap and slide/source-backed publishing can continue<br>without implying recording rights.</p>"
     }
   ],
   "sessions": [

--- a/site/data/submissions.json
+++ b/site/data/submissions.json
@@ -1,5 +1,5 @@
 {
-  "source": "Notion DB via worker/submissions cron (when wired up)",
+  "source": "Fallback static export; primary gallery source is GET /api/submissions on Vercel",
   "generated": null,
   "moderation": "manual — items must have published=true in Notion",
   "submissions": []

--- a/site/data/word-ban-presets.json
+++ b/site/data/word-ban-presets.json
@@ -22,7 +22,19 @@
         "low-hanging fruit",
         "circle back",
         "double down",
-        "best practices"
+        "best practices",
+        "conversion",
+        "retention",
+        "awareness",
+        "brand lift",
+        "full-funnel",
+        "performance marketing",
+        "customer journey",
+        "hyper-targeted",
+        "personalization",
+        "storytelling",
+        "content engine",
+        "always-on"
       ]
     },
     {
@@ -48,7 +60,18 @@
         "venture-backed",
         "unfair advantage",
         "flywheel",
-        "go-to-market"
+        "go-to-market",
+        "hockey-stick growth",
+        "blitzscale",
+        "zero to one",
+        "total addressable market",
+        "early traction",
+        "seed stage",
+        "series a",
+        "pre-revenue",
+        "exit strategy",
+        "platform play",
+        "market leader"
       ]
     },
     {
@@ -73,7 +96,19 @@
         "mission-critical",
         "key takeaways",
         "going forward",
-        "at the end of the day"
+        "at the end of the day",
+        "low-hanging fruit",
+        "quick wins",
+        "socialize",
+        "right-size",
+        "change management",
+        "strategic roadmap",
+        "north star",
+        "workstream",
+        "swimlane",
+        "optimize",
+        "touch base",
+        "table stakes"
       ]
     },
     {
@@ -98,7 +133,19 @@
         "stakeholders",
         "robust framework",
         "comprehensive analysis",
-        "in light of the foregoing"
+        "in light of the foregoing",
+        "therefore",
+        "thus",
+        "arguably",
+        "nuanced",
+        "situated",
+        "methodological",
+        "epistemological",
+        "salient",
+        "problematics",
+        "foreground",
+        "unpack",
+        "complexities"
       ]
     },
     {
@@ -123,7 +170,19 @@
         "rug pull",
         "blockchain-powered",
         "smart contract",
-        "ecosystem"
+        "ecosystem",
+        "layer two",
+        "airdrop",
+        "staking",
+        "yield farming",
+        "liquidity",
+        "wallet",
+        "mint",
+        "nft",
+        "metaverse",
+        "zero knowledge",
+        "consensus",
+        "whitepaper"
       ]
     },
     {
@@ -148,7 +207,58 @@
         "sacred",
         "elevate",
         "cultivate",
-        "authentic self"
+        "authentic self",
+        "nourish",
+        "grounded",
+        "aligned",
+        "ritual",
+        "embodied",
+        "holding space",
+        "inner child",
+        "breathwork",
+        "high-vibe",
+        "plant-based",
+        "whole-body",
+        "transformational"
+      ]
+    },
+    {
+      "id": "journalism",
+      "label": "Journalism",
+      "blurb": "Vague attribution, passive voice fog, and news-copy hedges.",
+      "words": [
+        "sources say",
+        "critics say",
+        "observers say",
+        "some say",
+        "many believe",
+        "it is believed",
+        "it is understood",
+        "it was learned",
+        "reportedly",
+        "allegedly",
+        "apparently",
+        "seemingly",
+        "amid",
+        "sparked backlash",
+        "raised questions",
+        "under fire",
+        "controversial",
+        "war of words",
+        "bombshell",
+        "stunning",
+        "shocking",
+        "slammed",
+        "touted",
+        "hailed",
+        "insiders",
+        "according to reports",
+        "could not be reached",
+        "declined to comment",
+        "the move comes as",
+        "at press time",
+        "in a statement",
+        "went viral"
       ]
     }
   ]

--- a/site/index.html
+++ b/site/index.html
@@ -372,8 +372,20 @@
               </a>
             </li>
             <li>
-              <a class="card" href="/widgets/taste-audit.html">
+              <a class="card" href="/widgets/receipt-tells.html">
                 <span class="card__num">06</span>
+                <h3 class="card__title">Training-corpus receipt</h3>
+                <p class="card__body">
+                  Paste AI-generated text. Print a non-definitive receipt of
+                  phrase matches, hedging, em-dash density, and
+                  delve/leverage/optimize frequency.
+                </p>
+                <span class="card__cta">Print tells &rarr;</span>
+              </a>
+            </li>
+            <li>
+              <a class="card" href="/widgets/taste-audit.html">
+                <span class="card__num">07</span>
                 <h3 class="card__title">Taste audit</h3>
                 <p class="card__body">
                   What did you throw away this week? List ten. Mark each kept
@@ -384,7 +396,7 @@
             </li>
             <li>
               <a class="card" href="/widgets/cutting-room.html">
-                <span class="card__num">07</span>
+                <span class="card__num">08</span>
                 <h3 class="card__title">Cutting room floor</h3>
                 <p class="card__body">
                   Twelve real cuts from this very talk, with the reason for
@@ -395,7 +407,7 @@
             </li>
             <li>
               <a class="card" href="/widgets/junior-pipeline.html">
-                <span class="card__num">08</span>
+                <span class="card__num">09</span>
                 <h3 class="card__title">Junior pipeline</h3>
                 <p class="card__body">
                   Two ladders side by side. The old career path. The new one
@@ -406,7 +418,7 @@
             </li>
             <li>
               <a class="card" href="/widgets/pattern-finder.html">
-                <span class="card__num">09</span>
+                <span class="card__num">10</span>
                 <h3 class="card__title">Pattern finder</h3>
                 <p class="card__body">
                   Paste your corpus. The model names the structural patterns
@@ -418,7 +430,7 @@
             </li>
             <li>
               <a class="card" href="/widgets/pattern-graph.html">
-                <span class="card__num">10</span>
+                <span class="card__num">11</span>
                 <h3 class="card__title">Pattern cluster graph</h3>
                 <p class="card__body">
                   Six eras as nodes. Cut-up, sampling, d&eacute;tournement,
@@ -429,7 +441,7 @@
             </li>
             <li>
               <a class="card" href="/widgets/chainsaws.html">
-                <span class="card__num">11</span>
+                <span class="card__num">12</span>
                 <h3 class="card__title">Chainsaws of history</h3>
                 <p class="card__body">
                   Every neutral tool was a corporate spectacle until somebody
@@ -441,7 +453,7 @@
             </li>
             <li>
               <a class="card" href="/widgets/mastery-gym.html">
-                <span class="card__num">12</span>
+                <span class="card__num">13</span>
                 <h3 class="card__title">Mastery Gym tracker</h3>
                 <p class="card__body">
                   Daily check-in. One cycle a day &mdash; try, feedback,
@@ -453,7 +465,7 @@
             </li>
             <li>
               <a class="card" href="/widgets/receipt.html">
-                <span class="card__num">13</span>
+                <span class="card__num">14</span>
                 <h3 class="card__title">Open Source Receipt</h3>
                 <p class="card__body">
                   Toy estimator: how much of you is in the training data?

--- a/site/js/signal.js
+++ b/site/js/signal.js
@@ -1,41 +1,73 @@
-// Signal — surface one slide per day, deterministic by UTC date so every
-// visitor sees the same slide on the same calendar day. Cycles through the
-// full slide manifest once a year (index = dayOfYear % slides.length).
+// Signal — surface one slide or quote per day, deterministic by UTC date so
+// every visitor sees the same signal on the same calendar day.
 
 const root = document.getElementById("signal");
 if (root) main();
 
+const DAY_MS = 86400000;
+let pool = [];
+let lastTodayISO = utcDateISO(new Date());
+
 async function main() {
   try {
-    const res = await fetch("/data/slides.json", { credentials: "same-origin" });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
-    const slides = Array.isArray(data?.slides) ? data.slides : [];
+    const [slidesRes, quotesRes] = await Promise.all([
+      fetch("/data/slides.json", { credentials: "same-origin" }),
+      fetch("/data/quotes.json", { credentials: "same-origin" }),
+    ]);
+    if (!slidesRes.ok || !quotesRes.ok) throw new Error("data fetch failed");
+    const [slidesData, quotesData] = await Promise.all([slidesRes.json(), quotesRes.json()]);
+    const slides = Array.isArray(slidesData?.slides) ? slidesData.slides : [];
+    const quotes = Array.isArray(quotesData?.quotes) ? quotesData.quotes : [];
     if (!slides.length) throw new Error("no slides");
-    const pick = pickForToday(slides);
-    render(pick, slides.length);
+    pool = buildPool(slides, quotes);
+    renderForCurrentURL();
+    watchUTCDate();
+    window.addEventListener("popstate", renderForCurrentURL);
   } catch (err) {
     console.warn("[signal]", err);
     root.dataset.state = "error";
   }
 }
 
-// UTC dayOfYear keeps the pick stable across timezones — every visitor on the
-// same UTC calendar day sees the same slide.
-function dayOfYearUTC(date) {
-  const start = Date.UTC(date.getUTCFullYear(), 0, 0);
-  const now = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
-  return Math.floor((now - start) / 86400000);
+function buildPool(slides, quotes) {
+  const items = [];
+  const max = Math.max(slides.length, quotes.length);
+  for (let i = 0; i < max; i += 1) {
+    if (slides[i]) items.push({ kind: "slide", item: slides[i] });
+    if (quotes[i]) items.push({ kind: "quote", item: quotes[i] });
+  }
+  return items;
 }
 
-function pickForToday(slides) {
-  const day = dayOfYearUTC(new Date());
-  const idx = ((day % slides.length) + slides.length) % slides.length;
-  return { slide: slides[idx], idx };
+function renderForCurrentURL() {
+  const dateISO = selectedDateISO();
+  const pick = pickForDate(dateISO);
+  render(pick, dateISO);
 }
 
-function render({ slide, idx }, total) {
-  if (!slide) return;
+function selectedDateISO() {
+  const params = new URLSearchParams(window.location.search);
+  const fromURL = params.get("d");
+  return isISODate(fromURL) ? fromURL : utcDateISO(new Date());
+}
+
+function pickForDate(dateISO) {
+  const days = daysSinceEpochUTC(dateISO);
+  const idx = ((days % pool.length) + pool.length) % pool.length;
+  return { ...pool[idx], idx };
+}
+
+function watchUTCDate() {
+  window.setInterval(() => {
+    const todayISO = utcDateISO(new Date());
+    if (todayISO === lastTodayISO) return;
+    lastTodayISO = todayISO;
+    if (!new URLSearchParams(window.location.search).has("d")) renderForCurrentURL();
+  }, 60000);
+}
+
+function render({ kind, item, idx }, dateISO) {
+  if (!item) return;
   const dateEl = root.querySelector("[data-signal-date]");
   const titleEl = root.querySelector("[data-signal-title]");
   const actEl = root.querySelector("[data-signal-act]");
@@ -43,45 +75,99 @@ function render({ slide, idx }, total) {
   const indexEl = root.querySelector("[data-signal-index]");
   const recapEl = root.querySelector("[data-signal-recap]");
   const talkEl = root.querySelector("[data-signal-talk]");
+  const prevEl = root.querySelector("[data-signal-prev]");
+  const nextEl = root.querySelector("[data-signal-next]");
+  const todayEl = root.querySelector("[data-signal-today]");
 
   if (dateEl) {
-    const today = new Date();
-    const iso = today.toISOString().slice(0, 10);
-    dateEl.setAttribute("datetime", iso);
-    dateEl.textContent = today.toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
-  }
-  if (titleEl) titleEl.textContent = slide.title || "Slide of the day";
-  if (actEl) actEl.textContent = slide.act || "";
-  if (noteEl) {
-    if (slide.note) {
-      noteEl.textContent = slide.note;
-      noteEl.hidden = false;
-    } else {
-      noteEl.hidden = true;
-    }
-  }
-  if (indexEl) {
-    const n = typeof slide.n === "number" ? slide.n : idx + 1;
-    indexEl.textContent = `Slide ${n} of ${total}`;
-  }
-  if (talkEl && slide.id) {
-    talkEl.setAttribute("href", `/talk.html#${slide.id}`);
-  }
-  if (recapEl) {
-    recapEl.setAttribute("href", "/recap.html#slides");
+    dateEl.setAttribute("datetime", dateISO);
+    dateEl.textContent = formatUTCDate(dateISO);
   }
 
+  if (kind === "quote") {
+    if (titleEl) titleEl.textContent = item.text || "Quote of the day";
+    if (actEl) actEl.textContent = item.act || "";
+    setNote(noteEl, item.slideTitle ? `Quote from slide ${item.slide}: ${item.slideTitle}` : "");
+    if (indexEl) indexEl.textContent = `Quote ${item.n ?? idx + 1} of ${pool.length} signals`;
+    if (talkEl && item.id) talkEl.setAttribute("href", `/talk.html#${item.id}`);
+  } else {
+    if (titleEl) titleEl.textContent = item.title || "Slide of the day";
+    if (actEl) actEl.textContent = item.act || "";
+    setNote(noteEl, item.note || "");
+    if (indexEl) {
+      const n = typeof item.n === "number" ? item.n : idx + 1;
+      indexEl.textContent = `Slide ${n} of ${pool.length} signals`;
+    }
+    if (talkEl && item.id) talkEl.setAttribute("href", `/talk.html#${item.id}`);
+  }
+
+  if (prevEl) prevEl.setAttribute("href", signalHref(addUTCDays(dateISO, -1)));
+  if (nextEl) nextEl.setAttribute("href", signalHref(addUTCDays(dateISO, 1)));
+  if (todayEl) {
+    todayEl.setAttribute("href", "/signal.html");
+    if (dateISO === utcDateISO(new Date())) {
+      todayEl.setAttribute("aria-current", "date");
+    } else {
+      todayEl.removeAttribute("aria-current");
+    }
+  }
+  if (recapEl) recapEl.setAttribute("href", "/recap.html#slides");
+
   const photoLayer = document.getElementById("signal-photo-layer");
-  if (photoLayer && slide.image) {
-    photoLayer.style.backgroundImage = `url('${slide.image}')`;
-    photoLayer.style.backgroundPosition = "center center";
-    photoLayer.style.backgroundSize = "cover";
-    photoLayer.style.backgroundRepeat = "no-repeat";
+  if (photoLayer) {
+    const image = imageFor(item);
+    photoLayer.style.backgroundImage = image ? `url('${image}')` : "";
+    if (image) {
+      photoLayer.style.backgroundPosition = "center center";
+      photoLayer.style.backgroundSize = "cover";
+      photoLayer.style.backgroundRepeat = "no-repeat";
+    }
   }
 
   root.dataset.state = "ready";
+}
+
+function setNote(noteEl, text) {
+  if (!noteEl) return;
+  if (text) {
+    noteEl.textContent = text;
+    noteEl.hidden = false;
+  } else {
+    noteEl.hidden = true;
+  }
+}
+
+function imageFor(item) {
+  return item.hiRes || item.loRes || item.image || "";
+}
+
+function isISODate(value) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const date = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(date.valueOf()) && utcDateISO(date) === value;
+}
+
+function utcDateISO(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function daysSinceEpochUTC(dateISO) {
+  return Math.floor(Date.parse(`${dateISO}T00:00:00Z`) / DAY_MS);
+}
+
+function addUTCDays(dateISO, days) {
+  return new Date(Date.parse(`${dateISO}T00:00:00Z`) + days * DAY_MS).toISOString().slice(0, 10);
+}
+
+function formatUTCDate(dateISO) {
+  return new Date(`${dateISO}T00:00:00Z`).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function signalHref(dateISO) {
+  return dateISO === utcDateISO(new Date()) ? "/signal.html" : `/signal.html?d=${dateISO}`;
 }

--- a/site/js/widgets/conductor-ratio.js
+++ b/site/js/widgets/conductor-ratio.js
@@ -1,0 +1,178 @@
+const titleEl = document.getElementById("cratio-title");
+const ledeEl = document.getElementById("cratio-lede");
+const sliderEl = document.getElementById("cratio-slider");
+const outputEl = document.getElementById("cratio-output");
+const anchorsEl = document.getElementById("cratio-anchors");
+const cardEl = document.getElementById("cratio-card");
+const fillEl = document.querySelector("[data-fill]");
+const closingTitleEl = document.getElementById("cratio-closing-title");
+const closingBodyEl = document.getElementById("cratio-closing-body");
+const closingCiteEl = document.getElementById("cratio-closing-cite");
+
+let anchors = [];
+
+main();
+
+async function main() {
+  try {
+    const res = await fetch("/data/conductor-tradeoffs.json");
+    if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
+    const data = await res.json();
+    anchors = normalizeAnchors(data.anchors);
+
+    if (titleEl && data.title) titleEl.textContent = data.title;
+    if (ledeEl && data.lede) ledeEl.textContent = data.lede;
+    if (closingTitleEl && data.closing?.title) closingTitleEl.textContent = data.closing.title;
+    if (closingBodyEl && data.closing?.body) closingBodyEl.textContent = data.closing.body;
+    if (closingCiteEl && data.closing?.cite) closingCiteEl.textContent = "↳ " + data.closing.cite;
+
+    renderAnchors();
+    wireSlider();
+    update(Number(sliderEl?.value || 50));
+  } catch (err) {
+    if (cardEl) cardEl.innerHTML = `<p class="kicker">ratio data unavailable.</p>`;
+    console.warn("[conductor-ratio]", err);
+  }
+}
+
+function normalizeAnchors(items) {
+  return (Array.isArray(items) ? items : [])
+    .filter((item) => Number.isFinite(Number(item.value)))
+    .map((item) => ({ ...item, value: clamp(Number(item.value)) }))
+    .sort((a, b) => b.value - a.value);
+}
+
+function renderAnchors() {
+  if (!anchorsEl) return;
+  anchorsEl.innerHTML = anchors.map((anchor) => {
+    const value = escapeAttr(anchor.value);
+    return `
+      <button
+        type="button"
+        class="cratio-anchor"
+        data-value="${value}"
+        style="--x:${anchor.value}%"
+        aria-label="Jump to ${value}% machine throughput"
+      >
+        <span class="cratio-anchor__tick" aria-hidden="true"></span>
+        <span class="cratio-anchor__label">${escapeHTML(anchor.value)}%</span>
+      </button>
+    `;
+  }).join("");
+
+  anchorsEl.querySelectorAll("[data-value]").forEach((button) => {
+    button.addEventListener("click", () => {
+      const value = Number(button.getAttribute("data-value"));
+      if (!sliderEl || !Number.isFinite(value)) return;
+      sliderEl.value = String(value);
+      sliderEl.focus();
+      update(value);
+    });
+  });
+}
+
+function wireSlider() {
+  if (!sliderEl) return;
+  sliderEl.addEventListener("input", () => update(Number(sliderEl.value)));
+  sliderEl.addEventListener("keydown", (event) => {
+    const current = Number(sliderEl.value);
+    let next = null;
+    if (event.key === "Home") next = 0;
+    else if (event.key === "End") next = 100;
+    else if (event.key === "PageUp") next = current + 10;
+    else if (event.key === "PageDown") next = current - 10;
+    if (next === null) return;
+    event.preventDefault();
+    sliderEl.value = String(clamp(next));
+    update(Number(sliderEl.value));
+  });
+}
+
+function update(value) {
+  const safeValue = clamp(value);
+  const active = nearestAnchor(safeValue);
+  const machine = safeValue;
+  const human = 100 - safeValue;
+  const loss = Math.round(Math.abs(machine - 50) * 1.3);
+
+  if (outputEl) outputEl.textContent = `${machine}% machine / ${human}% human`;
+  if (fillEl) fillEl.style.width = `${machine}%`;
+  if (sliderEl) {
+    sliderEl.setAttribute("aria-valuetext", `${machine}% machine throughput, ${human}% human craft`);
+  }
+  paintAnchors(active);
+  renderCard(active, { machine, human, loss });
+}
+
+function nearestAnchor(value) {
+  return anchors.reduce((closest, anchor) => {
+    if (!closest) return anchor;
+    return Math.abs(anchor.value - value) < Math.abs(closest.value - value) ? anchor : closest;
+  }, null);
+}
+
+function paintAnchors(active) {
+  if (!anchorsEl) return;
+  anchorsEl.querySelectorAll("[data-value]").forEach((button) => {
+    button.toggleAttribute("aria-current", Number(button.getAttribute("data-value")) === active?.value);
+  });
+}
+
+function renderCard(anchor, values) {
+  if (!cardEl || !anchor) return;
+  cardEl.innerHTML = `
+    <div class="cratio-card__main">
+      <p class="cratio-card__tag">${escapeHTML(anchor.tag || anchor.label || "")}</p>
+      <h3>${escapeHTML(anchor.label || `${anchor.value}% machine`)}</h3>
+      <p>${escapeHTML(anchor.throughput || "")}</p>
+    </div>
+    <dl class="cratio-metrics">
+      <div>
+        <dt>Throughput</dt>
+        <dd><span style="--w:${values.machine}%"></span>${values.machine}%</dd>
+      </div>
+      <div>
+        <dt>Human craft</dt>
+        <dd><span style="--w:${values.human}%"></span>${values.human}%</dd>
+      </div>
+      <div>
+        <dt>Cost pressure</dt>
+        <dd><span style="--w:${values.machine}%"></span>${values.machine >= 50 ? "falling" : "rising"}</dd>
+      </div>
+      <div>
+        <dt>Loss risk</dt>
+        <dd><span style="--w:${values.loss}%"></span>${values.loss}%</dd>
+      </div>
+    </dl>
+    <div class="cratio-tradeoffs">
+      ${renderTradeoff("Craft", anchor.craft)}
+      ${renderTradeoff("Cost", anchor.cost)}
+      ${renderTradeoff("Loss", anchor.loss)}
+    </div>
+    <p class="cratio-card__source">${escapeHTML(anchor.sourceNote || "")}</p>
+  `;
+}
+
+function renderTradeoff(label, text) {
+  return `
+    <section>
+      <h4>${escapeHTML(label)}</h4>
+      <p>${escapeHTML(text || "")}</p>
+    </section>
+  `;
+}
+
+function clamp(value) {
+  return Math.max(0, Math.min(100, Math.round(Number(value) || 0)));
+}
+
+function escapeHTML(s) {
+  return String(s ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function escapeAttr(s) {
+  return escapeHTML(s).replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+}

--- a/site/js/widgets/cutting-room-buckets.js
+++ b/site/js/widgets/cutting-room-buckets.js
@@ -1,0 +1,326 @@
+const buckets = [
+  { id: "keep", label: "Keep" },
+  { id: "cut", label: "Cut" },
+  { id: "later", label: "Save for later" },
+];
+
+const bucketIds = new Set(buckets.map((bucket) => bucket.id));
+const poolEl = document.getElementById("crb-pool");
+const bucketsEl = document.getElementById("crb-buckets");
+const statusEl = document.getElementById("crb-status");
+const countsEl = document.getElementById("crb-counts");
+const copyLinkEl = document.getElementById("crb-copy-link");
+const exportEl = document.getElementById("crb-export");
+const resetEl = document.getElementById("crb-reset");
+
+const state = {
+  cuts: [],
+  assignments: new Map(),
+};
+
+main();
+
+async function main() {
+  try {
+    const res = await fetch("/data/cutting-room.json");
+    if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
+    const data = await res.json();
+    state.cuts = Array.isArray(data.cuts) ? data.cuts : [];
+    readHash();
+    render();
+    bindActions();
+  } catch (err) {
+    if (statusEl) statusEl.textContent = "Cutting-room data unavailable.";
+    console.warn("[cutting-room-buckets]", err);
+  }
+}
+
+function bindActions() {
+  document.addEventListener("dragstart", onDragStart);
+  document.addEventListener("dragend", onDragEnd);
+  document.addEventListener("dragover", onDragOver);
+  document.addEventListener("dragleave", onDragLeave);
+  document.addEventListener("drop", onDrop);
+  document.addEventListener("click", onBucketButtonClick);
+  window.addEventListener("hashchange", () => {
+    readHash();
+    render();
+  });
+  copyLinkEl?.addEventListener("click", copyShareLink);
+  exportEl?.addEventListener("click", exportPNG);
+  resetEl?.addEventListener("click", resetBoard);
+}
+
+function readHash() {
+  state.assignments.clear();
+  const params = new URLSearchParams(location.hash.replace(/^#/, ""));
+  const encoded = params.get("s");
+  if (!encoded) return;
+  for (const pair of encoded.split(",")) {
+    const [id, bucket] = pair.split(":");
+    if (id && bucketIds.has(bucket) && state.cuts.some((cut) => cut.id === id)) {
+      state.assignments.set(id, bucket);
+    }
+  }
+}
+
+function render() {
+  renderCounts();
+  renderPool();
+  renderBuckets();
+}
+
+function renderCounts() {
+  if (!countsEl) return;
+  const counts = countAssignments();
+  countsEl.innerHTML = [
+    countHTML("Unsorted", counts.unassigned),
+    ...buckets.map((bucket) => countHTML(bucket.label, counts[bucket.id] || 0)),
+  ].join("");
+}
+
+function renderPool() {
+  if (!poolEl) return;
+  poolEl.querySelectorAll(".crb-card").forEach((card) => card.remove());
+  const unsorted = state.cuts.filter((cut) => !state.assignments.has(cut.id));
+  if (statusEl) {
+    statusEl.textContent = unsorted.length
+      ? `${unsorted.length} waiting for a call.`
+      : "All cuts have a bucket.";
+  }
+  poolEl.insertAdjacentHTML("beforeend", unsorted.map(cardHTML).join(""));
+}
+
+function renderBuckets() {
+  for (const bucket of buckets) {
+    const dropzone = document.querySelector(`[data-dropzone="${bucket.id}"]`);
+    if (!dropzone) continue;
+    const cards = state.cuts.filter((cut) => state.assignments.get(cut.id) === bucket.id);
+    dropzone.innerHTML = cards.length
+      ? cards.map(cardHTML).join("")
+      : `<p class="crb-empty">Drop cards here.</p>`;
+  }
+}
+
+function cardHTML(cut) {
+  const assigned = state.assignments.get(cut.id) || "unassigned";
+  return `
+    <article class="crb-card" draggable="true" data-card-id="${escapeAttr(cut.id)}">
+      <header class="crb-card__head">
+        <span>${escapeHTML(cut.reason || "cut")}</span>
+        ${cut.cut_date ? `<time datetime="${escapeAttr(cut.cut_date)}">${escapeHTML(cut.cut_date)}</time>` : ""}
+      </header>
+      <h3>${escapeHTML(cut.title)}</h3>
+      <p>${escapeHTML(cut.body)}</p>
+      <div class="crb-card__moves" aria-label="Move ${escapeAttr(cut.title)}">
+        ${bucketButtonHTML(cut.id, assigned, "keep", "Keep")}
+        ${bucketButtonHTML(cut.id, assigned, "cut", "Cut")}
+        ${bucketButtonHTML(cut.id, assigned, "later", "Later")}
+      </div>
+    </article>
+  `;
+}
+
+function bucketButtonHTML(id, assigned, bucket, label) {
+  return `
+    <button
+      type="button"
+      data-card-move="${escapeAttr(id)}"
+      data-bucket-target="${bucket}"
+      aria-pressed="${assigned === bucket ? "true" : "false"}"
+    >${label}</button>
+  `;
+}
+
+function countHTML(label, value) {
+  return `<span><strong>${value}</strong> ${escapeHTML(label)}</span>`;
+}
+
+function onDragStart(e) {
+  const card = e.target.closest(".crb-card");
+  if (!card || !e.dataTransfer) return;
+  e.dataTransfer.setData("text/plain", card.dataset.cardId);
+  e.dataTransfer.effectAllowed = "move";
+  card.classList.add("is-dragging");
+}
+
+function onDragEnd(e) {
+  e.target.closest(".crb-card")?.classList.remove("is-dragging");
+  clearDropTargets();
+}
+
+function onDragOver(e) {
+  const target = closestDropTarget(e.target);
+  if (!target) return;
+  e.preventDefault();
+  target.classList.add("is-over");
+  if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
+}
+
+function onDragLeave(e) {
+  const target = closestDropTarget(e.target);
+  if (target && !target.contains(e.relatedTarget)) target.classList.remove("is-over");
+}
+
+function onDrop(e) {
+  const target = closestDropTarget(e.target);
+  if (!target || !e.dataTransfer) return;
+  e.preventDefault();
+  const id = e.dataTransfer.getData("text/plain");
+  const bucket = target.dataset.dropzone || target.dataset.bucket;
+  moveCard(id, bucket);
+  clearDropTargets();
+}
+
+function onBucketButtonClick(e) {
+  const button = e.target.closest("[data-card-move]");
+  if (!button) return;
+  moveCard(button.dataset.cardMove, button.dataset.bucketTarget);
+}
+
+function closestDropTarget(target) {
+  return target.closest("[data-dropzone], .crb-pool");
+}
+
+function moveCard(id, bucket) {
+  if (!state.cuts.some((cut) => cut.id === id)) return;
+  if (bucketIds.has(bucket)) {
+    state.assignments.set(id, bucket);
+  } else {
+    state.assignments.delete(id);
+  }
+  writeHash();
+  render();
+}
+
+function writeHash() {
+  const encoded = [...state.assignments.entries()]
+    .filter(([, bucket]) => bucketIds.has(bucket))
+    .map(([id, bucket]) => `${id}:${bucket}`)
+    .join(",");
+  if (encoded) {
+    history.replaceState(null, "", `#s=${encoded}`);
+  } else {
+    history.replaceState(null, "", location.pathname + location.search);
+  }
+}
+
+async function copyShareLink() {
+  writeHash();
+  const url = location.href;
+  try {
+    await navigator.clipboard.writeText(url);
+    flash(copyLinkEl, "Copied");
+  } catch {
+    window.prompt("Share link", url);
+  }
+}
+
+function resetBoard() {
+  state.assignments.clear();
+  writeHash();
+  render();
+}
+
+function countAssignments() {
+  const counts = { unassigned: 0, keep: 0, cut: 0, later: 0 };
+  for (const cut of state.cuts) {
+    const bucket = state.assignments.get(cut.id);
+    if (bucketIds.has(bucket)) counts[bucket] += 1;
+    else counts.unassigned += 1;
+  }
+  return counts;
+}
+
+function exportPNG() {
+  const canvas = document.createElement("canvas");
+  const scale = 2;
+  canvas.width = 1200 * scale;
+  canvas.height = 900 * scale;
+  const ctx = canvas.getContext("2d");
+  ctx.scale(scale, scale);
+  ctx.fillStyle = "#0a0a0a";
+  ctx.fillRect(0, 0, 1200, 900);
+  ctx.fillStyle = "#f4f0e8";
+  ctx.font = "700 44px sans-serif";
+  ctx.fillText("Cutting Room Buckets", 48, 72);
+  ctx.font = "18px monospace";
+  ctx.fillStyle = "#ffcc00";
+  ctx.fillText(new Date().toLocaleDateString(), 48, 108);
+
+  const columns = [
+    { id: "keep", label: "KEEP", x: 48 },
+    { id: "cut", label: "CUT", x: 424 },
+    { id: "later", label: "SAVE FOR LATER", x: 800 },
+  ];
+
+  for (const column of columns) {
+    drawColumn(ctx, column);
+  }
+
+  const link = document.createElement("a");
+  link.download = "cutting-room-buckets.png";
+  link.href = canvas.toDataURL("image/png");
+  link.click();
+}
+
+function drawColumn(ctx, column) {
+  const cards = state.cuts.filter((cut) => state.assignments.get(cut.id) === column.id);
+  ctx.strokeStyle = "#ffcc00";
+  ctx.lineWidth = 2;
+  ctx.strokeRect(column.x, 140, 328, 700);
+  ctx.fillStyle = "#ffcc00";
+  ctx.font = "700 22px monospace";
+  ctx.fillText(`${column.label} (${cards.length})`, column.x + 18, 178);
+  ctx.fillStyle = "#f4f0e8";
+  ctx.font = "16px sans-serif";
+  let y = 220;
+  for (const cut of cards.slice(0, 10)) {
+    y = drawWrappedText(ctx, cut.title, column.x + 18, y, 292, 20) + 18;
+  }
+  if (cards.length > 10) {
+    ctx.fillStyle = "#8f8a80";
+    ctx.fillText(`+ ${cards.length - 10} more`, column.x + 18, y);
+  }
+}
+
+function drawWrappedText(ctx, text, x, y, maxWidth, lineHeight) {
+  const words = String(text).split(/\s+/);
+  let line = "";
+  for (const word of words) {
+    const testLine = line ? `${line} ${word}` : word;
+    if (ctx.measureText(testLine).width > maxWidth && line) {
+      ctx.fillText(line, x, y);
+      line = word;
+      y += lineHeight;
+    } else {
+      line = testLine;
+    }
+  }
+  if (line) ctx.fillText(line, x, y);
+  return y + lineHeight;
+}
+
+function flash(button, label) {
+  if (!button) return;
+  const original = button.textContent;
+  button.textContent = label;
+  window.setTimeout(() => {
+    button.textContent = original;
+  }, 1200);
+}
+
+function clearDropTargets() {
+  document.querySelectorAll(".is-over").forEach((el) => el.classList.remove("is-over"));
+}
+
+function escapeHTML(s) {
+  return String(s ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function escapeAttr(s) {
+  return escapeHTML(s).replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+}

--- a/site/js/widgets/receipt-tells.js
+++ b/site/js/widgets/receipt-tells.js
@@ -1,0 +1,254 @@
+// /widgets/receipt-tells.html — local, non-definitive AI-output tell receipt.
+
+import { load, save } from "/js/common/storage.js";
+
+const DATA_URL = "/data/ai-tells.json";
+const STORAGE_KEY = "rctl:input";
+const WORD_RE = /[A-Za-z0-9]+(?:['-][A-Za-z0-9]+)*/g;
+
+const els = {};
+let tells = {
+  sample: "",
+  phraseMatches: [],
+  hedges: [],
+  watchedTerms: ["delve", "leverage", "optimize"],
+};
+
+init();
+
+async function init() {
+  cacheEls();
+  hydrate();
+  wire();
+  paintMeta();
+  await loadTells();
+}
+
+function cacheEls() {
+  els.form = document.getElementById("rctl-form");
+  els.input = document.getElementById("rctl-input");
+  els.output = document.getElementById("rctl-output");
+  els.status = document.getElementById("rctl-status");
+  els.stamp = document.querySelector("[data-stamp]");
+  els.time = document.querySelector("[data-time]");
+  els.sample = document.querySelector('[data-action="sample"]');
+}
+
+function hydrate() {
+  const { value } = load(STORAGE_KEY, "");
+  if (typeof value === "string" && els.input) els.input.value = value;
+}
+
+function wire() {
+  els.form?.addEventListener("submit", (event) => {
+    event.preventDefault();
+    analyze();
+  });
+  els.form?.addEventListener("reset", () => {
+    setTimeout(() => {
+      save(STORAGE_KEY, "");
+      paintEmpty();
+      flash("cleared");
+    }, 0);
+  });
+  els.input?.addEventListener("input", () => {
+    save(STORAGE_KEY, els.input.value || "");
+  });
+  els.sample?.addEventListener("click", () => {
+    if (!els.input) return;
+    els.input.value = tells.sample || "";
+    save(STORAGE_KEY, els.input.value);
+    analyze();
+    els.input.focus();
+  });
+}
+
+async function loadTells() {
+  try {
+    const res = await fetch(DATA_URL, { cache: "no-cache" });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    tells = {
+      sample: typeof data?.sample === "string" ? data.sample : "",
+      phraseMatches: Array.isArray(data?.phraseMatches) ? data.phraseMatches : [],
+      hedges: Array.isArray(data?.hedges) ? data.hedges : [],
+      watchedTerms: Array.isArray(data?.watchedTerms) ? data.watchedTerms : tells.watchedTerms,
+    };
+  } catch (err) {
+    console.warn("[receipt-tells] tell data unavailable:", err);
+    flash("tell list unavailable - basic scan only");
+  }
+}
+
+function analyze() {
+  const text = (els.input?.value || "").trim();
+  if (!text) {
+    flash("paste text first");
+    return;
+  }
+
+  const metrics = buildMetrics(text);
+  paintMeta();
+  renderReceipt(metrics);
+  flash("receipt printed");
+}
+
+function buildMetrics(text) {
+  const words = text.match(WORD_RE) || [];
+  const wordCount = words.length;
+  const phraseHits = tells.phraseMatches
+    .map((item) => {
+      const count = countRegex(text, item.pattern);
+      return { ...item, count };
+    })
+    .filter((item) => item.count > 0);
+  const hedgeHits = tells.hedges
+    .map((term) => ({ term, count: countTerm(text, term) }))
+    .filter((item) => item.count > 0);
+  const watchedHits = tells.watchedTerms.map((term) => ({
+    term,
+    count: countTerm(text, term),
+  }));
+  const emDashes = (text.match(/—/g) || []).length;
+  const hedgeTotal = sum(hedgeHits);
+  const watchedTotal = sum(watchedHits);
+
+  return {
+    wordCount,
+    phraseHits,
+    hedgeHits,
+    watchedHits,
+    emDashes,
+    hedgeTotal,
+    watchedTotal,
+    hedgeScore: rate(hedgeTotal, wordCount, 100),
+    emDashDensity: rate(emDashes, wordCount, 100),
+    watchedDensity: rate(watchedTotal, wordCount, 100),
+  };
+}
+
+function renderReceipt(metrics) {
+  if (!els.output) return;
+
+  const phraseRows = metrics.phraseHits.length
+    ? metrics.phraseHits.map((hit) => row(hit.label, hit.count)).join("")
+    : `<li class="rctl-line"><span>No listed phrase matches</span><strong>0</strong></li>`;
+
+  const hedgeRows = metrics.hedgeHits.length
+    ? metrics.hedgeHits.slice(0, 8).map((hit) => row(hit.term, hit.count)).join("")
+    : `<li class="rctl-line"><span>No listed hedges</span><strong>0</strong></li>`;
+
+  const watchedRows = metrics.watchedHits.map((hit) => row(hit.term, hit.count)).join("");
+
+  els.output.innerHTML = `
+    <section class="rctl-ticket-section">
+      <p class="rctl-label">SCAN BASIS</p>
+      <p class="rctl-total"><span>Words inspected</span><strong>${metrics.wordCount}</strong></p>
+      <p class="rctl-note">Local text scan. No model call. No upload.</p>
+    </section>
+
+    <section class="rctl-ticket-section">
+      <p class="rctl-label">PHRASE MATCHES</p>
+      <ul class="rctl-list">${phraseRows}</ul>
+      <p class="rctl-note">Stock phrases are weak tells. Context still matters.</p>
+    </section>
+
+    <section class="rctl-ticket-section">
+      <p class="rctl-label">HEDGING SCORE</p>
+      <p class="rctl-score">${metrics.hedgeScore.toFixed(1)} / 100 words</p>
+      <ul class="rctl-list">${hedgeRows}</ul>
+    </section>
+
+    <section class="rctl-ticket-section">
+      <p class="rctl-label">EM-DASH DENSITY</p>
+      <p class="rctl-total"><span>Em dashes</span><strong>${metrics.emDashes}</strong></p>
+      <p class="rctl-score">${metrics.emDashDensity.toFixed(1)} / 100 words</p>
+    </section>
+
+    <section class="rctl-ticket-section">
+      <p class="rctl-label">DELVE / LEVERAGE / OPTIMIZE</p>
+      <ul class="rctl-list">${watchedRows}</ul>
+      <p class="rctl-score">${metrics.watchedDensity.toFixed(1)} / 100 words</p>
+    </section>
+
+    <section class="rctl-ticket-section rctl-ticket-section--verdict">
+      <p class="rctl-label">ANNOTATION</p>
+      <p>${escapeHTML(annotation(metrics))}</p>
+      <p class="rctl-note">Non-definitive heuristic. Do not use as proof of AI authorship.</p>
+    </section>
+  `;
+}
+
+function annotation(metrics) {
+  const signals = [
+    metrics.phraseHits.length,
+    metrics.hedgeScore >= 3 ? 1 : 0,
+    metrics.emDashDensity >= 1.5 ? 1 : 0,
+    metrics.watchedTotal > 0 ? 1 : 0,
+  ].reduce((a, b) => a + b, 0);
+
+  if (signals >= 3) return "Several familiar AI-output tells are visible. Name the pattern, then read the prose.";
+  if (signals >= 1) return "A few listed tells appear. Treat them as prompts for editing, not evidence.";
+  return "Few listed tells appear. That does not prove the text is human-written.";
+}
+
+function paintEmpty() {
+  if (!els.output) return;
+  els.output.innerHTML = '<p class="rctl-receipt__placeholder">Paste text and print the tells.</p>';
+}
+
+function countRegex(text, source) {
+  try {
+    const re = new RegExp(source, "gi");
+    return (text.match(re) || []).length;
+  } catch {
+    return 0;
+  }
+}
+
+function countTerm(text, term) {
+  const escaped = escapeRegExp(term).replace(/\\ /g, "\\s+");
+  return countRegex(text, `\\b${escaped}\\b`);
+}
+
+function row(label, count) {
+  return `<li class="rctl-line"><span>${escapeHTML(label)}</span><strong>${count}</strong></li>`;
+}
+
+function rate(count, wordCount, per) {
+  if (!wordCount) return 0;
+  return (count / wordCount) * per;
+}
+
+function sum(rows) {
+  return rows.reduce((total, row) => total + row.count, 0);
+}
+
+function paintMeta() {
+  const now = new Date();
+  if (els.stamp) els.stamp.textContent = now.toISOString().slice(0, 10);
+  if (els.time) els.time.textContent = now.toTimeString().slice(0, 5);
+}
+
+function flash(message) {
+  if (!els.status) return;
+  els.status.textContent = message;
+  clearTimeout(flash._t);
+  if (!message) return;
+  flash._t = setTimeout(() => {
+    if (els.status) els.status.textContent = "";
+  }, 3000);
+}
+
+function escapeHTML(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/site/js/widgets/release-day.js
+++ b/site/js/widgets/release-day.js
@@ -5,6 +5,7 @@ import { load, save, remove } from "/js/common/storage.js";
 
 const RELEASE_DAY = new Date("2026-05-29T23:59:00-07:00");
 const PORTAL_ENDPOINT = "/api/submissions";
+const STATIC_GALLERY_ENDPOINT = "/data/submissions.json";
 const PENDING_KEY = "rd:pending";
 const DRAFT_KEY = "rd:draft";
 
@@ -110,6 +111,11 @@ async function onSubmit(e) {
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
+    if (data.status === "queued-no-backend") {
+      queueLocally(submission);
+      flash("portal not connected yet — saved locally");
+      return;
+    }
     formEl.reset();
     remove(DRAFT_KEY);
     flash(`submitted — id ${data.id ?? "—"}`);
@@ -143,9 +149,7 @@ function paintPending() {
 async function loadGallery() {
   if (!galleryEl) return;
   try {
-    const res = await fetch("/data/submissions.json");
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
+    const data = await loadGalleryData();
     const list = data.submissions ?? [];
     if (!list.length) {
       galleryEl.hidden = true;
@@ -156,6 +160,24 @@ async function loadGallery() {
     galleryEl.innerHTML = list.map(renderGalleryCard).join("");
   } catch (err) {
     console.warn("[release-day] gallery", err);
+  }
+}
+
+async function loadGalleryData() {
+  const live = await fetchJson(PORTAL_ENDPOINT);
+  if (live?.submissions?.length) return live;
+  const fallback = await fetchJson(STATIC_GALLERY_ENDPOINT);
+  return fallback ?? { submissions: [] };
+}
+
+async function fetchJson(url) {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.json();
+  } catch (err) {
+    console.warn(`[release-day] ${url}`, err);
+    return null;
   }
 }
 

--- a/site/js/widgets/tool-not-neutral-matrix.js
+++ b/site/js/widgets/tool-not-neutral-matrix.js
@@ -1,0 +1,251 @@
+const matrixEl = document.getElementById("tnnm-matrix");
+const detailEl = document.getElementById("tnnm-detail");
+const statusEl = document.getElementById("tnnm-status");
+
+const toolTypes = [
+  { id: "vision", label: "Vision", note: "face, image, recognition" },
+  { id: "selection", label: "Selection", note: "hiring, ads, ranking" },
+  { id: "risk", label: "Risk", note: "courts, care, policing" },
+  { id: "speech", label: "Speech", note: "language, voice, moderation" },
+  { id: "generation", label: "Generation", note: "image, text, captions" },
+];
+
+const designAxes = [
+  { id: "data", label: "Training data", note: "who shows up" },
+  { id: "proxy", label: "Proxy target", note: "what stands in for truth" },
+  { id: "audit", label: "Audit frame", note: "what gets measured" },
+  { id: "loop", label: "Feedback loop", note: "what the system reinforces" },
+  { id: "default", label: "Default image", note: "who counts as normal" },
+];
+
+const caseByCell = {
+  "vision:data": "gender-shades",
+  "vision:proxy": "indigenous-representation",
+  "vision:audit": "gender-shades",
+  "vision:loop": "sweeney-ads",
+  "vision:default": "marketing-professor",
+  "selection:data": "amazon-resume",
+  "selection:proxy": "sweeney-ads",
+  "selection:audit": "amazon-resume",
+  "selection:loop": "amazon-resume",
+  "selection:default": "marketing-professor",
+  "risk:data": "predictive-policing",
+  "risk:proxy": "healthcare-algorithm",
+  "risk:audit": "compas",
+  "risk:loop": "predictive-policing",
+  "risk:default": "compas",
+  "speech:data": "asr-accent",
+  "speech:proxy": "aave-moderation",
+  "speech:audit": "asr-accent",
+  "speech:loop": "english-default",
+  "speech:default": "english-default",
+  "generation:data": "indigenous-representation",
+  "generation:proxy": "disability-captions",
+  "generation:audit": "disability-captions",
+  "generation:loop": "indigenous-representation",
+  "generation:default": "marketing-professor",
+};
+
+let casesById = new Map();
+let cells = [];
+let active = 0;
+let touchStartX = null;
+let touchStartY = null;
+
+main();
+
+async function main() {
+  try {
+    const res = await fetch("/data/tool-cases.json");
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    const cases = Array.isArray(data.cases) ? data.cases : [];
+    casesById = new Map(cases.map((item) => [item.id, item]));
+    cells = buildCells();
+    if (!cells.length) throw new Error("no matrix cells");
+    renderMatrix();
+    activateCellFromHash() || activateCell(0, { pushHash: false });
+    wireInteractions();
+  } catch (err) {
+    if (statusEl) statusEl.textContent = "Cases unavailable.";
+    console.warn("[tool-not-neutral-matrix]", err);
+  }
+}
+
+function buildCells() {
+  return toolTypes.flatMap((tool) =>
+    designAxes.map((axis) => {
+      const key = `${tool.id}:${axis.id}`;
+      const caseId = caseByCell[key];
+      const example = casesById.get(caseId);
+      return example ? { key, tool, axis, example } : null;
+    })
+  ).filter(Boolean);
+}
+
+function renderMatrix() {
+  if (!matrixEl) return;
+  const headers = [
+    `<div class="tnnm__corner" aria-hidden="true">tool / axis</div>`,
+    ...designAxes.map((axis) => axisHeader(axis)),
+  ];
+  const rows = toolTypes.flatMap((tool) => [
+    rowHeader(tool),
+    ...designAxes.map((axis) => cellButton(`${tool.id}:${axis.id}`)),
+  ]);
+
+  matrixEl.innerHTML = [...headers, ...rows].join("");
+  matrixEl.addEventListener("click", handleCellEvent);
+  matrixEl.addEventListener("focusin", handleCellEvent);
+  matrixEl.addEventListener("mouseover", (e) => {
+    if (window.matchMedia("(hover: hover)").matches) handleCellEvent(e);
+  });
+}
+
+function axisHeader(axis) {
+  return `
+    <div class="tnnm__axis-head">
+      <span>${escapeHTML(axis.label)}</span>
+      <small>${escapeHTML(axis.note)}</small>
+    </div>
+  `;
+}
+
+function rowHeader(tool) {
+  return `
+    <div class="tnnm__tool-head">
+      <span>${escapeHTML(tool.label)}</span>
+      <small>${escapeHTML(tool.note)}</small>
+    </div>
+  `;
+}
+
+function cellButton(key) {
+  const index = cells.findIndex((cell) => cell.key === key);
+  const cell = cells[index];
+  if (!cell) return `<div class="tnnm__empty" aria-hidden="true"></div>`;
+
+  return `
+    <button class="tnnm-cell" type="button" data-i="${index}" aria-expanded="false">
+      <span class="tnnm-cell__axis">${escapeHTML(cell.axis.label)}</span>
+      <span class="tnnm-cell__tool">${escapeHTML(cell.tool.label)}</span>
+      <strong>${escapeHTML(cell.example.tool)}</strong>
+      <span>${escapeHTML(shortOutcome(cell.example))}</span>
+    </button>
+  `;
+}
+
+function wireInteractions() {
+  document.addEventListener("keydown", (e) => {
+    if (e.target.matches("textarea, input, a")) return;
+    if (e.key === "ArrowLeft") activateByDelta(-1);
+    if (e.key === "ArrowRight") activateByDelta(1);
+    if (e.key === "ArrowUp") activateByDelta(-designAxes.length);
+    if (e.key === "ArrowDown") activateByDelta(designAxes.length);
+  });
+  window.addEventListener("hashchange", activateCellFromHash);
+  for (const el of [matrixEl, detailEl]) {
+    el?.addEventListener("touchstart", rememberTouch, { passive: true });
+    el?.addEventListener("touchend", handleSwipe, { passive: true });
+  }
+}
+
+function handleCellEvent(e) {
+  const button = e.target.closest(".tnnm-cell[data-i]");
+  if (!button) return;
+  activateCell(Number(button.dataset.i));
+}
+
+function activateCellFromHash() {
+  const raw = decodeURIComponent((location.hash || "").replace(/^#/, ""));
+  if (!raw) return false;
+  const index = cells.findIndex((cell) => cell.key === raw || cell.example.id === raw);
+  if (index < 0) return false;
+  activateCell(index, { pushHash: false });
+  return true;
+}
+
+function activateByDelta(delta) {
+  if (!cells.length) return;
+  const next = Math.max(0, Math.min(cells.length - 1, active + delta));
+  activateCell(next);
+}
+
+function activateCell(index, options = {}) {
+  if (!cells[index]) return;
+  const pushHash = options.pushHash !== false;
+  active = index;
+  for (const button of matrixEl.querySelectorAll(".tnnm-cell[data-i]")) {
+    const isActive = Number(button.dataset.i) === active;
+    button.classList.toggle("is-active", isActive);
+    button.setAttribute("aria-expanded", String(isActive));
+  }
+  renderDetail(cells[active]);
+  if (statusEl) {
+    statusEl.textContent = `${cells[active].tool.label} by ${cells[active].axis.label}: ${cells[active].example.tool}`;
+  }
+  if (pushHash) history.replaceState(null, "", `#${encodeURIComponent(cells[active].key)}`);
+}
+
+function renderDetail(cell) {
+  if (!detailEl) return;
+  const c = cell.example;
+  const citation = c.citation
+    ? c.citationUrl
+      ? `<a href="${escapeAttr(c.citationUrl)}" target="_blank" rel="noopener">${escapeHTML(c.citation)} &nearr;</a>`
+      : escapeHTML(c.citation)
+    : "";
+
+  detailEl.innerHTML = `
+    <header>
+      <p class="kicker kicker--accent">${escapeHTML(cell.tool.label)} x ${escapeHTML(cell.axis.label)}</p>
+      <h3>${escapeHTML(c.tool)}</h3>
+    </header>
+    <dl>
+      <div>
+        <dt>design choice</dt>
+        <dd>${escapeHTML(c.decision)}</dd>
+      </div>
+      <div>
+        <dt>outcome</dt>
+        <dd>${escapeHTML(c.outcome)}</dd>
+      </div>
+    </dl>
+    ${c.preciseName ? `<p class="tnnm__precise">${escapeHTML(c.preciseName)}</p>` : ""}
+    ${citation ? `<p class="tnnm__cite">${citation}</p>` : ""}
+  `;
+}
+
+function rememberTouch(e) {
+  const touch = e.changedTouches[0];
+  touchStartX = touch.clientX;
+  touchStartY = touch.clientY;
+}
+
+function handleSwipe(e) {
+  if (touchStartX === null || touchStartY === null) return;
+  const touch = e.changedTouches[0];
+  const dx = touch.clientX - touchStartX;
+  const dy = touch.clientY - touchStartY;
+  touchStartX = null;
+  touchStartY = null;
+  if (Math.abs(dx) < 44 || Math.abs(dx) < Math.abs(dy) * 1.25) return;
+  activateByDelta(dx < 0 ? 1 : -1);
+}
+
+function shortOutcome(c) {
+  return c.harm || c.preciseName || c.outcome;
+}
+
+function escapeHTML(s) {
+  return String(s ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function escapeAttr(s) {
+  return escapeHTML(s);
+}

--- a/site/js/widgets/word-ban.js
+++ b/site/js/widgets/word-ban.js
@@ -42,6 +42,8 @@ const DEFAULTS = [
 const STORAGE_KEY = "wban:list";
 const LAST_INPUT_KEY = "wban:input";
 const HISTORY_KEY = "wordban:history";
+const LAST_PRESET_KEY = "wban:preset";
+const PRESET_MODE_KEY = "wban:preset-mode";
 const HISTORY_MAX = 10;
 
 const inputEl = document.getElementById("wban-input");
@@ -54,6 +56,7 @@ const statusEl = document.getElementById("wban-status");
 const listCountEl = document.querySelector("[data-list-count]");
 const presetSelectEl = document.getElementById("wban-preset");
 const presetBlurbEl = document.getElementById("wban-preset-blurb");
+const presetModeEls = document.querySelectorAll('input[name="wban-preset-mode"]');
 const historyBox = document.getElementById("wban-history");
 const historyList = document.getElementById("wban-history-list");
 const sparkEl = document.getElementById("wban-sparkline");
@@ -81,6 +84,8 @@ function hydrate() {
   listEl.value = Array.isArray(value) && value.length ? value.join("\n") : DEFAULTS.join("\n");
   const { value: prevInput } = load(LAST_INPUT_KEY, "");
   if (typeof prevInput === "string" && prevInput) inputEl.value = prevInput;
+  const { value: presetMode } = load(PRESET_MODE_KEY, "stack");
+  setPresetMode(presetMode === "replace" ? "replace" : "stack");
 }
 
 function bind() {
@@ -92,8 +97,14 @@ function bind() {
   document.querySelector('[data-action="apply-preset"]').addEventListener("click", applySelectedPreset);
 
   if (presetSelectEl) {
-    presetSelectEl.addEventListener("change", paintPresetBlurb);
+    presetSelectEl.addEventListener("change", () => {
+      save(LAST_PRESET_KEY, presetSelectEl.value);
+      paintPresetBlurb();
+    });
   }
+  presetModeEls.forEach((el) => {
+    el.addEventListener("change", () => save(PRESET_MODE_KEY, getPresetMode()));
+  });
 
   document.querySelector('[data-action="clear-history"]').addEventListener("click", clearHistory);
   historyList.addEventListener("change", onHistoryToggle);
@@ -311,6 +322,9 @@ function paintPresetOptions() {
     opt.textContent = p.label;
     presetSelectEl.appendChild(opt);
   }
+  const { value: lastPresetId } = load(LAST_PRESET_KEY, "");
+  if (presets.some((p) => p.id === lastPresetId)) presetSelectEl.value = lastPresetId;
+  paintPresetBlurb();
 }
 
 function paintPresetBlurb() {
@@ -331,17 +345,32 @@ function applySelectedPreset() {
     flash("preset is empty");
     return;
   }
+  save(LAST_PRESET_KEY, id);
+  const mode = getPresetMode();
   const before = parseList(listEl.value);
-  const merged = parseList([listEl.value, preset.words.join("\n")].join("\n"));
-  const added = merged.length - before.length;
-  listEl.value = merged.join("\n");
-  debouncedSaveList(merged);
+  const next = mode === "replace"
+    ? parseList(preset.words.join("\n"))
+    : parseList([listEl.value, preset.words.join("\n")].join("\n"));
+  listEl.value = next.join("\n");
+  save(STORAGE_KEY, next);
   paintListMeta();
-  flash(
-    added
-      ? `added ${added} from ${preset.label}`
-      : `${preset.label} already in your list`
-  );
+  if (mode === "replace") {
+    flash(`replaced list with ${preset.label}`);
+  } else {
+    const added = next.length - before.length;
+    flash(added ? `added ${added} from ${preset.label}` : `${preset.label} already in your list`);
+  }
+}
+
+function getPresetMode() {
+  const picked = [...presetModeEls].find((el) => el.checked);
+  return picked?.value === "replace" ? "replace" : "stack";
+}
+
+function setPresetMode(mode) {
+  presetModeEls.forEach((el) => {
+    el.checked = el.value === mode;
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/site/partials/header.html
+++ b/site/partials/header.html
@@ -12,6 +12,7 @@
         <a href="/widgets/cut-up.html" data-route="/widgets/cut-up.html">Cut-up</a>
         <a href="/widgets/selector.html" data-route="/widgets/selector.html">Selector</a>
         <a href="/widgets/conductor.html" data-route="/widgets/conductor.html">Conductor</a>
+        <a href="/widgets/conductor-ratio.html" data-route="/widgets/conductor-ratio.html">Craft Ratio</a>
         <a href="/widgets/voice-clone-booth.html" data-route="/widgets/voice-clone-booth.html">Voice Booth</a>
         <a href="/widgets/manifesto.html" data-route="/widgets/manifesto.html">Manifesto</a>
         <a href="/widgets/sig.html" data-route="/widgets/sig.html">Email Sig</a>
@@ -27,7 +28,9 @@
         <a href="/widgets/name-what-you-see.html" data-route="/widgets/name-what-you-see.html">Name What You See</a>
         <a href="/widgets/word-ban.html" data-route="/widgets/word-ban.html">Word-ban</a>
         <a href="/widgets/tool-not-neutral.html" data-route="/widgets/tool-not-neutral.html">Tool Is Never Neutral</a>
+        <a href="/widgets/tool-not-neutral-matrix.html" data-route="/widgets/tool-not-neutral-matrix.html">Tool Matrix</a>
         <a href="/widgets/in-there.html" data-route="/widgets/in-there.html">Am I in There?</a>
+        <a href="/widgets/receipt-tells.html" data-route="/widgets/receipt-tells.html">Training Receipt</a>
         <a href="/widgets/taste-audit.html" data-route="/widgets/taste-audit.html">Taste Audit</a>
         <a href="/widgets/cutting-room.html" data-route="/widgets/cutting-room.html">Cutting Room</a>
         <a href="/widgets/pattern-finder.html" data-route="/widgets/pattern-finder.html">Pattern Finder</a>
@@ -60,7 +63,7 @@
         <a href="/release-day.html" data-route="/release-day.html">Release Day</a>
         <a href="/widgets/action.html" data-route="/widgets/action.html">Action Chooser</a>
         <a href="/workshop.html" data-route="/workshop.html">Workshop Kit</a>
-        <a href="/signal.html" data-route="/signal.html">Signal (Slide of the Day)</a>
+        <a href="/signal.html" data-route="/signal.html">Signal</a>
         <a href="/feed.xml">RSS Feed</a>
       </div>
     </details>

--- a/site/signal.html
+++ b/site/signal.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Signal &mdash; slide of the day</title>
+    <title>Signal &mdash; daily talk signal</title>
     <meta
       name="description"
-      content="One slide from the Punk Rock AI talk, surfaced for today. Same slide for every visitor on the same day. Cycles through the deck once a year."
+      content="One slide or quote from the Punk Rock AI talk, surfaced for today. Same signal for every visitor on the same UTC day."
     />
     <meta name="theme-color" content="#0a0a0a" />
     <meta property="og:type" content="article" />
-    <meta property="og:title" content="Signal — slide of the day" />
-    <meta property="og:description" content="One slide from the talk, surfaced for today." />
+    <meta property="og:title" content="Signal — daily talk signal" />
+    <meta property="og:description" content="One slide or quote from the talk, surfaced for today." />
     <meta property="og:url" content="https://punkrockai.com/signal.html" />
     <meta name="twitter:card" content="summary_large_image" />
     <link rel="stylesheet" href="/css/theme.css" />
@@ -33,12 +33,17 @@
             <span class="signal__tag">Signal</span>
             <time class="signal__date" data-signal-date></time>
           </p>
-          <h1 class="signal__title" data-signal-title>Slide of the day</h1>
+          <h1 class="signal__title" data-signal-title>Signal of the day</h1>
           <p class="signal__act" data-signal-act></p>
           <p class="signal__note" data-signal-note hidden></p>
           <p class="signal__meta">
             <span data-signal-index></span>
           </p>
+          <nav class="signal__nav" aria-label="Signal date navigation">
+            <a class="signal__nav-link" data-signal-prev href="/signal.html">←</a>
+            <a class="signal__nav-link signal__nav-link--today" data-signal-today href="/signal.html">Today</a>
+            <a class="signal__nav-link" data-signal-next href="/signal.html">→</a>
+          </nav>
           <p class="signal__cta">
             <a class="btn" data-signal-recap href="/recap.html#slides">Read the recap</a>
             <a class="btn btn--ghost" data-signal-talk href="/talk.html">See the full talk</a>

--- a/site/widgets/conductor-ratio.html
+++ b/site/widgets/conductor-ratio.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Conductor Craft Ratio &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="A draggable conductor slider for choosing the ratio between AI throughput and human craft, cost, and loss."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="Conductor Craft Ratio — Punk Rock AI" />
+    <meta property="og:description" content="Move between 90, 50, and 10 percent machine throughput and see what changes in craft, cost, and loss." />
+    <meta property="og:url" content="https://punkrockai.com/widgets/conductor-ratio.html" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/punk-graphics.css" />
+    <link rel="stylesheet" href="/css/widgets/conductor-ratio.css" />
+    <link rel="stylesheet" href="/css/zine-overhaul.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main class="cratio">
+      <section class="cratio-hero grain scanlines punk-tile punk-section--make">
+        <div class="section-slide-bg" aria-hidden="true" style="background-image: url('/public/slides/taste-full.webp');"></div>
+        <span class="punk-slash" style="--punk-x:78%;--punk-y:24%;--punk-rotate:-12deg;--punk-scale:1.1;--punk-opacity:0.38;" aria-hidden="true"></span>
+        <div class="wrap wrap--narrow">
+          <p class="kicker kicker--accent">Conductor &middot; craft ratio</p>
+          <h1 id="cratio-title">Conductor craft ratio.</h1>
+          <p id="cratio-lede"></p>
+        </div>
+      </section>
+
+      <section class="cratio-board" aria-labelledby="cratio-control-title">
+        <div class="wrap">
+          <div class="cratio-board__head">
+            <div>
+              <p class="kicker kicker--accent">Drag, tap, or use arrow keys</p>
+              <h2 id="cratio-control-title">How much of the pipeline do you hand to the machine?</h2>
+            </div>
+            <output class="cratio-board__readout" id="cratio-output" for="cratio-slider">50%</output>
+          </div>
+
+          <div class="cratio-slider" data-slider-shell>
+            <div class="cratio-slider__track" aria-hidden="true">
+              <span class="cratio-slider__fill" data-fill></span>
+            </div>
+            <input
+              id="cratio-slider"
+              class="cratio-slider__input"
+              type="range"
+              min="0"
+              max="100"
+              step="1"
+              value="50"
+              aria-label="Machine throughput ratio"
+              aria-describedby="cratio-slider-help"
+            />
+            <div class="cratio-slider__anchors" id="cratio-anchors"></div>
+          </div>
+          <p class="sr-only" id="cratio-slider-help">
+            Left and right arrow keys move one percent. Page keys move ten percent. Anchor buttons jump to 90, 50, or 10 percent.
+          </p>
+
+          <article class="cratio-card" id="cratio-card" aria-live="polite"></article>
+        </div>
+      </section>
+
+      <section class="cratio-final">
+        <div class="wrap wrap--narrow">
+          <h2 id="cratio-closing-title"></h2>
+          <p id="cratio-closing-body"></p>
+          <p class="cratio-final__cite" id="cratio-closing-cite"></p>
+          <div class="cratio-final__actions">
+            <a class="btn" href="/widgets/conductor.html">Conduct the orchestra</a>
+            <a class="btn" href="/widgets/taste-audit.html">Audit your taste</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/conductor-ratio.js"></script>
+  </body>
+</html>

--- a/site/widgets/cutting-room-buckets.html
+++ b/site/widgets/cutting-room-buckets.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cutting Room Buckets &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="Sort the keynote cutting-room floor into keep, cut, and save-for-later buckets."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:title" content="Cutting Room Buckets — Punk Rock AI" />
+    <meta property="og:description" content="Sort the keynote cutting-room floor." />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/punk-graphics.css" />
+    <link rel="stylesheet" href="/css/widgets/cutting-room-buckets.css" />
+    <link rel="stylesheet" href="/css/zine-overhaul.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main class="crb">
+      <section class="crb-intro grain scanlines punk-tile punk-section--make">
+        <div class="section-slide-bg" aria-hidden="true" style="background-image: url('/public/slides/taste-drip.webp'); opacity: 0.07; mix-blend-mode: screen;"></div>
+        <span class="punk-slash" style="--punk-x:78%;--punk-y:15%;--punk-rotate:-10deg;--punk-scale:1.3;--punk-opacity:0.38;" aria-hidden="true"></span>
+        <div class="wrap wrap--narrow">
+          <p class="kicker kicker--accent">Slides 6&ndash;9 &middot; cutting room floor</p>
+          <h1>Sort the refuse pile.</h1>
+          <p class="crb-intro__lede">
+            Drag every cut beat into a bucket: keep, cut, or save for later. The link carries your choices.
+          </p>
+          <p class="crb-intro__neighbor">
+            Companion to <a href="/widgets/cutting-room.html">/widgets/cutting-room</a>.
+          </p>
+        </div>
+      </section>
+
+      <section class="crb-toolbar" aria-label="Bucket actions">
+        <div class="wrap">
+          <div class="crb-counts" id="crb-counts" aria-live="polite"></div>
+          <div class="crb-actions">
+            <button class="btn btn--primary" type="button" id="crb-copy-link">Copy share link</button>
+            <button class="btn" type="button" id="crb-export">Export PNG</button>
+            <button class="btn" type="button" id="crb-reset">Reset</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="crb-board" aria-label="Cutting room sorting board">
+        <div class="crb-pool" id="crb-pool" data-bucket="unassigned">
+          <header class="crb-pool__head">
+            <p class="kicker kicker--accent">Unsorted cards</p>
+            <p id="crb-status">Loading cuts...</p>
+          </header>
+        </div>
+
+        <div class="crb-buckets" id="crb-buckets">
+          <section class="crb-bucket" data-bucket="keep" aria-labelledby="bucket-keep">
+            <header>
+              <span class="crb-bucket__mark">01</span>
+              <h2 id="bucket-keep">Keep</h2>
+            </header>
+            <div class="crb-bucket__drop" data-dropzone="keep"></div>
+          </section>
+
+          <section class="crb-bucket" data-bucket="cut" aria-labelledby="bucket-cut">
+            <header>
+              <span class="crb-bucket__mark">02</span>
+              <h2 id="bucket-cut">Cut</h2>
+            </header>
+            <div class="crb-bucket__drop" data-dropzone="cut"></div>
+          </section>
+
+          <section class="crb-bucket" data-bucket="later" aria-labelledby="bucket-later">
+            <header>
+              <span class="crb-bucket__mark">03</span>
+              <h2 id="bucket-later">Save for later</h2>
+            </header>
+            <div class="crb-bucket__drop" data-dropzone="later"></div>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/cutting-room-buckets.js"></script>
+  </body>
+</html>

--- a/site/widgets/pattern-finder.html
+++ b/site/widgets/pattern-finder.html
@@ -29,9 +29,9 @@
           <h1>Make it legible.</h1>
           <p class="pf-intro__lede">
             Paste anything you&rsquo;ve made. Old blog posts. Photo captions.
-            Project descriptions. The model reads it back and names the
-            structural patterns you&rsquo;ve been making without ever
-            consciously articulating them.
+            Project descriptions. For now, this page prepares the corpus and
+            prompt for a model you choose; the live backend stays off until the
+            cost, privacy, and abuse controls are accepted.
           </p>
           <p class="pf-intro__pull">
             That&rsquo;s not replacement. That&rsquo;s revelation.
@@ -47,7 +47,8 @@
               <p>
                 Forty thousand characters max &mdash; that&rsquo;s about 8,000
                 words, or twenty blog posts. Drafts auto-save locally. No
-                content leaves your browser unless you press the button.
+                content leaves your browser unless you copy the prompt or press
+                the backend button in an environment where it has been wired.
               </p>
               <label class="sr-only" for="pf-input">Corpus to analyze</label>
               <textarea
@@ -71,8 +72,8 @@
               <h2>The patterns</h2>
               <p>
                 Four to seven patterns named in your own register, each with
-                two or three quoted excerpts as evidence. Don&rsquo;t expect
-                hype &mdash; the prompt forbids it.
+                two or three quoted excerpts as evidence. The built-in path is
+                copy-paste until a production backend is intentionally enabled.
               </p>
               <div class="pf__results" id="pf-results" aria-live="polite"></div>
               <div class="pf__fallback" id="pf-fallback" hidden>

--- a/site/widgets/receipt-tells.html
+++ b/site/widgets/receipt-tells.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Training-corpus receipt &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="Paste AI-generated text and print a receipt-style heuristic readout: stock phrases, hedging, em-dash density, and a few overused AI-tell verbs. Educational, not definitive."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:title" content="Training-corpus receipt — Punk Rock AI" />
+    <meta
+      property="og:description"
+      content="A non-definitive receipt of common AI-output tells: phrase matches, hedging, em dashes, and delve/leverage/optimize frequency."
+    />
+    <meta property="og:url" content="https://punkrockai.com/widgets/receipt-tells.html" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/punk-graphics.css" />
+    <link rel="stylesheet" href="/css/widgets/receipt-tells.css" />
+    <link rel="stylesheet" href="/css/zine-overhaul.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main>
+      <section class="rctl-intro grain scanlines punk-tile punk-section--name" style="position: relative; overflow: hidden;">
+        <div class="section-slide-bg" aria-hidden="true" style="background-image: url('/public/slides/feed-machine-stamp.webp'); opacity: 0.07; mix-blend-mode: screen;"></div>
+        <span class="punk-refuse" style="--punk-x:80%;--punk-y:22%;--punk-scale:0.9;--punk-opacity:0.34;" aria-hidden="true"></span>
+        <div class="wrap wrap--narrow" style="position: relative; z-index: 1;">
+          <p class="kicker kicker--accent">Slide 10 &middot; the receipt moment</p>
+          <h1>Training-corpus receipt.</h1>
+          <p class="rctl-intro__lede">
+            Paste AI-generated text. The printer marks a few familiar tells:
+            stock phrases, hedging, em-dash density, and the tiny word cloud
+            around delve, leverage, and optimize.
+          </p>
+          <p class="rctl-intro__hint">
+            Heuristic only. This cannot prove authorship, training origin, or
+            model use. It just names visible patterns in the pasted text.
+          </p>
+        </div>
+      </section>
+
+      <section class="rctl-caveat" aria-label="Heuristic caveat">
+        <div class="wrap wrap--narrow">
+          <p class="rctl-caveat__tag">Non-definitive by design</p>
+          <p>
+            These checks are receipts, not verdicts. Human writers can hedge,
+            use em dashes, and say leverage. AI systems can avoid every marker
+            here. Use this as a pattern-naming aid, not an accusation machine.
+          </p>
+        </div>
+      </section>
+
+      <section class="rctl-app">
+        <div class="wrap">
+          <div class="rctl-layout">
+            <form class="rctl-panel" id="rctl-form">
+              <h2 class="rctl-h2">Pastebox</h2>
+              <label class="sr-only" for="rctl-input">AI-generated text to inspect</label>
+              <textarea
+                id="rctl-input"
+                class="rctl-textarea"
+                rows="12"
+                placeholder="Paste AI-generated text here. The receipt prints local heuristics only; nothing leaves your browser."
+              ></textarea>
+              <div class="rctl-row">
+                <button class="btn btn--primary" type="submit">Print tells</button>
+                <button class="btn" type="button" data-action="sample">Load sample</button>
+                <button class="btn" type="reset">Clear</button>
+              </div>
+              <p class="rctl-status" id="rctl-status" aria-live="polite"></p>
+            </form>
+
+            <div class="rctl-stage" aria-label="Receipt-style heuristic report">
+              <div class="rctl-printer" aria-hidden="true">
+                <div class="rctl-printer__slot"></div>
+              </div>
+              <article class="rctl-receipt" id="rctl-receipt" aria-live="polite">
+                <header class="rctl-receipt__head">
+                  <p class="rctl-receipt__brand">PUNK ROCK AI</p>
+                  <p class="rctl-receipt__sub">TRAINING-CORPUS TELLS</p>
+                  <p class="rctl-receipt__rule" aria-hidden="true">================================</p>
+                  <p class="rctl-receipt__meta">
+                    <span data-stamp>0000-00-00</span>
+                    <span data-time>00:00</span>
+                  </p>
+                  <p class="rctl-receipt__rule" aria-hidden="true">--------------------------------</p>
+                </header>
+                <div class="rctl-receipt__body" id="rctl-output">
+                  <p class="rctl-receipt__placeholder">Paste text and print the tells.</p>
+                </div>
+                <footer class="rctl-receipt__foot">
+                  <p class="rctl-receipt__rule" aria-hidden="true">================================</p>
+                  <p>NOT PROOF. JUST PATTERNS.</p>
+                  <p class="rctl-receipt__barcode" aria-hidden="true">|||| || |||| ||| ||||</p>
+                </footer>
+              </article>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/receipt-tells.js"></script>
+  </body>
+</html>

--- a/site/widgets/tool-not-neutral-matrix.html
+++ b/site/widgets/tool-not-neutral-matrix.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tool Not Neutral Matrix &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="A 5 by 5 matrix of tool types, design decisions, and real cases showing how every tool ships values."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:title" content="Tool Not Neutral Matrix — Punk Rock AI" />
+    <meta property="og:description" content="Hover or tap the matrix to see real cases behind design choices." />
+    <meta property="og:url" content="https://punkrockai.com/widgets/tool-not-neutral-matrix.html" />
+    <meta property="og:image" content="https://punkrockai.com/public/slides/tool-neutral-full.webp" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/punk-graphics.css" />
+    <link rel="stylesheet" href="/css/widgets/tool-not-neutral-matrix.css" />
+    <link rel="stylesheet" href="/css/zine-overhaul.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main>
+      <section class="tnnm-hero punk-tile grain scanlines punk-section--name">
+        <div class="section-slide-bg" style="background-image: url('/public/slides/tool-neutral-full.webp');" aria-hidden="true"></div>
+        <div class="wrap wrap--narrow">
+          <p class="kicker kicker--accent">Slide 19 &middot; matrix variant</p>
+          <h1>Tool not neutral: the pattern map.</h1>
+          <p>
+            Five tool families. Five design axes. Every square is a choice someone made,
+            with a real case underneath it.
+          </p>
+        </div>
+      </section>
+
+      <section class="tnnm" aria-labelledby="tnnm-title">
+        <div class="wrap">
+          <div class="tnnm__head">
+            <div>
+              <p class="kicker kicker--accent">Hover, focus, or tap a cell</p>
+              <h2 id="tnnm-title">Where the value gets baked in</h2>
+            </div>
+            <p class="tnnm__hint">Swipe the expanded case on mobile to move between cells.</p>
+          </div>
+
+          <div class="tnnm__status" id="tnnm-status" aria-live="polite">Loading cases...</div>
+          <div class="tnnm__matrix" id="tnnm-matrix" aria-label="Tool type by design axis matrix"></div>
+          <article class="tnnm__detail" id="tnnm-detail" aria-live="polite"></article>
+        </div>
+      </section>
+
+      <section class="tnnm-coda">
+        <div class="wrap wrap--narrow">
+          <p>
+            Same evidence as the <a href="/widgets/tool-not-neutral.html">card-walker</a>,
+            rearranged for pattern recognition instead of sequence.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/tool-not-neutral-matrix.js"></script>
+  </body>
+</html>

--- a/site/widgets/word-ban.html
+++ b/site/widgets/word-ban.html
@@ -96,14 +96,24 @@
             <aside class="wban__sidebar">
               <div class="wban__presets">
                 <h2>Industry presets</h2>
-                <p class="wban__presets-help">Stack any preset onto your list. Custom additions stay.</p>
+                <p class="wban__presets-help">Stack or replace your list with a saved preset.</p>
                 <label class="sr-only" for="wban-preset">Choose an industry preset</label>
                 <div class="wban__row wban__row--tight">
                   <select id="wban-preset" class="wban__select">
                     <option value="">Pick a preset&hellip;</option>
                   </select>
-                  <button class="btn" type="button" data-action="apply-preset">Add to list</button>
+                  <button class="btn" type="button" data-action="apply-preset">Apply preset</button>
                 </div>
+                <fieldset class="wban__preset-mode" aria-label="Preset apply mode">
+                  <label>
+                    <input type="radio" name="wban-preset-mode" value="stack" checked />
+                    <span>Stack</span>
+                  </label>
+                  <label>
+                    <input type="radio" name="wban-preset-mode" value="replace" />
+                    <span>Replace</span>
+                  </label>
+                </fieldset>
                 <p class="wban__preset-blurb" id="wban-preset-blurb"></p>
               </div>
 

--- a/worker/pattern-finder/README.md
+++ b/worker/pattern-finder/README.md
@@ -2,10 +2,11 @@
 
 Cloudflare Worker prototype that proxies Claude Sonnet 4.6 calls for the
 Pattern Finder widget at `/widgets/pattern-finder.html`. Production backend
-ownership is still undecided in #139 / BC-56; do not deploy this as the active
-path until that decision is accepted. System prompt marked for ephemeral prompt
-caching so per-call cost stays low under load. Per-IP rate-limit (10 calls /
-hour) via a bound KV namespace.
+ownership decision for #139 / BC-56: keep Pattern Finder fallback-only for the
+Release Day push. Do not deploy this as the active path until the project
+accepts a live LLM budget, privacy notice, and abuse-control plan. System
+prompt marked for ephemeral prompt caching so per-call cost stays low under
+load. Per-IP rate-limit (10 calls / hour) via a bound KV namespace.
 
 ## Deploy
 


### PR DESCRIPTION
## Summary
- Ships the issue-swarm widget batch: Word-ban journalism/replace mode, Signal quote/date navigation, Conductor ratio, Cutting-room buckets, Training-corpus receipt, and Tool Not Neutral matrix.
- Documents the Release Day moderation-to-gallery path with explicit fallback and rollback steps, while keeping live Notion smoke as a separate blocker.
- Records the Pattern Finder Release Day decision as fallback-only/copy-paste, deferring live backend work until budget, privacy, rate-limit, and abuse controls are accepted.
- Keeps Adobe involvement and recording rights marked as named-confirmation blockers.

## Tracking
Closes #122
Closes #123
Closes #124
Closes #125
Closes #126
Closes #127
Closes #139
Refs #134
Refs #135
Refs #136
Linear: BC-53, BC-56; related BC-51, BC-52

## Verification
- `npm run build:decisions`
- `npm run eval`
- Browser smoke on local `http://localhost:3000`: `/signal`, `/word-ban`, `/conductor-ratio`, `/cutting-room-buckets`, `/receipt-tells`, `/tool-not-neutral-matrix`, `/release-day`, and `/pattern-finder`.
- Mocked `/api/submissions` browser smoke confirmed `queued-no-backend` saves to local pending and leaves the draft available.

## Still not closed here
- #134 / BC-53 still needs published-row gallery proof against configured Vercel/Notion before full closure.
- #135 / BC-51 still needs live preview/production browser-to-Notion smoke evidence.
- #136 / BC-52 still needs named confirmation for Adobe role and recording rights.

Draft because this intentionally batches several issue-swarm outputs and should get one review pass before merge.