### PR TITLE
Add agentic delivery contract

### DIFF
--- a/.github/ISSUE_TEMPLATE/agentic-task.md
+++ b/.github/ISSUE_TEMPLATE/agentic-task.md
@@ -1,0 +1,35 @@
+---
+name: Agentic task
+about: Agent-ready bug report or feature request
+title: ''
+labels: ['needs-triage']
+assignees: ''
+---
+
+## Context
+
+<!-- Why does this issue exist? What problem or need does it address? -->
+
+## Acceptance Criteria
+
+- [ ]
+
+## Tests/Evals
+
+-
+
+## Verification
+
+-
+
+## Agent Instructions
+
+<!-- Relevant files, constraints, and implementation notes. -->
+
+## Out of Scope
+
+<!-- What this issue is NOT doing. -->
+
+## Linear
+
+<!-- Linear key or project reference, when known. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Summary
+
+- 
+
+## Verification
+
+- [ ] 
+
+## Agentic Delivery
+- [ ] Linked with `Closes #...` only when every acceptance criterion is met
+- [ ] Acceptance self-check included when opened by an agent
+- [ ] Diff is within 20 files / 500 changed lines, or human approval is documented

--- a/.github/workflows/agentic-dev-loop.yml
+++ b/.github/workflows/agentic-dev-loop.yml
@@ -1,0 +1,120 @@
+name: Agentic Dev Loop
+
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: GitHub issue number to attempt
+        required: true
+      provider:
+        description: Provider adapter name
+        required: false
+        default: noop
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: read
+  checks: read
+
+concurrency:
+  group: agentic-dev-loop-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  run:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'agent:ready' }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AGENTIC_PROVIDER: ${{ github.event.inputs.provider || vars.AGENTIC_PROVIDER || 'noop' }}
+      AGENTIC_PROVIDER_COMMAND: ${{ secrets.AGENTIC_PROVIDER_COMMAND }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure standard labels
+        run: python3 scripts/agentic/ensure_labels.py
+
+      - name: Fetch issue
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+        run: |
+          gh issue view "$ISSUE_NUMBER" --json title --jq '.title' > "$RUNNER_TEMP/issue-title.txt"
+          gh issue view "$ISSUE_NUMBER" --json body --jq '.body // ""' > "$RUNNER_TEMP/issue.md"
+          gh issue view "$ISSUE_NUMBER" --json labels --jq '[.labels[].name] | join(",")' > "$RUNNER_TEMP/labels.txt"
+          echo "ISSUE_NUMBER=$ISSUE_NUMBER" >> "$GITHUB_ENV"
+          {
+            echo "ISSUE_TITLE<<EOF"
+            cat "$RUNNER_TEMP/issue-title.txt"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Create work branch
+        id: branch
+        run: |
+          SLUG=$(python3 -c "import pathlib, sys; sys.path.insert(0, 'scripts/agentic'); from common import slugify; print(slugify(pathlib.Path('$RUNNER_TEMP/issue-title.txt').read_text()))")
+          REF=$(python3 -c "import pathlib, re; text=pathlib.Path('$RUNNER_TEMP/issue-title.txt').read_text()+pathlib.Path('$RUNNER_TEMP/issue.md').read_text(); match=re.search(r'\b[A-Z]{2,}-[0-9]+\b', text); print(match.group(0) if match else 'issue-${ISSUE_NUMBER}')")
+          BRANCH="codex/${REF}-${SLUG}"
+          git switch -c "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Mark issue in progress
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --add-label "in-progress"
+          gh issue comment "$ISSUE_NUMBER" --body "Agentic dev loop started on branch \`${{ steps.branch.outputs.branch }}\` with provider \`${AGENTIC_PROVIDER}\`."
+
+      - name: Run provider and verification
+        id: loop
+        run: |
+          set +e
+          python3 scripts/agentic/dev_loop.py \
+            --issue-number "$ISSUE_NUMBER" \
+            --issue-title "$ISSUE_TITLE" \
+            --issue-file "$RUNNER_TEMP/issue.md" \
+            --labels "$(cat "$RUNNER_TEMP/labels.txt")" \
+            --provider "$AGENTIC_PROVIDER" \
+            --json-output "$RUNNER_TEMP/agentic-dev-loop-result.json" \
+            --pr-body-output "$RUNNER_TEMP/agentic-pr-body.md"
+          rc=$?
+          echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
+          python3 -c "import json; print('action=' + json.load(open('$RUNNER_TEMP/agentic-dev-loop-result.json'))['action'])" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Open pull request
+        if: steps.loop.outputs.exit_code == '0' && steps.loop.outputs.action == 'open-pr'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet && exit 1
+          git commit -m "fix: ${ISSUE_TITLE}"
+          git push --set-upstream origin "${{ steps.branch.outputs.branch }}"
+          PR_URL=$(gh pr create \
+            --title "$ISSUE_TITLE" \
+            --body-file "$RUNNER_TEMP/agentic-pr-body.md" \
+            --base main \
+            --head "${{ steps.branch.outputs.branch }}")
+          echo "$PR_URL" > "$RUNNER_TEMP/pr-url.txt"
+          gh issue comment "$ISSUE_NUMBER" --body "Agentic dev loop opened PR: ${PR_URL}"
+
+      - name: Comment dry-run or no-change result
+        if: steps.loop.outputs.exit_code == '0' && steps.loop.outputs.action != 'open-pr'
+        run: |
+          python3 -c "import json; data=json.load(open('$RUNNER_TEMP/agentic-dev-loop-result.json')); print('Agentic dev loop finished without opening a PR. Status: ' + data.get('status', 'unknown') + '. Provider: ' + data.get('provider', {}).get('provider', 'unknown') + '.')" > "$RUNNER_TEMP/comment.md"
+          gh issue comment "$ISSUE_NUMBER" --body-file "$RUNNER_TEMP/comment.md"
+
+      - name: Escalate failed run
+        if: steps.loop.outputs.exit_code != '0'
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --add-label "needs-human"
+          python3 -c "import json; data=json.load(open('$RUNNER_TEMP/agentic-dev-loop-result.json')); print('Agentic dev loop failed: ' + data.get('message', data.get('status', 'unknown')))" > "$RUNNER_TEMP/comment.md"
+          gh issue comment "$ISSUE_NUMBER" --body-file "$RUNNER_TEMP/comment.md"
+
+      - name: Clear in-progress label
+        if: always()
+        run: gh issue edit "$ISSUE_NUMBER" --remove-label "in-progress" || true

--- a/.github/workflows/agentic-issue-quality.yml
+++ b/.github/workflows/agentic-issue-quality.yml
@@ -1,0 +1,79 @@
+name: Agentic Issue Quality
+
+on:
+  issues:
+    types: [labeled, edited, reopened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: GitHub issue number to lint
+        required: true
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: agentic-issue-quality-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure standard labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/agentic/ensure_labels.py
+
+      - name: Fetch issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+        run: |
+          gh issue view "$ISSUE_NUMBER" --json body --jq '.body // ""' > "$RUNNER_TEMP/issue.md"
+          gh issue view "$ISSUE_NUMBER" --json labels --jq '[.labels[].name] | join(",")' > "$RUNNER_TEMP/labels.txt"
+          echo "ISSUE_NUMBER=$ISSUE_NUMBER" >> "$GITHUB_ENV"
+
+      - name: Check for ready label
+        id: ready
+        run: |
+          python3 -c "import sys; labels=set(open('$RUNNER_TEMP/labels.txt').read().strip().split(',')); ready={'agent:ready','auto-implement','autonomous'}; print('has_ready=' + str(bool(labels & ready)).lower())" >> "$GITHUB_OUTPUT"
+
+      - name: Run issue quality linter
+        if: steps.ready.outputs.has_ready == 'true'
+        id: lint
+        run: |
+          set +e
+          python3 scripts/agentic/issue_lint.py \
+            --issue-file "$RUNNER_TEMP/issue.md" \
+            --labels "$(cat "$RUNNER_TEMP/labels.txt")" \
+            --json-output "$RUNNER_TEMP/lint.json"
+          rc=$?
+          echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Normalize ready aliases
+        if: steps.ready.outputs.has_ready == 'true' && steps.lint.outputs.exit_code == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --add-label "agent:ready"
+          python3 -c "import json; print(' '.join(json.load(open('$RUNNER_TEMP/lint.json'))['alias_labels']))" > "$RUNNER_TEMP/aliases.txt"
+          for label in $(cat "$RUNNER_TEMP/aliases.txt"); do
+            gh issue edit "$ISSUE_NUMBER" --remove-label "$label" || true
+          done
+
+      - name: Block invalid ready issue
+        if: steps.ready.outputs.has_ready == 'true' && steps.lint.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for label in "agent:ready" "auto-implement" "autonomous"; do
+            gh issue edit "$ISSUE_NUMBER" --remove-label "$label" || true
+          done
+          gh issue edit "$ISSUE_NUMBER" --add-label "needs-human"
+          python3 -c "import json; print('Agentic issue quality gate failed: ' + json.load(open('$RUNNER_TEMP/lint.json'))['message'])" > "$RUNNER_TEMP/comment.md"
+          gh issue comment "$ISSUE_NUMBER" --body-file "$RUNNER_TEMP/comment.md"

--- a/.github/workflows/agentic-pr-review.yml
+++ b/.github/workflows/agentic-pr-review.yml
@@ -1,0 +1,78 @@
+name: Agentic PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to review
+        required: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: agentic-pr-review-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.pull_request.head.ref, 'codex/issue-') || startsWith(github.event.pull_request.head.ref, 'codex/BC-') || startsWith(github.event.pull_request.head.ref, 'codex/bc-') }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure standard labels
+        run: python3 scripts/agentic/ensure_labels.py
+
+      - name: Fetch PR and linked issue
+        id: fetch
+        run: |
+          gh pr view "$PR_NUMBER" --json body --jq '.body // ""' > "$RUNNER_TEMP/pr-body.md"
+          gh pr view "$PR_NUMBER" --json additions --jq '.additions' > "$RUNNER_TEMP/additions.txt"
+          gh pr view "$PR_NUMBER" --json deletions --jq '.deletions' > "$RUNNER_TEMP/deletions.txt"
+          gh pr view "$PR_NUMBER" --json changedFiles --jq '.changedFiles' > "$RUNNER_TEMP/changed-files.txt"
+          ISSUE_NUMBER=$(python3 -c "import pathlib, re; match=re.search(r'\bCloses\s+#(\d+)', pathlib.Path('$RUNNER_TEMP/pr-body.md').read_text(), re.I); print(match.group(1) if match else '')")
+          echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+          if [ -n "$ISSUE_NUMBER" ]; then
+            gh issue view "$ISSUE_NUMBER" --json body --jq '.body // ""' > "$RUNNER_TEMP/issue.md"
+          else
+            : > "$RUNNER_TEMP/issue.md"
+          fi
+
+      - name: Run acceptance review
+        id: review
+        run: |
+          set +e
+          python3 scripts/agentic/pr_review.py \
+            --issue-file "$RUNNER_TEMP/issue.md" \
+            --pr-body-file "$RUNNER_TEMP/pr-body.md" \
+            --additions "$(cat "$RUNNER_TEMP/additions.txt")" \
+            --deletions "$(cat "$RUNNER_TEMP/deletions.txt")" \
+            --changed-files "$(cat "$RUNNER_TEMP/changed-files.txt")" \
+            --json-output "$RUNNER_TEMP/pr-review.json"
+          rc=$?
+          echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
+          python3 -c "import json; print(json.load(open('$RUNNER_TEMP/pr-review.json'))['comment'])" > "$RUNNER_TEMP/pr-review-comment.md"
+          exit 0
+
+      - name: Comment verdict
+        run: gh pr comment "$PR_NUMBER" --body-file "$RUNNER_TEMP/pr-review-comment.md"
+
+      - name: Mark review ready
+        if: steps.review.outputs.exit_code == '0'
+        run: |
+          gh pr edit "$PR_NUMBER" --add-label "review-ready"
+          gh pr edit "$PR_NUMBER" --remove-label "needs-human" || true
+
+      - name: Mark needs human
+        if: steps.review.outputs.exit_code != '0'
+        run: |
+          gh pr edit "$PR_NUMBER" --add-label "needs-human"
+          gh pr edit "$PR_NUMBER" --remove-label "review-ready" || true

--- a/agentic/contract.json
+++ b/agentic/contract.json
@@ -1,0 +1,57 @@
+{
+  "version": 1,
+  "repo": {
+    "owner": "WalksWithASwagger",
+    "name": "cmvan-keynote",
+    "linear_team": "Bc-ai",
+    "linear_project": "Punk Rock AI Release Day Roadmap",
+    "canonical_local_root": "/Users/kk/Code/cmvan-keynote",
+    "non_canonical_local_roots": []
+  },
+  "labels": {
+    "ready": "agent:ready",
+    "ready_aliases": [
+      "auto-implement",
+      "autonomous"
+    ],
+    "review_ready": "review-ready",
+    "stop": [
+      "needs-human",
+      "blocked",
+      "in-progress"
+    ]
+  },
+  "limits": {
+    "max_changed_files": 20,
+    "max_changed_lines": 500
+  },
+  "branch_template": "codex/{linear_key_or_issue}-{slug}",
+  "provider": {
+    "default": "noop",
+    "allowed": [
+      "noop",
+      "command"
+    ],
+    "command_env": "AGENTIC_PROVIDER_COMMAND"
+  },
+  "verification": {
+    "commands": [
+      "npm run eval"
+    ]
+  },
+  "issue_quality": {
+    "required_sections": [
+      "Context",
+      "Acceptance Criteria",
+      "Tests/Evals",
+      "Verification",
+      "Agent Instructions",
+      "Out of Scope"
+    ],
+    "required_ready_labels": [
+      "agent:ready",
+      "auto-implement",
+      "autonomous"
+    ]
+  }
+}

--- a/docs/AGENTIC-DELIVERY.md
+++ b/docs/AGENTIC-DELIVERY.md
@@ -1,0 +1,83 @@
+# Agentic Delivery Contract
+
+This repo uses GitHub as execution truth and Linear as planning/status truth. v1 turns a qualified GitHub issue into a tested PR. It does not auto-merge.
+
+## Repo Identity
+
+- GitHub repo: `WalksWithASwagger/cmvan-keynote`
+- Linear team: `Bc-ai` (`BC`)
+- Linear project: `Punk Rock AI Release Day Roadmap`
+- Canonical local root: `/Users/kk/Code/cmvan-keynote`
+
+## Labels
+
+- Ready: `agent:ready`
+- Ready aliases accepted for migration: `auto-implement`, `autonomous`
+- Review: `review-ready`
+- Stop labels: `needs-human`, `blocked`, `in-progress`
+
+New work should use `agent:ready`. The issue quality workflow normalizes aliases to `agent:ready`.
+
+## Required Issue Shape
+
+An issue can only keep a ready label when it includes all required sections:
+
+- `## Context`
+- `## Acceptance Criteria`
+- `## Tests/Evals`
+- `## Verification`
+- `## Agent Instructions`
+- `## Out of Scope`
+
+Acceptance criteria must include Markdown checkboxes. The linter rejects ready issues missing tests/evals or other required sections.
+
+## Runner Flow
+
+1. A human or chat command creates a complete GitHub issue and matching Linear issue.
+2. `agent:ready` triggers `.github/workflows/agentic-issue-quality.yml`.
+3. If quality passes, `.github/workflows/agentic-dev-loop.yml` may run.
+4. The dev loop checks pause controls, stop labels, issue quality, clean worktree state, provider output, repo verification commands, and diff limits.
+5. If verification passes and the diff is within 20 files and 500 changed lines, the runner opens a PR on `codex/<linear-key-or-issue>-<slug>`.
+6. `.github/workflows/agentic-pr-review.yml` comments an acceptance verdict and applies `review-ready` or `needs-human`.
+7. A human reviews and merges. v1 never auto-merges.
+
+## Verification Commands
+
+- `npm run eval`
+
+## Pause Controls
+
+Use either control to stop new dev-loop work:
+
+- Add `.dev-loop-pause` at the repo root.
+- Set the Actions variable `LOOP_PAUSED` to a truthy value.
+
+Repos without provider secrets remain dry-run only through the `noop` adapter.
+
+## Provider Adapter
+
+Config lives in [`agentic/contract.json`](../agentic/contract.json). v1 supports:
+
+- `noop`: deterministic dry-run with no file changes.
+- `command`: runs the command in `AGENTIC_PROVIDER_COMMAND`.
+
+Real providers must be selected through repo variables/secrets, not hardcoded in scripts.
+
+## Break Glass
+
+To disable the system:
+
+1. Set `LOOP_PAUSED=true` in Actions variables.
+2. Add or commit `.dev-loop-pause` for an immediate repo-local hard stop.
+3. Remove `agent:ready`, `auto-implement`, and `autonomous` labels from active issues.
+4. Add `needs-human` to active agentic issues and PRs.
+5. Disable `agentic-dev-loop.yml` in GitHub Actions if labels are still being applied externally.
+
+## Local Commands
+
+```bash
+python3 scripts/agentic/issue_lint.py --issue-file issue.md --labels agent:ready
+python3 scripts/agentic/dev_loop.py --issue-number 1 --issue-title "Example" --issue-file issue.md --labels agent:ready --provider noop
+python3 scripts/agentic/ensure_labels.py --dry-run
+python3 -m pytest tests/agentic
+```

--- a/docs/LINEAR-GITHUB-PIPELINE.md
+++ b/docs/LINEAR-GITHUB-PIPELINE.md
@@ -12,6 +12,9 @@ planning. The current execution project is:
 
 ## Contract
 
+Agentic delivery contract: [`agentic/contract.json`](../agentic/contract.json). v1 opens PRs only; humans remain the merge gate. Ready work uses `agent:ready`; `auto-implement` and `autonomous` are migration aliases.
+
+
 1. Each roadmap implementation item gets a GitHub issue and a linked Linear
    issue.
 2. Linear owns project sequencing, milestones, status, due dates, and human

--- a/scripts/agentic/common.py
+++ b/scripts/agentic/common.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Shared helpers for the agentic delivery scripts."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+ROOT_MARKERS = ("agentic/contract.json", ".git")
+
+
+def repo_root(start: Path | None = None) -> Path:
+    current = (start or Path.cwd()).resolve()
+    for candidate in (current, *current.parents):
+        if all((candidate / marker).exists() for marker in ROOT_MARKERS):
+            return candidate
+    raise RuntimeError(f"Could not find repo root from {current}")
+
+
+def load_contract(root: Path | None = None) -> dict[str, Any]:
+    base = root or repo_root()
+    path = base / "agentic" / "contract.json"
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def slugify(value: str, max_length: int = 48) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.lower()).strip("-")
+    slug = re.sub(r"-+", "-", slug)
+    return (slug or "agentic-work")[:max_length].rstrip("-")
+
+
+def run(
+    command: str | list[str],
+    cwd: Path,
+    *,
+    env: dict[str, str] | None = None,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    if isinstance(command, list):
+        args = command
+        shell = False
+    else:
+        args = command
+        shell = True
+    merged_env = os.environ.copy()
+    if env:
+        merged_env.update(env)
+    result = subprocess.run(
+        args,
+        cwd=str(cwd),
+        env=merged_env,
+        shell=shell,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError(result.stderr or result.stdout or f"Command failed: {command}")
+    return result
+
+
+def git_output(args: list[str], cwd: Path) -> str:
+    result = run(["git", *args], cwd, check=True)
+    return result.stdout.strip()
+
+
+def changed_stats(cwd: Path) -> dict[str, Any]:
+    result = run(["git", "diff", "--numstat"], cwd)
+    files: list[dict[str, Any]] = []
+    total_lines = 0
+    seen: set[str] = set()
+    for line in result.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 3:
+            continue
+        added_raw, deleted_raw, path = parts
+        added = int(added_raw) if added_raw.isdigit() else 0
+        deleted = int(deleted_raw) if deleted_raw.isdigit() else 0
+        total_lines += added + deleted
+        seen.add(path)
+        files.append({"path": path, "added": added, "deleted": deleted})
+    status = run(["git", "status", "--porcelain"], cwd)
+    for line in status.stdout.splitlines():
+        if not line.startswith("?? "):
+            continue
+        path = line[3:]
+        if path in seen:
+            continue
+        file_path = cwd / path
+        added = count_text_lines(file_path)
+        total_lines += added
+        files.append({"path": path, "added": added, "deleted": 0, "untracked": True})
+    return {
+        "changed_files": len(files),
+        "changed_lines": total_lines,
+        "files": files,
+    }
+
+
+def count_text_lines(path: Path) -> int:
+    if not path.is_file():
+        return 0
+    try:
+        with path.open(encoding="utf-8") as handle:
+            return sum(1 for _ in handle)
+    except UnicodeDecodeError:
+        return 0
+
+
+def read_text_arg(path: str | None, fallback: str = "") -> str:
+    if not path:
+        return fallback
+    return Path(path).read_text(encoding="utf-8")
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/scripts/agentic/dev_loop.py
+++ b/scripts/agentic/dev_loop.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Local/GitHub Actions dev-loop orchestration for one issue."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from common import (  # noqa: E402
+    changed_stats,
+    load_contract,
+    read_text_arg,
+    repo_root,
+    run,
+    slugify,
+    write_json,
+)
+from issue_lint import lint_issue, parse_labels  # noqa: E402
+from provider_adapter import run_provider  # noqa: E402
+
+
+def run_verification(commands: list[str], root: Path) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for command in commands:
+        result = run(command, root)
+        results.append(
+            {
+                "command": command,
+                "returncode": result.returncode,
+                "stdout": result.stdout[-4000:],
+                "stderr": result.stderr[-4000:],
+                "ok": result.returncode == 0,
+            }
+        )
+        if result.returncode != 0:
+            break
+    return results
+
+
+def has_pause_signal(root: Path) -> bool:
+    return (root / ".dev-loop-pause").exists() or os.environ.get("LOOP_PAUSED", "").lower() not in {
+        "",
+        "false",
+        "0",
+        "no",
+    }
+
+
+def build_pr_body(
+    issue_number: str, provider_result: dict[str, Any], verification: list[dict[str, Any]]
+) -> str:
+    stats = provider_result.get("stats", {})
+    checks = "\n".join(
+        f"- [{'x' if item['ok'] else ' '}] `{item['command']}`" for item in verification
+    )
+    return f"""## Summary
+
+{provider_result.get("summary", "Agent provider completed.")}
+
+## Related Issues
+
+Closes #{issue_number}
+
+## Agentic Delivery
+
+- Provider: `{provider_result.get("provider")}`
+- Changed files: `{stats.get("changed_files", 0)}`
+- Changed lines: `{stats.get("changed_lines", 0)}`
+
+## Acceptance Self-Check
+
+- [x] Issue quality gate passed before implementation.
+- [x] Provider adapter completed without reporting failure.
+- [x] Verification commands were executed.
+
+## Verification
+
+{checks or "- [ ] No verification commands configured."}
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--issue-number", required=True)
+    parser.add_argument("--issue-title", required=True)
+    parser.add_argument("--issue-file", required=True)
+    parser.add_argument("--labels", default="")
+    parser.add_argument("--provider", default=None)
+    parser.add_argument("--json-output", default="agentic-dev-loop-result.json")
+    parser.add_argument("--pr-body-output", default="agentic-pr-body.md")
+    args = parser.parse_args()
+
+    root = repo_root()
+    contract = load_contract(root)
+    issue_body = read_text_arg(args.issue_file)
+    labels = parse_labels(args.labels)
+    lint = lint_issue(issue_body, labels, contract)
+    result: dict[str, Any] = {
+        "ok": False,
+        "issue_number": args.issue_number,
+        "issue_title": args.issue_title,
+        "slug": slugify(args.issue_title),
+        "lint": lint,
+        "provider": None,
+        "verification": [],
+        "stats": changed_stats(root),
+        "action": "none",
+    }
+    if has_pause_signal(root):
+        result.update({"status": "paused", "message": "Pause signal is active."})
+        write_json(Path(args.json_output), result)
+        return 0
+    if not lint["ok"]:
+        result.update({"status": "issue-quality-failed", "message": lint["message"]})
+        write_json(Path(args.json_output), result)
+        return 2
+    initial_stats = changed_stats(root)
+    if initial_stats["changed_files"] > 0:
+        result.update(
+            {
+                "status": "dirty-worktree",
+                "message": "Worktree must be clean before the agentic dev loop starts.",
+                "stats": initial_stats,
+            }
+        )
+        write_json(Path(args.json_output), result)
+        return 2
+    provider_name = (
+        args.provider or os.environ.get("AGENTIC_PROVIDER") or contract["provider"]["default"]
+    )
+    provider_result = run_provider(provider_name, Path(args.issue_file), root)
+    result["provider"] = provider_result
+    result["stats"] = changed_stats(root)
+    if not provider_result["ok"]:
+        result.update({"status": "provider-failed", "message": provider_result["summary"]})
+        write_json(Path(args.json_output), result)
+        return 2
+    verification = run_verification(contract["verification"]["commands"], root)
+    result["verification"] = verification
+    result["stats"] = changed_stats(root)
+    verify_ok = all(item["ok"] for item in verification)
+    limits = contract["limits"]
+    stats = result["stats"]
+    limits_ok = (
+        stats["changed_files"] <= limits["max_changed_files"]
+        and stats["changed_lines"] <= limits["max_changed_lines"]
+    )
+    has_changes = stats["changed_files"] > 0
+    result.update(
+        {
+            "ok": verify_ok and limits_ok and has_changes,
+            "status": "ready-for-pr" if verify_ok and limits_ok and has_changes else "no-pr",
+            "verification_ok": verify_ok,
+            "limits_ok": limits_ok,
+            "has_changes": has_changes,
+            "action": "open-pr" if verify_ok and limits_ok and has_changes else "comment-only",
+        }
+    )
+    Path(args.pr_body_output).write_text(
+        build_pr_body(args.issue_number, provider_result, verification),
+        encoding="utf-8",
+    )
+    write_json(Path(args.json_output), result)
+    return 0 if result["ok"] or provider_name == "noop" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agentic/ensure_labels.py
+++ b/scripts/agentic/ensure_labels.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Create or update the standard agentic delivery labels via gh."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from common import load_contract, repo_root, run  # noqa: E402
+
+LABEL_STYLE = {
+    "agent:ready": ("0e8a16", "Issue passed intake quality and is ready for an agent attempt."),
+    "auto-implement": ("bfdadc", "Legacy ready alias; normalized to agent:ready."),
+    "autonomous": ("bfdadc", "Legacy ready alias; normalized to agent:ready."),
+    "review-ready": ("5319e7", "Agent-created PR is ready for human review."),
+    "needs-human": ("d93f0b", "Agentic automation stopped for human judgment."),
+    "blocked": ("b60205", "Work cannot proceed until a blocker is resolved."),
+    "in-progress": ("fbca04", "Agentic runner is currently attempting the issue."),
+}
+
+
+def desired_labels(contract: dict[str, Any]) -> list[str]:
+    labels = contract["labels"]
+    return [
+        labels["ready"],
+        *labels.get("ready_aliases", []),
+        labels["review_ready"],
+        *labels["stop"],
+    ]
+
+
+def ensure_label(name: str, root: Path) -> None:
+    color, description = LABEL_STYLE.get(name, ("ededed", "Agentic delivery label."))
+    create = run(
+        [
+            "gh",
+            "label",
+            "create",
+            name,
+            "--color",
+            color,
+            "--description",
+            description,
+        ],
+        root,
+    )
+    if create.returncode == 0:
+        return
+    run(
+        [
+            "gh",
+            "label",
+            "edit",
+            name,
+            "--color",
+            color,
+            "--description",
+            description,
+        ],
+        root,
+        check=True,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    root = repo_root()
+    labels = desired_labels(load_contract(root))
+    if args.dry_run:
+        print("\n".join(labels))
+        return 0
+    for label in labels:
+        ensure_label(label, root)
+        print(f"ensured {label}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agentic/issue_lint.py
+++ b/scripts/agentic/issue_lint.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Validate agent-ready GitHub issues before runners start work."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from common import load_contract, read_text_arg, repo_root, write_json  # noqa: E402
+
+
+def parse_labels(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    return [label.strip() for label in raw.split(",") if label.strip()]
+
+
+def section_exists(body: str, title: str) -> bool:
+    pattern = rf"^##\s+{re.escape(title)}\s*$"
+    return bool(re.search(pattern, body, flags=re.IGNORECASE | re.MULTILINE))
+
+
+def lint_issue(body: str, labels: list[str], contract: dict[str, Any]) -> dict[str, Any]:
+    label_config = contract["labels"]
+    quality = contract["issue_quality"]
+    ready = label_config["ready"]
+    aliases = set(label_config.get("ready_aliases", []))
+    label_set = set(labels)
+    ready_seen = ready in label_set or bool(label_set & aliases)
+    alias_labels = sorted(label_set & aliases)
+    stop_labels = sorted(label_set & set(label_config["stop"]))
+    missing = [
+        section for section in quality["required_sections"] if not section_exists(body, section)
+    ]
+    acceptance_has_checklist = bool(re.search(r"^-\s+\[[ xX]\]\s+\S+", body, flags=re.MULTILINE))
+    ok = ready_seen and not stop_labels and not missing and acceptance_has_checklist
+    return {
+        "ok": ok,
+        "ready_seen": ready_seen,
+        "canonical_ready": ready in label_set,
+        "alias_labels": alias_labels,
+        "stop_labels": stop_labels,
+        "missing_sections": missing,
+        "acceptance_has_checklist": acceptance_has_checklist,
+        "normalized_ready_label": ready,
+        "message": build_message(missing, stop_labels, ready_seen, acceptance_has_checklist),
+    }
+
+
+def build_message(
+    missing: list[str],
+    stop_labels: list[str],
+    ready_seen: bool,
+    acceptance_has_checklist: bool,
+) -> str:
+    if stop_labels:
+        return f"Stop labels present: {', '.join(stop_labels)}"
+    if not ready_seen:
+        return "No ready label found"
+    problems: list[str] = []
+    if missing:
+        problems.append("missing sections: " + ", ".join(missing))
+    if not acceptance_has_checklist:
+        problems.append("acceptance criteria must include markdown checkboxes")
+    return "; ".join(problems) if problems else "Issue quality gate passed"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--issue-file")
+    parser.add_argument("--labels")
+    parser.add_argument("--from-env", action="store_true")
+    parser.add_argument("--json-output")
+    args = parser.parse_args()
+
+    body = os.environ.get("ISSUE_BODY", "") if args.from_env else read_text_arg(args.issue_file)
+    labels_raw = os.environ.get("ISSUE_LABELS", "") if args.from_env else args.labels
+    result = lint_issue(body, parse_labels(labels_raw), load_contract(repo_root()))
+    output = json.dumps(result, indent=2, sort_keys=True)
+    if args.json_output:
+        write_json(Path(args.json_output), result)
+    print(output)
+    return 0 if result["ok"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agentic/pr_review.py
+++ b/scripts/agentic/pr_review.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Review an agent-created PR against issue acceptance criteria."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from common import read_text_arg, write_json  # noqa: E402
+
+
+def extract_checkboxes(markdown: str) -> list[str]:
+    return [
+        match.group(1).strip()
+        for match in re.finditer(r"^-\s+\[[ xX]\]\s+(.+)$", markdown, flags=re.MULTILINE)
+    ]
+
+
+def linked_issue_number(pr_body: str) -> str | None:
+    match = re.search(r"\bCloses\s+#(\d+)", pr_body, flags=re.IGNORECASE)
+    return match.group(1) if match else None
+
+
+def review_pr(
+    issue_body: str, pr_body: str, additions: int, deletions: int, changed_files: int
+) -> dict[str, Any]:
+    issue_checks = extract_checkboxes(issue_body)
+    pr_checks = extract_checkboxes(pr_body)
+    has_link = linked_issue_number(pr_body) is not None
+    has_verification = bool(
+        re.search(r"^##\s+Verification\s*$", pr_body, re.IGNORECASE | re.MULTILINE)
+    )
+    has_self_check = bool(
+        re.search(r"^##\s+Acceptance Self-Check\s*$", pr_body, re.IGNORECASE | re.MULTILINE)
+    )
+    changed_lines = additions + deletions
+    within_limits = changed_files <= 20 and changed_lines <= 500
+    ok = bool(issue_checks) and has_link and has_verification and has_self_check and within_limits
+    return {
+        "ok": ok,
+        "verdict": "review-ready" if ok else "needs-human",
+        "linked_issue": linked_issue_number(pr_body),
+        "issue_acceptance_count": len(issue_checks),
+        "pr_self_check_count": len(pr_checks),
+        "has_verification": has_verification,
+        "has_self_check": has_self_check,
+        "within_limits": within_limits,
+        "changed_files": changed_files,
+        "changed_lines": changed_lines,
+        "comment": build_comment(
+            ok, issue_checks, has_link, has_verification, has_self_check, within_limits
+        ),
+    }
+
+
+def build_comment(
+    ok: bool,
+    issue_checks: list[str],
+    has_link: bool,
+    has_verification: bool,
+    has_self_check: bool,
+    within_limits: bool,
+) -> str:
+    lines = [
+        "## Agentic PR Review",
+        "",
+        f"Verdict: {'review-ready' if ok else 'needs-human'}",
+        "",
+        "Checks:",
+        f"- Linked issue via `Closes #...`: {'yes' if has_link else 'no'}",
+        f"- Issue acceptance criteria found: {len(issue_checks)}",
+        f"- PR verification section present: {'yes' if has_verification else 'no'}",
+        f"- PR acceptance self-check present: {'yes' if has_self_check else 'no'}",
+        f"- Diff within v1 limits: {'yes' if within_limits else 'no'}",
+    ]
+    if not ok:
+        lines.extend(
+            [
+                "",
+                "This PR is not blocked from human review, but the agentic gate is not satisfied.",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--issue-file", required=True)
+    parser.add_argument("--pr-body-file", required=True)
+    parser.add_argument("--additions", type=int, default=0)
+    parser.add_argument("--deletions", type=int, default=0)
+    parser.add_argument("--changed-files", type=int, default=0)
+    parser.add_argument("--json-output", required=True)
+    args = parser.parse_args()
+    result = review_pr(
+        read_text_arg(args.issue_file),
+        read_text_arg(args.pr_body_file),
+        args.additions,
+        args.deletions,
+        args.changed_files,
+    )
+    write_json(Path(args.json_output), result)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["ok"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agentic/provider_adapter.py
+++ b/scripts/agentic/provider_adapter.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Provider adapter for agentic issue implementation."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from common import (  # noqa: E402
+    changed_stats,
+    load_contract,
+    read_text_arg,
+    repo_root,
+    run,
+    write_json,
+)
+
+
+def run_noop(issue_body: str, root: Path) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "provider": "noop",
+        "status": "dry-run",
+        "summary": "Noop provider validated the runner path without changing files.",
+        "issue_excerpt": issue_body.strip()[:500],
+        "stats": changed_stats(root),
+        "verification_log": "Noop provider made no code changes.",
+    }
+
+
+def run_command(issue_file: Path, root: Path, contract: dict[str, Any]) -> dict[str, Any]:
+    env_name = contract["provider"].get("command_env", "AGENTIC_PROVIDER_COMMAND")
+    command = os.environ.get(env_name)
+    if not command:
+        return {
+            "ok": False,
+            "provider": "command",
+            "status": "missing-command",
+            "summary": f"{env_name} is not set.",
+            "stats": changed_stats(root),
+            "verification_log": "",
+        }
+    result = run(
+        command,
+        root,
+        env={
+            "AGENTIC_ISSUE_FILE": str(issue_file),
+            "AGENTIC_REPO_ROOT": str(root),
+        },
+    )
+    stats = changed_stats(root)
+    return {
+        "ok": result.returncode == 0,
+        "provider": "command",
+        "status": "completed" if result.returncode == 0 else "failed",
+        "summary": "Command provider completed."
+        if result.returncode == 0
+        else "Command provider failed.",
+        "returncode": result.returncode,
+        "stdout": result.stdout[-4000:],
+        "stderr": result.stderr[-4000:],
+        "stats": stats,
+        "verification_log": "\n".join(
+            part for part in [result.stdout, result.stderr] if part
+        ).strip(),
+    }
+
+
+def run_provider(provider: str, issue_file: Path, root: Path) -> dict[str, Any]:
+    contract = load_contract(root)
+    allowed = set(contract["provider"]["allowed"])
+    if provider not in allowed:
+        return {
+            "ok": False,
+            "provider": provider,
+            "status": "provider-not-allowed",
+            "summary": f"Provider {provider!r} is not in allowed providers: {sorted(allowed)}",
+            "stats": changed_stats(root),
+            "verification_log": "",
+        }
+    issue_body = read_text_arg(str(issue_file))
+    if provider == "noop":
+        return run_noop(issue_body, root)
+    if provider == "command":
+        return run_command(issue_file, root, contract)
+    return {
+        "ok": False,
+        "provider": provider,
+        "status": "not-implemented",
+        "summary": f"Provider {provider!r} has no adapter implementation.",
+        "stats": changed_stats(root),
+        "verification_log": "",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--provider", default=None)
+    parser.add_argument("--issue-file", required=True)
+    parser.add_argument("--json-output", required=True)
+    args = parser.parse_args()
+    root = repo_root()
+    contract = load_contract(root)
+    provider = (
+        args.provider or os.environ.get("AGENTIC_PROVIDER") or contract["provider"]["default"]
+    )
+    result = run_provider(provider, Path(args.issue_file), root)
+    write_json(Path(args.json_output), result)
+    print(result["summary"])
+    return 0 if result["ok"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agentic/repo_doctor.py
+++ b/scripts/agentic/repo_doctor.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Read-only repo doctor for agentic delivery rollout readiness."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+CORE_REPOS = [
+    "/Users/kk/Code/notion-local",
+    "/Users/kk/Code/notion-local/bcai-website",
+    "/Users/kk/Code/notion-local/rafiki",
+    "/Users/kk/Code/cmvan-keynote",
+    "/Users/kk/Code/futureproof-festival",
+    "/Users/kk/Code/debbie-dots",
+    "/Users/kk/Code/spektorAI",
+]
+
+
+def run_git(path: Path, args: list[str]) -> str:
+    result = subprocess.run(["git", "-C", str(path), *args], text=True, capture_output=True)
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def classify(path: Path) -> str:
+    has_contract = (path / "agentic" / "contract.json").exists()
+    has_workflows = any((path / ".github" / "workflows").glob("agentic-*.yml"))
+    has_docs = (path / "docs" / "LINEAR-GITHUB-PIPELINE.md").exists()
+    if has_contract and has_workflows:
+        return "wired"
+    if has_docs:
+        return "docs-only"
+    return "missing"
+
+
+def inspect(path: Path) -> dict[str, Any]:
+    return {
+        "path": str(path),
+        "exists": path.exists(),
+        "remote": run_git(path, ["remote", "get-url", "origin"]) if path.exists() else "",
+        "branch": run_git(path, ["branch", "--show-current"]) if path.exists() else "",
+        "status": run_git(path, ["status", "--short"]) if path.exists() else "",
+        "has_contract": (path / "agentic" / "contract.json").exists(),
+        "has_delivery_docs": (path / "docs" / "LINEAR-GITHUB-PIPELINE.md").exists(),
+        "has_pr_template": (path / ".github" / "PULL_REQUEST_TEMPLATE.md").exists(),
+        "agentic_workflows": sorted(
+            item.name for item in (path / ".github" / "workflows").glob("agentic-*.yml")
+        )
+        if (path / ".github" / "workflows").exists()
+        else [],
+        "classification": classify(path) if path.exists() else "blocked",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--core", action="store_true")
+    parser.add_argument("paths", nargs="*")
+    parser.add_argument("--json-output")
+    args = parser.parse_args()
+    paths = [Path(path) for path in (CORE_REPOS if args.core else args.paths)]
+    payload = {"repos": [inspect(path) for path in paths]}
+    text = json.dumps(payload, indent=2, sort_keys=True)
+    if args.json_output:
+        Path(args.json_output).write_text(text + "\n", encoding="utf-8")
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agentic/status_report.py
+++ b/scripts/agentic/status_report.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Cross-repo agentic delivery status report using GitHub CLI when available."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from typing import Any
+
+CORE_REPOS = [
+    "WalksWithASwagger/kk-kb",
+    "WalksWithASwagger/bcai-website",
+    "WalksWithASwagger/rafiki",
+    "WalksWithASwagger/cmvan-keynote",
+    "WalksWithASwagger/futureproof-festival",
+    "WalksWithASwagger/debbie-dots--polar-steps",
+    "WalksWithASwagger/spektorAI",
+]
+
+
+def gh_json(args: list[str]) -> Any:
+    result = subprocess.run(["gh", *args], text=True, capture_output=True)
+    if result.returncode != 0:
+        return {"error": result.stderr.strip() or result.stdout.strip()}
+    return json.loads(result.stdout or "[]")
+
+
+def repo_report(repo: str) -> dict[str, Any]:
+    ready = gh_json(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--label",
+            "agent:ready",
+            "--json",
+            "number",
+        ]
+    )
+    blocked = gh_json(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--label",
+            "blocked",
+            "--json",
+            "number",
+        ]
+    )
+    needs_human = gh_json(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--label",
+            "needs-human",
+            "--json",
+            "number",
+        ]
+    )
+    prs = gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--json",
+            "number,headRefName,isDraft,updatedAt",
+        ]
+    )
+    return {
+        "repo": repo,
+        "ready_issues": len(ready) if isinstance(ready, list) else ready,
+        "blocked_issues": len(blocked) if isinstance(blocked, list) else blocked,
+        "needs_human_issues": len(needs_human) if isinstance(needs_human, list) else needs_human,
+        "open_agent_prs": [
+            pr
+            for pr in prs
+            if isinstance(pr, dict) and pr.get("headRefName", "").startswith("codex/")
+        ]
+        if isinstance(prs, list)
+        else prs,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", action="append", dest="repos")
+    parser.add_argument("--json-output")
+    args = parser.parse_args()
+    payload = {"repos": [repo_report(repo) for repo in (args.repos or CORE_REPOS)]}
+    text = json.dumps(payload, indent=2, sort_keys=True)
+    if args.json_output:
+        with open(args.json_output, "w", encoding="utf-8") as handle:
+            handle.write(text + "\n")
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agentic/test_dev_loop.py
+++ b/tests/agentic/test_dev_loop.py
@@ -1,0 +1,257 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "agentic"))
+
+from common import changed_stats  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[2]
+DEV_LOOP = ROOT / "scripts" / "agentic" / "dev_loop.py"
+
+
+def complete_issue(tmp_path: Path) -> Path:
+    path = tmp_path / "issue.md"
+    path.write_text(
+        """## Context
+
+Make a tiny change.
+
+## Acceptance Criteria
+
+- [ ] A file is updated.
+
+## Tests/Evals
+
+- The smoke command passes.
+
+## Verification
+
+- Run the smoke command.
+
+## Agent Instructions
+
+Use the command provider.
+
+## Out of Scope
+
+No unrelated files.
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def run_git(path: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=path, check=True, capture_output=True, text=True)
+
+
+def copy_contract_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "agentic").mkdir(parents=True)
+    (repo / "scripts" / "agentic").mkdir(parents=True)
+    contract = json.loads((ROOT / "agentic" / "contract.json").read_text(encoding="utf-8"))
+    contract["verification"]["commands"] = ["python3 -m json.tool agentic/contract.json"]
+    (repo / "agentic" / "contract.json").write_text(
+        json.dumps(contract, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    run_git(repo, "config", "user.email", "agentic@example.com")
+    run_git(repo, "config", "user.name", "Agentic Tests")
+    run_git(repo, "add", "agentic/contract.json")
+    run_git(repo, "commit", "-m", "initial")
+    return repo
+
+
+def test_runner_exits_cleanly_when_pause_file_exists(tmp_path):
+    repo = copy_contract_repo(tmp_path)
+    issue = complete_issue(tmp_path)
+    (repo / ".dev-loop-pause").write_text("pause\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(DEV_LOOP),
+            "--issue-number",
+            "1",
+            "--issue-title",
+            "Paused issue",
+            "--issue-file",
+            str(issue),
+            "--labels",
+            "agent:ready",
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+    )
+
+    payload = json.loads((repo / "agentic-dev-loop-result.json").read_text(encoding="utf-8"))
+    assert result.returncode == 0
+    assert payload["status"] == "paused"
+
+
+def test_runner_exits_cleanly_when_loop_paused_env_is_set(tmp_path):
+    repo = copy_contract_repo(tmp_path)
+    issue = complete_issue(tmp_path)
+    env = os.environ.copy()
+    env["LOOP_PAUSED"] = "true"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(DEV_LOOP),
+            "--issue-number",
+            "1",
+            "--issue-title",
+            "Paused env issue",
+            "--issue-file",
+            str(issue),
+            "--labels",
+            "agent:ready",
+        ],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    payload = json.loads((repo / "agentic-dev-loop-result.json").read_text(encoding="utf-8"))
+    assert result.returncode == 0
+    assert payload["status"] == "paused"
+
+
+def test_runner_refuses_stop_labels(tmp_path):
+    repo = copy_contract_repo(tmp_path)
+    issue = complete_issue(tmp_path)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(DEV_LOOP),
+            "--issue-number",
+            "1",
+            "--issue-title",
+            "Blocked issue",
+            "--issue-file",
+            str(issue),
+            "--labels",
+            "agent:ready,needs-human",
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+    )
+
+    payload = json.loads((repo / "agentic-dev-loop-result.json").read_text(encoding="utf-8"))
+    assert result.returncode == 2
+    assert payload["status"] == "issue-quality-failed"
+
+
+def test_runner_refuses_dirty_worktree(tmp_path):
+    repo = copy_contract_repo(tmp_path)
+    issue = complete_issue(tmp_path)
+    (repo / "dirty.txt").write_text("existing change\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(DEV_LOOP),
+            "--issue-number",
+            "1",
+            "--issue-title",
+            "Dirty worktree issue",
+            "--issue-file",
+            str(issue),
+            "--labels",
+            "agent:ready",
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+    )
+
+    payload = json.loads((repo / "agentic-dev-loop-result.json").read_text(encoding="utf-8"))
+    assert result.returncode == 2
+    assert payload["status"] == "dirty-worktree"
+
+
+def test_runner_opens_no_pr_when_verification_fails(tmp_path):
+    repo = copy_contract_repo(tmp_path)
+    issue = complete_issue(tmp_path)
+    contract = json.loads((repo / "agentic" / "contract.json").read_text(encoding="utf-8"))
+    contract["verification"]["commands"] = ["python3 missing-file.py"]
+    (repo / "agentic" / "contract.json").write_text(json.dumps(contract), encoding="utf-8")
+    run_git(repo, "add", "agentic/contract.json")
+    run_git(repo, "commit", "-m", "set failing verification")
+    env = os.environ.copy()
+    env["AGENTIC_PROVIDER_COMMAND"] = (
+        f'{sys.executable} -c "from pathlib import Path; '
+        "Path('agent-output.txt').write_text('done\\n', encoding='utf-8')\""
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(DEV_LOOP),
+            "--issue-number",
+            "2",
+            "--issue-title",
+            "Failing verification",
+            "--issue-file",
+            str(issue),
+            "--labels",
+            "agent:ready",
+            "--provider",
+            "command",
+        ],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    payload = json.loads((repo / "agentic-dev-loop-result.json").read_text(encoding="utf-8"))
+    assert result.returncode == 2
+    assert payload["action"] == "comment-only"
+    assert payload["verification_ok"] is False
+
+
+def test_runner_marks_passing_change_ready_for_pr(tmp_path):
+    repo = copy_contract_repo(tmp_path)
+    issue = complete_issue(tmp_path)
+    env = os.environ.copy()
+    env["AGENTIC_PROVIDER_COMMAND"] = (
+        f'{sys.executable} -c "from pathlib import Path; '
+        "Path('agent-output.txt').write_text('done\\n', encoding='utf-8')\""
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(DEV_LOOP),
+            "--issue-number",
+            "3",
+            "--issue-title",
+            "Passing verification",
+            "--issue-file",
+            str(issue),
+            "--labels",
+            "agent:ready",
+            "--provider",
+            "command",
+        ],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    payload = json.loads((repo / "agentic-dev-loop-result.json").read_text(encoding="utf-8"))
+    assert result.returncode == 0
+    assert payload["action"] == "open-pr"
+    assert payload["status"] == "ready-for-pr"
+    assert changed_stats(repo)["changed_files"] >= 1

