### PR TITLE
Add Both Hands Full cross-link

### DIFF
--- a/site/widgets/both-hands.html
+++ b/site/widgets/both-hands.html
@@ -36,6 +36,8 @@
           <p class="bhf-intro__hint">
             Five items per side. Drafts autosave. Export as PNG to print, or
             copy a share link to send the exact stance to a posse member.
+            The broader Both Hands Full project lives at
+            <a href="https://bothhandsfull.com">bothhandsfull.com</a>.
           </p>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Add a small contextual cross-link from the Both Hands Full widget intro to https://bothhandsfull.com
- Preserve the existing Punk Rock AI page structure and styles

## Verification
- npm run check
- Manual browser check: http://localhost:30148/widgets/both-hands.html rendered, clean URL redirect worked, and the bothhandsfull.com link appeared in the intro copy

Closes #148