### PR TITLE
Add Punk Rock AI merch shop (Shopify Buy Buttons)

### DIFF
--- a/site/_headers
+++ b/site/_headers
@@ -5,7 +5,7 @@
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(self), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; media-src 'self' https:; font-src 'self' data:; connect-src 'self' https://*.r2.dev https://*.cloudflarestorage.com https://www.google-analytics.com https://analytics.google.com https://api.beehiiv.com https://api.notion.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.googletagmanager.com https://sdks.shopifycdn.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; media-src 'self' https:; font-src 'self' data:; connect-src 'self' https://*.r2.dev https://*.cloudflarestorage.com https://www.google-analytics.com https://analytics.google.com https://api.beehiiv.com https://api.notion.com https://*.myshopify.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
 
 # Long-cache static assets
 /css/*

--- a/site/_redirects
+++ b/site/_redirects
@@ -11,6 +11,7 @@
 /decisions        /decisions.html        200
 /signal           /signal.html           200
 /workshop         /workshop.html         200
+/merch            /merch.html            200
 /photos/michelle-diamond  /photos/michelle-diamond.html  200
 /photos/rick      /photos/rick.html      200
 /widgets/action              /widgets/action.html              200

--- a/site/css/widgets/merch.css
+++ b/site/css/widgets/merch.css
@@ -1,0 +1,52 @@
+.merch-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  margin-top: 2rem;
+}
+
+.merch-card {
+  display: flex;
+  flex-direction: column;
+  border: 2px solid var(--paper-ink, #111);
+  background: var(--paper, #fff);
+  padding: 1.25rem;
+}
+
+.merch-card__name {
+  margin: 0;
+  font-size: 1.15rem;
+  letter-spacing: 0.01em;
+}
+
+.merch-card__blurb {
+  flex: 1;
+  margin: 0.5rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  opacity: 0.85;
+}
+
+.merch-card__price {
+  margin: 0.75rem 0 0;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.merch-card__buy {
+  margin-top: 0.75rem;
+  min-height: 2.75rem;
+}
+
+.merch-card__soon {
+  display: inline-block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  opacity: 0.6;
+}
+
+/* When live buttons mount, drop the placeholder text. */
+.merch-grid[data-state="ready"] .merch-card__soon {
+  display: none;
+}

--- a/site/data/merch.json
+++ b/site/data/merch.json
@@ -1,0 +1,29 @@
+{
+  "store": {
+    "domain": "",
+    "storefrontToken": ""
+  },
+  "products": [
+    {
+      "id": "both-hands-tee",
+      "name": "Both Hands Full Tee",
+      "blurb": "Critique in one hand, capability in the other. Unisex cotton.",
+      "price": "$36",
+      "productId": ""
+    },
+    {
+      "id": "tool-not-neutral-sticker",
+      "name": "Tool Is Never Neutral Sticker",
+      "blurb": "Die-cut vinyl. For the laptop that knows better.",
+      "price": "$5",
+      "productId": ""
+    },
+    {
+      "id": "manifesto-poster",
+      "name": "Punk Rock AI Manifesto Poster",
+      "blurb": "The talk's thesis, screen-print style, ready for your wall.",
+      "price": "$20",
+      "productId": ""
+    }
+  ]
+}

