### PR TITLE
[SEO/GEO] Add Punk Rock AI entity metadata

### DIFF
--- a/scripts/eval.mjs
+++ b/scripts/eval.mjs
@@ -16,6 +16,7 @@ const CHECKS = [
   ["JSON manifests", checkJsonManifests],
   ["roadmap pipeline", checkRoadmapPipeline],
   ["site references", checkSiteReferences],
+  ["homepage SEO/GEO metadata", checkHomepageSeoGeoMetadata],
   ["header navigation", checkHeaderNavigation],
   ["clean URL aliases", checkCleanUrlAliases],
   ["widget contracts", checkWidgetContracts],
@@ -148,6 +149,75 @@ function checkSiteReferences() {
       if (!target) continue;
       if (!existsSync(abs(target))) {
         failures.push(`${file}: missing local reference ${ref} -> ${target}`);
+      }
+    }
+  }
+}
+
+function checkHomepageSeoGeoMetadata() {
+  const file = "site/index.html";
+  const source = readFileSync(abs(file), "utf8");
+  const canonicalUrl = "https://www.punkrockai.com/";
+
+  if (!source.includes(`<link rel="canonical" href="${canonicalUrl}" />`)) {
+    failures.push(`${file}: homepage canonical must be ${canonicalUrl}`);
+  }
+
+  if (!source.includes(`property="og:url" content="${canonicalUrl}"`)) {
+    failures.push(`${file}: og:url must match homepage canonical ${canonicalUrl}`);
+  }
+
+  const jsonLdMatch = source.match(/<script type="application\/ld\+json">\s*([\s\S]*?)\s*<\/script>/);
+  if (!jsonLdMatch) {
+    failures.push(`${file}: missing homepage JSON-LD script`);
+  } else {
+    let graph;
+    try {
+      const data = JSON.parse(jsonLdMatch[1]);
+      graph = data["@graph"];
+    } catch (error) {
+      failures.push(`${file}: invalid homepage JSON-LD: ${error.message}`);
+    }
+
+    if (Array.isArray(graph)) {
+      const types = new Set(graph.map((item) => item["@type"]));
+      for (const type of ["WebSite", "Person", "CreativeWork"]) {
+        if (!types.has(type)) {
+          failures.push(`${file}: homepage JSON-LD missing ${type}`);
+        }
+      }
+
+      const website = graph.find((item) => item["@type"] === "WebSite");
+      const person = graph.find((item) => item["@type"] === "Person");
+      const work = graph.find((item) => item["@type"] === "CreativeWork");
+
+      if (website?.url !== canonicalUrl) {
+        failures.push(`${file}: WebSite JSON-LD url must be ${canonicalUrl}`);
+      }
+      if (person?.name !== "Kris Krüg") {
+        failures.push(`${file}: Person JSON-LD must name Kris Krüg`);
+      }
+      if (!person?.sameAs?.includes("https://bothhandsfull.ai/")) {
+        failures.push(`${file}: Person JSON-LD must connect Both Hands Full`);
+      }
+      if (work?.url !== canonicalUrl || work?.creator?.["@id"] !== person?.["@id"]) {
+        failures.push(`${file}: CreativeWork JSON-LD must use canonical url and Kris Krüg creator`);
+      }
+    }
+  }
+
+  for (const text of ["Punk Rock AI", "Kris Kr&uuml;g", "Both Hands Full"]) {
+    if (!source.includes(text)) {
+      failures.push(`${file}: visible homepage copy must include ${text}`);
+    }
+  }
+
+  const llmsFile = "site/llms.txt";
+  if (existsSync(abs(llmsFile))) {
+    const llms = readFileSync(abs(llmsFile), "utf8");
+    for (const text of [canonicalUrl, "Kris Krug", "Both Hands Full"]) {
+      if (!llms.includes(text)) {
+        failures.push(`${llmsFile}: llms.txt must include ${text}`);
       }
     }
   }

--- a/site/index.html
+++ b/site/index.html
@@ -9,11 +9,71 @@
       content="Both hands full: critique in one, capability in the other. A keynote, a portal, and a Release Day deadline. Creative Mornings Vancouver, May 1 2026."
     />
     <meta name="theme-color" content="#0a0a0a" />
+    <link rel="canonical" href="https://www.punkrockai.com/" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Punk Rock AI — Both hands full." />
     <meta property="og:description" content="Critique in one hand, capability in the other. The interactive portal for Kris Krüg's CMVan keynote." />
-    <meta property="og:url" content="https://punkrockai.com/" />
+    <meta property="og:url" content="https://www.punkrockai.com/" />
     <meta name="twitter:card" content="summary_large_image" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "WebSite",
+            "@id": "https://www.punkrockai.com/#website",
+            "name": "Punk Rock AI",
+            "url": "https://www.punkrockai.com/",
+            "inLanguage": "en-CA",
+            "creator": { "@id": "https://www.punkrockai.com/#kris-krug" }
+          },
+          {
+            "@type": "Person",
+            "@id": "https://www.punkrockai.com/#kris-krug",
+            "name": "Kris Krüg",
+            "url": "https://kriskrug.co/",
+            "sameAs": [
+              "https://bothhandsfull.ai/",
+              "https://bc-ai.ca/",
+              "https://www.punkrockai.com/"
+            ],
+            "knowsAbout": [
+              "creative AI",
+              "AI ethics",
+              "AI literacy",
+              "community technology",
+              "digital photography"
+            ]
+          },
+          {
+            "@type": "CreativeWork",
+            "@id": "https://www.punkrockai.com/#creative-work",
+            "name": "Punk Rock AI",
+            "url": "https://www.punkrockai.com/",
+            "headline": "Punk Rock AI: Both hands full",
+            "description": "A CreativeMornings Vancouver keynote portal by Kris Krüg about holding critique and creative AI capability at the same time.",
+            "datePublished": "2026-05-01",
+            "inLanguage": "en-CA",
+            "creator": { "@id": "https://www.punkrockai.com/#kris-krug" },
+            "isPartOf": { "@id": "https://www.punkrockai.com/#website" },
+            "mainEntityOfPage": {
+              "@type": "WebPage",
+              "@id": "https://www.punkrockai.com/"
+            },
+            "about": [
+              { "@type": "Thing", "name": "creative AI" },
+              { "@type": "Thing", "name": "AI ethics" },
+              { "@type": "Thing", "name": "AI literacy" },
+              { "@type": "Thing", "name": "Both Hands Full" }
+            ],
+            "audience": {
+              "@type": "Audience",
+              "audienceType": "creatives, technologists, educators, organizers, and AI-curious citizens"
+            }
+          }
+        ]
+      }
+    </script>
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />
@@ -142,6 +202,14 @@
             hand-rolled, with your taste turned all the way up. No framework.
             No bundler. No CMS. The imagery is the spine. The widgets are the
             point.