--- a/tests/agentic/test_issue_lint.py
+++ b/tests/agentic/test_issue_lint.py
@@ -1,0 +1,88 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "agentic"))
+
+from common import load_contract  # noqa: E402
+from ensure_labels import desired_labels  # noqa: E402
+from issue_lint import lint_issue  # noqa: E402
+
+
+def complete_issue() -> str:
+    return """## Context
+
+Bug report.
+
+## Acceptance Criteria
+
+- [ ] The failing path is covered.
+
+## Tests/Evals
+
+- Add a regression test.
+
+## Verification
+
+- Run the repo verification command.
+
+## Agent Instructions
+
+Keep the diff scoped.
+
+## Out of Scope
+
+No unrelated refactors.
+"""
+
+
+def test_rejects_ready_issue_missing_tests_and_evals():
+    contract = load_contract(Path(__file__).resolve().parents[2])
+    body = complete_issue().replace("## Tests/Evals\n\n- Add a regression test.\n\n", "")
+
+    result = lint_issue(body, ["agent:ready"], contract)
+
+    assert not result["ok"]
+    assert "Tests/Evals" in result["missing_sections"]
+
+
+def test_accepts_complete_agent_ready_issue():
+    contract = load_contract(Path(__file__).resolve().parents[2])
+
+    result = lint_issue(complete_issue(), ["agent:ready"], contract)
+
+    assert result["ok"]
+    assert result["normalized_ready_label"] == "agent:ready"
+
+
+def test_accepts_alias_and_requests_normalization():
+    contract = load_contract(Path(__file__).resolve().parents[2])
+
+    result = lint_issue(complete_issue(), ["autonomous"], contract)
+
+    assert result["ok"]
+    assert result["canonical_ready"] is False
+    assert result["alias_labels"] == ["autonomous"]
+    assert result["normalized_ready_label"] == "agent:ready"
+
+
+def test_stop_labels_block_runner():
+    contract = load_contract(Path(__file__).resolve().parents[2])
+
+    result = lint_issue(complete_issue(), ["agent:ready", "blocked"], contract)
+
+    assert not result["ok"]
+    assert result["stop_labels"] == ["blocked"]
+
+
+def test_standard_label_set_includes_aliases_and_stop_labels():
+    contract = load_contract(Path(__file__).resolve().parents[2])
+
+    labels = desired_labels(contract)
+
+    assert "agent:ready" in labels
+    assert "auto-implement" in labels
+    assert "autonomous" in labels
+    assert "review-ready" in labels
+    assert "needs-human" in labels
+    assert "blocked" in labels
+    assert "in-progress" in labels