--- a/site/js/widgets/merch.js
+++ b/site/js/widgets/merch.js
@@ -1,0 +1,152 @@
+// Merch — renders the Punk Rock AI shop from /data/merch.json and mounts
+// Shopify Buy Buttons (Store A "Krug umbrella" → punk-rock collection).
+// Storefront domain + token are publishable, so they live in the JSON.
+// Degrades to "Shop opening soon" whenever store config or a product id is
+// missing, so the page is safe to ship before the Shopify store is wired.
+
+const SDK_URL =
+  "https://sdks.shopifycdn.com/buy-button/latest/buy-button-storefront.min.js";
+
+const grid = document.getElementById("merch-grid");
+if (grid) main();
+
+async function main() {
+  let config;
+  try {
+    const res = await fetch("/data/merch.json", { credentials: "same-origin" });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    config = await res.json();
+  } catch (err) {
+    console.warn("[merch]", err);
+    grid.dataset.state = "error";
+    return;
+  }
+
+  const products = Array.isArray(config?.products) ? config.products : [];
+  renderCards(products);
+
+  const domain = config?.store?.domain?.trim();
+  const token = config?.store?.storefrontToken?.trim();
+  const live = products.filter((p) => p.productId?.trim());
+
+  if (!domain || !token || !live.length) {
+    grid.dataset.state = "pending";
+    return;
+  }
+
+  try {
+    const ui = await getShopifyUI(domain, token);
+    live.forEach((product) => {
+      const node = grid.querySelector(`[data-buy="${product.id}"]`);
+      if (!node) return;
+      node.innerHTML = "";
+      ui.createComponent("product", {
+        id: product.productId.trim(),
+        node,
+        moneyFormat: "%24%7B%7Bamount%7D%7D",
+        options: buyButtonOptions,
+      });
+    });
+    grid.dataset.state = "ready";
+  } catch (err) {
+    console.warn("[merch]", err);
+    grid.dataset.state = "error";
+  }
+}
+
+function renderCards(products) {
+  grid.innerHTML = products
+    .map(
+      (p) => `
+      <article class="merch-card">
+        <h2 class="merch-card__name">${escapeHtml(p.name)}</h2>
+        <p class="merch-card__blurb">${escapeHtml(p.blurb)}</p>
+        <p class="merch-card__price">${escapeHtml(p.price)}</p>
+        <div class="merch-card__buy" data-buy="${escapeHtml(p.id)}">
+          <span class="merch-card__soon">Shop opening soon</span>
+        </div>
+      </article>`
+    )
+    .join("");
+}
+
+let uiPromise = null;
+function getShopifyUI(domain, storefrontAccessToken) {
+  if (uiPromise) return uiPromise;
+  uiPromise = loadScript().then(() => {
+    const shopify = window.ShopifyBuy;
+    const client = shopify.buildClient({ domain, storefrontAccessToken });
+    return shopify.UI.onReady(client);
+  });
+  return uiPromise;
+}
+
+let scriptPromise = null;
+function loadScript() {
+  if (window.ShopifyBuy?.UI) return Promise.resolve();
+  if (scriptPromise) return scriptPromise;
+  scriptPromise = new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.async = true;
+    script.src = SDK_URL;
+    script.onload = () => resolve();
+    script.onerror = reject;
+    document.head.appendChild(script);
+  });
+  return scriptPromise;
+}
+
+const buyButtonOptions = {
+  product: {
+    buttonDestination: "cart",
+    contents: { img: false, title: false, price: false, options: true },
+    text: { button: "Add to cart" },
+    styles: {
+      product: { margin: "0", "max-width": "100%" },
+      button: {
+        "background-color": "#e11d2e",
+        color: "#ffffff",
+        "border-radius": "0",
+        "font-weight": "700",
+        "text-transform": "uppercase",
+        "letter-spacing": "0.08em",
+        ":hover": { "background-color": "#b51624" },
+        ":focus": { "background-color": "#b51624" },
+      },
+    },
+  },
+  cart: {
+    text: { title: "Punk Rock AI", total: "Subtotal", button: "Checkout" },
+    styles: {
+      button: {
+        "background-color": "#e11d2e",
+        color: "#ffffff",
+        ":hover": { "background-color": "#b51624" },
+        ":focus": { "background-color": "#b51624" },
+      },
+    },
+  },
+  toggle: {
+    styles: {
+      toggle: {
+        "background-color": "#e11d2e",
+        ":hover": { "background-color": "#b51624" },
+        ":focus": { "background-color": "#b51624" },
+      },
+    },
+  },
+};
+
+function escapeHtml(value) {
+  return String(value ?? "").replace(
+    /[&<>"']/g,
+    (c) =>
+      ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      })[c]
+  );
+}

