### PR TITLE
Fix Punk Rock AI social metadata gaps

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -9,11 +9,13 @@
       content="Both hands full: critique in one, capability in the other. A keynote, a portal, and a Release Day deadline. Creative Mornings Vancouver, May 1 2026."
     />
     <meta name="theme-color" content="#0a0a0a" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="canonical" href="https://www.punkrockai.com/" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Punk Rock AI — Both hands full." />
     <meta property="og:description" content="Critique in one hand, capability in the other. The interactive portal for Kris Krüg's CMVan keynote." />
     <meta property="og:url" content="https://www.punkrockai.com/" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <meta name="twitter:card" content="summary_large_image" />
     <script type="application/ld+json">
       {

--- a/site/library.html
+++ b/site/library.html
@@ -9,9 +9,12 @@
       content="Searchable knowledge base across the script, source material, dress rehearsal, and research. 60+ documents, one search box."
     />
     <meta name="theme-color" content="#0a0a0a" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="canonical" href="https://www.punkrockai.com/library" />
     <meta property="og:title" content="Library — Punk Rock AI" />
     <meta property="og:description" content="Sixty-plus documents. One search box. The whole talk is in there." />
+    <meta property="og:url" content="https://www.punkrockai.com/library" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/taste-full.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/photos/rick.html
+++ b/site/photos/rick.html
@@ -9,6 +9,7 @@
       content="Rick's 200-photo gallery from the Punk Rock AI talk at Creative Mornings Vancouver on May 1, 2026."
     />
     <meta name="theme-color" content="#0a0a0a" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="canonical" href="https://www.punkrockai.com/photos/rick" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Rick Photo Gallery — Punk Rock AI at Creative Mornings Vancouver" />

--- a/site/recap.html
+++ b/site/recap.html
@@ -9,6 +9,7 @@
       content="A feature-length recap of the Punk Rock AI / Both Hands Full keynote — the talk, the building, the room, what came next. The whole arc, with receipts."
     />
     <meta name="theme-color" content="#0a0a0a" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="canonical" href="https://www.punkrockai.com/recap" />
     <meta property="og:type" content="article" />
     <meta property="og:title" content="Recap — How we built Punk Rock AI" />

--- a/site/talk.html
+++ b/site/talk.html
@@ -9,6 +9,7 @@
       content="Twenty minutes, seven acts, twenty-two slides. Every key line linkable, copyable, and quotable. The talk made into a working portal."
     />
     <meta name="theme-color" content="#0a0a0a" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="canonical" href="https://www.punkrockai.com/talk" />
     <meta property="og:type" content="article" />
     <meta property="og:title" content="The Talk — Punk Rock AI" />

--- a/site/widgets/conductor.html
+++ b/site/widgets/conductor.html
@@ -9,11 +9,13 @@
       content="You're not a player anymore. You're the conductor. Hand each AI instrument a part, set the tempo, listen for the wrong notes. The taste is yours. The hands are theirs."
     />
     <meta name="theme-color" content="#0a0a0a" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="canonical" href="https://www.punkrockai.com/widgets/conductor" />
     <meta property="og:type" content="article" />
     <meta property="og:title" content="The Conductor's Orchestra — Punk Rock AI" />
     <meta property="og:description" content="Visualize directing N AI agents in parallel. Frame Painter, Motion Director, Voice Actor, Scribe, Compositor, Polisher. The taste stays with you." />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/conductor" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/taste-full.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/cutting-room-buckets.html
+++ b/site/widgets/cutting-room-buckets.html
@@ -9,11 +9,13 @@
       content="Drag Punk Rock AI keynote cuts into keep, cut, and save-for-later buckets, then copy a share link for your editorial choices."
     />
     <meta name="theme-color" content="#0a0a0a" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="canonical" href="https://www.punkrockai.com/widgets/cutting-room-buckets" />
     <meta property="og:type" content="article" />
     <meta property="og:title" content="Cutting Room Buckets — Keep, Cut, Save — Punk Rock AI" />
     <meta property="og:description" content="Sort the real keynote cutting-room floor into keep, cut, and save-for-later piles." />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/cutting-room-buckets" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/taste-drip.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/receipt-tells.html
+++ b/site/widgets/receipt-tells.html
@@ -9,6 +9,7 @@
       content="Paste AI-generated text and print a local receipt of weak AI-output tells: stock phrases, hedging, em-dash density, and overused verbs."
     />
     <meta name="theme-color" content="#0a0a0a" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="canonical" href="https://www.punkrockai.com/widgets/receipt-tells" />
     <meta property="og:type" content="article" />
     <meta property="og:title" content="AI Tell Receipt — Training-Corpus Heuristics — Punk Rock AI" />
@@ -17,6 +18,7 @@
       content="A non-definitive receipt of common AI-output tells: phrase matches, hedging, em dashes, and delve/leverage/optimize frequency."
     />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/receipt-tells" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/feed-machine-stamp.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />


### PR DESCRIPTION
## Summary
- add explicit favicon links to the sampled public pages
- add missing `og:image` tags for the homepage, library, and selected widget pages
- add the missing `/library` `og:url` canonical social signal

Closes #155

## Acceptance Self-Check
- [x] Sampled pages include explicit icon links to the existing `site/favicon.ico` asset.
- [x] `/`, `/library`, `/widgets/conductor`, `/widgets/cutting-room-buckets`, and `/widgets/receipt-tells` include `og:image` values using existing assets.
- [x] `/library` includes `og:url` equal to `https://www.punkrockai.com/library`.
- [x] Remaining sampled pages keep existing canonical, description, and social metadata intact.

## Verification
- [x] `npm run eval`
- [x] `npm run seo:index-hygiene`
- [x] `npm run check`
- [x] `git diff --check`
- [x] focused local metadata extraction for `/`, `/talk`, `/recap`, `/library`, `/photos/rick`, `/widgets/conductor`, `/widgets/cutting-room-buckets`, and `/widgets/receipt-tells`