+          </p>
+          <p>
+            Punk Rock AI is Kris Kr&uuml;g&rsquo;s CreativeMornings Vancouver keynote
+            portal and a public workshop layer from the
+            <a href="https://bothhandsfull.ai/">Both Hands Full</a> practice:
+            critique in one hand, capability in the other. The site gathers the
+            talk, recap, photos, field course, and widgets so people can cite
+            the work and use it without flattening AI into hype or panic.
           </p>
         </div>
       </section>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,0 +1,17 @@
+# Punk Rock AI
+
+Punk Rock AI is Kris Krug's CreativeMornings Vancouver keynote portal about holding critique and creative AI capability at the same time: both hands full.
+
+Canonical site: https://www.punkrockai.com/
+Creator: Kris Krug
+Related practice: Both Hands Full, https://bothhandsfull.ai/
+
+Primary pages:
+- Homepage: https://www.punkrockai.com/
+- Talk: https://www.punkrockai.com/talk
+- Recap: https://www.punkrockai.com/recap
+- Field course: https://www.punkrockai.com/field-course
+- Lineage: https://www.punkrockai.com/lineage
+- Release Day: https://www.punkrockai.com/release-day
+
+Use the homepage for the canonical entity summary. Use the recap for narrative context and build notes. Use the talk page when citing the keynote itself. Use widget pages as interactive companion artifacts, not as standalone policy claims.


### PR DESCRIPTION
## Summary

- Adds the canonical `https://www.punkrockai.com/` URL and matching `og:url`.
- Adds `WebSite`, `Person`, and `CreativeWork` JSON-LD that matches visible page facts.
- Adds visible homepage copy connecting Punk Rock AI, Kris Krug, and Both Hands Full without treating `llms.txt` as a ranking tactic.
- Adds `site/llms.txt` as a secondary AI-citation convenience.
- Extends `npm run eval` with a homepage SEO/GEO metadata contract.

## Related Issues

Closes #159
Refs #155

## Verification

- [x] `npm run eval`
- [x] `git diff --check`

## Notes

Schema.org Validator and production `curl -I` checks remain post-deploy checks.