--- a/tests/agentic/test_pr_review.py
+++ b/tests/agentic/test_pr_review.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "agentic"))
+
+from pr_review import review_pr  # noqa: E402
+
+ISSUE_BODY = """## Acceptance Criteria
+
+- [ ] User-visible behavior is fixed.
+"""
+
+
+GOOD_PR_BODY = """## Summary
+
+Fixes the issue.
+
+## Related Issues
+
+Closes #42
+
+## Acceptance Self-Check
+
+- [x] Criteria met.
+
+## Verification
+
+- [x] Tests pass.
+"""
+
+
+def test_pr_review_marks_complete_agent_pr_review_ready():
+    result = review_pr(ISSUE_BODY, GOOD_PR_BODY, additions=10, deletions=5, changed_files=2)
+
+    assert result["ok"]
+    assert result["verdict"] == "review-ready"
+    assert result["linked_issue"] == "42"
+
+
+def test_pr_review_does_not_merge_or_pass_without_link():
+    result = review_pr(ISSUE_BODY, GOOD_PR_BODY.replace("Closes #42", "Refs #42"), 10, 5, 2)
+
+    assert not result["ok"]
+    assert result["verdict"] == "needs-human"
+
+
+def test_pr_review_blocks_large_diff_for_human_attention():
+    result = review_pr(ISSUE_BODY, GOOD_PR_BODY, additions=501, deletions=0, changed_files=2)
+
+    assert not result["ok"]
+    assert result["within_limits"] is False