--- a/site/merch.html
+++ b/site/merch.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Merch &mdash; Punk Rock AI</title>
+    <meta
+      name="description"
+      content="Stickers, tees, and posters from the Punk Rock AI / Both Hands Full keynote by Kris Krüg."
+    />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Merch — Punk Rock AI" />
+    <meta property="og:description" content="Stickers, tees, and posters from the Punk Rock AI keynote." />
+    <meta property="og:url" content="https://punkrockai.com/merch.html" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <link rel="stylesheet" href="/css/theme.css" />
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/punk-graphics.css" />
+    <link rel="stylesheet" href="/css/zine-overhaul.css" />
+    <link rel="stylesheet" href="/css/widgets/merch.css" />
+  </head>
+  <body class="shell">
+    <header class="site-header" data-include="header"></header>
+
+    <main>
+      <section class="wrap">
+        <header class="merch-intro">
+          <h1>Merch</h1>
+          <p>
+            Stickers, tees, and posters from the talk. Checkout runs on Shopify;
+            apparel is print-on-demand, stickers ship from the studio.
+          </p>
+        </header>
+
+        <div class="merch-grid" id="merch-grid" data-state="loading"></div>
+      </section>
+    </main>
+
+    <footer class="site-footer" data-include="footer"></footer>
+
+    <script type="module" src="/js/common/header.js"></script>
+    <script type="module" src="/js/widgets/merch.js"></script>
+  </body>
+</html>

--- a/site/partials/header.html
+++ b/site/partials/header.html
@@ -4,6 +4,7 @@
     <a href="/talk.html" class="site-nav__primary" data-route="/talk.html">Talk</a>
     <a href="/field-course.html" class="site-nav__primary" data-route="/field-course.html">Course</a>
     <a href="/recap.html" class="site-nav__primary" data-route="/recap.html">Recap</a>
+    <a href="/merch.html" class="site-nav__primary" data-route="/merch.html">Merch</a>
 
     <details class="site-nav__group" data-nav-group="make">
       <summary>Make<span class="site-nav__caret" aria-hidden="true">▾</span></summary>

--- a/vercel.json
+++ b/vercel.json
@@ -19,7 +19,7 @@
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(self), geolocation=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; media-src 'self' https:; font-src 'self' data:; connect-src 'self' https://*.r2.dev https://*.cloudflarestorage.com https://www.google-analytics.com https://analytics.google.com https://api.beehiiv.com https://api.notion.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.googletagmanager.com https://sdks.shopifycdn.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; media-src 'self' https:; font-src 'self' data:; connect-src 'self' https://*.r2.dev https://*.cloudflarestorage.com https://www.google-analytics.com https://analytics.google.com https://api.beehiiv.com https://api.notion.com https://*.myshopify.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" }
       ]
     },
     {


### PR DESCRIPTION
## What
A `/merch` page on punkrockai.com selling stickers, tees, and posters from the keynote, powered by the **Krug umbrella** Shopify store (`punk-rock` collection).

## How
- **`site/merch.html`** — new page, mirrors the existing static-page skeleton (header/footer includes, theme CSS).
- **`site/js/widgets/merch.js`** — ES-module loader following the site's own data-driven widget pattern (`fetch('/data/*.json') -> render`), then mounts Shopify Buy Buttons via the BuyButton.js SDK.
- **`site/data/merch.json`** — store config (publishable domain + storefront token) and product list. Placeholder products; IDs empty for now.
- **`site/css/widgets/merch.css`** — product grid in the punk theme.
- **CSP** (`vercel.json` + `site/_headers`) — added `https://sdks.shopifycdn.com` (script-src) and `https://*.myshopify.com` (connect-src). This was the gating constraint: the hardened CSP would otherwise silently block the Shopify SDK.
- **Nav** — "Merch" added to the primary nav.

## Safe to merge now
Degrades to **"Shop opening soon"** until `merch.json` is filled with the store domain, storefront token, and product IDs. Nothing breaks before the Shopify store exists.

## Before this sells
1. Create the punk-rock products in the Krug umbrella Shopify store, publish to the Buy Button channel.
2. Fill `site/data/merch.json` with the store domain, Storefront API token, and each product's ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)