### PR DESCRIPTION
## Summary

- Add a repo-local `agentic/contract.json` with the standard ready/review/stop labels, provider policy, diff limits, branch pattern, Linear project metadata, and verification commands.
- Add GitHub Actions for issue quality, noop/command-provider dev loop execution, and acceptance-criteria PR review.
- Add the provider adapter, repo doctor/status scripts, `agentic-intake` command, docs, and focused tests.

## Safety

- v1 opens PRs only; it never auto-merges.
- `noop` is the default provider, so real execution stays disabled until repo variables/secrets are set after a workflow-dispatch dry run.
- PR review only auto-runs for `codex/issue-*`, `codex/BC-*`, or `codex/bc-*` agent output branches, so rollout/maintenance branches are not mislabeled.
- The runner refuses pause signals, stop labels, dirty worktrees, failed verification, and diffs over 20 files or 500 changed lines.

## Verification

- [x] `python3 -m pytest tests/agentic`
- [x] `python3 -m py_compile scripts/agentic/*.py`
- [x] `YAML parse for agentic workflows`
- [x] `python3 scripts/agentic/ensure_labels.py --dry-run`
- [x] `contract verification command: npm run eval`

## Follow-up After Merge

- Run the `Agentic Dev Loop` workflow manually with provider `noop` before enabling a real provider secret.
