### PR TITLE
Fix sitemap social preview images

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
   },
   "scripts": {
     "dev": "npx --yes serve site -l 3000",
-    "check": "npm run eval && npm run docs:links:all && npm run test:agentic && npm run check:python && npm audit --audit-level=moderate",
+    "check": "npm run eval && npm run docs:links:all && npm run test:index-hygiene && npm run test:agentic && npm run check:python && npm audit --audit-level=moderate",
     "eval": "node scripts/eval.mjs",
     "seo:index-hygiene": "node scripts/check-index-hygiene.mjs",
     "docs:links": "node scripts/check-doc-links.mjs --maintained",
     "docs:links:all": "node scripts/check-doc-links.mjs --all",
+    "test:index-hygiene": "node --test tests/index-hygiene.test.mjs",
     "test:agentic": "python3 -m pytest tests/agentic",
     "check:python": "python3 -m compileall -q scripts/agentic dress-rehearsal tests/agentic",
     "smoke:release-day": "node scripts/smoke-release-day.mjs",

--- a/scripts/check-index-hygiene.mjs
+++ b/scripts/check-index-hygiene.mjs
@@ -27,6 +27,7 @@ checkPublicMarkdownFiles();
 checkPublicMarkdownLinks();
 checkHtmlCrawlTargets();
 checkSitemapTargets();
+checkSitemapSocialPreviewImages();
 checkCanonicalOgDrift();
 
 if (BASE_URL) {
@@ -129,6 +130,63 @@ function checkSitemapTargets() {
   }
   summaries.push(["sitemap URLs", urls.length]);
   summaries.push(["sitemap canonical/.html issues", suspect]);
+}
+
+function checkSitemapSocialPreviewImages() {
+  const sitemapFile = path.join(SITE_DIR, "sitemap.xml");
+  if (!existsSync(abs(sitemapFile))) {
+    summaries.push(["sitemap HTML pages checked for social images", 0]);
+    summaries.push(["social preview image issues", 0]);
+    return;
+  }
+
+  const urls = extractSitemapUrls(readFileSync(abs(sitemapFile), "utf8"));
+  let checked = 0;
+  let issues = 0;
+
+  for (const url of urls) {
+    const parsed = parseUrl(url);
+    if (!parsed || parsed.origin !== CANONICAL_ORIGIN) continue;
+
+    const file = sitemapHtmlFile(parsed.pathname);
+    if (!existsSync(abs(file))) {
+      issues += 1;
+      failures.push({
+        check: "sitemap social preview",
+        file,
+        detail: `missing HTML source for ${url}`,
+      });
+      continue;
+    }
+
+    checked += 1;
+    const source = readFileSync(abs(file), "utf8");
+    const ogImage = extractTagUrl(source, "meta", "property", "og:image", "content");
+    const twitterImage = extractTagUrl(source, "meta", "name", "twitter:image", "content");
+
+    for (const [name, value] of [["og:image", ogImage], ["twitter:image", twitterImage]]) {
+      const problem = socialImageUrlProblem(value);
+      if (!problem) continue;
+      issues += 1;
+      failures.push({
+        check: "sitemap social preview",
+        file,
+        detail: `${name} ${problem}`,
+      });
+    }
+
+    if (ogImage && twitterImage && ogImage !== twitterImage) {
+      issues += 1;
+      failures.push({
+        check: "sitemap social preview",
+        file,
+        detail: `twitter:image ${twitterImage} should match og:image ${ogImage}`,
+      });
+    }
+  }
+
+  summaries.push(["sitemap HTML pages checked for social images", checked]);
+  summaries.push(["social preview image issues", issues]);
 }
 
 function checkCanonicalOgDrift() {
@@ -290,6 +348,28 @@ function extractTagUrl(source, tag, keyAttr, keyValue, valueAttr) {
   if (!match) return null;
   const valuePattern = new RegExp(`\\b${valueAttr}=["']([^"']+)["']`, "i");
   return match[0].match(valuePattern)?.[1] || null;
+}
+
+function sitemapHtmlFile(pathname) {
+  const route = pathname.replace(/^\/+|\/+$/g, "");
+  return path.join(SITE_DIR, route ? `${route}.html` : "index.html");
+}
+
+function socialImageUrlProblem(value) {
+  if (!value) return "is missing";
+  const parsed = parseUrl(value);
+  if (!parsed) return `${value} must be an absolute URL`;
+
+  const canonical = parseUrl(CANONICAL_ORIGIN);
+  const sameSiteHost = normalizeSiteHost(parsed.hostname) === normalizeSiteHost(canonical.hostname);
+  if (parsed.protocol !== canonical.protocol || parsed.port !== canonical.port || !sameSiteHost) {
+    return `${value} must use the ${normalizeSiteHost(canonical.hostname)} canonical site host (www optional)`;
+  }
+  return null;
+}
+
+function normalizeSiteHost(hostname) {
+  return hostname.toLowerCase().replace(/^www\./, "");
 }
 
 function expectedCanonicalUrl(file) {

--- a/site/decisions.html
+++ b/site/decisions.html
@@ -12,6 +12,8 @@
     <link rel="canonical" href="https://www.punkrockai.com/decisions" />
     <meta property="og:title" content="Decisions — Punk Rock AI" />
     <meta property="og:description" content="The talk's own decision log, in public." />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/field-course.html
+++ b/site/field-course.html
@@ -15,6 +15,7 @@
     <meta property="og:description" content="Five modules. One path through the talk, widgets, worksheets, and Release Day." />
     <meta property="og:url" content="https://www.punkrockai.com/field-course" />
     <meta property="og:image" content="https://punkrockai.com/public/slides/three-docs-full.webp" />
+    <meta name="twitter:image" content="https://punkrockai.com/public/slides/three-docs-full.webp" />
     <meta name="twitter:card" content="summary_large_image" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />

--- a/site/index.html
+++ b/site/index.html
@@ -16,6 +16,7 @@
     <meta property="og:description" content="Critique in one hand, capability in the other. The interactive portal for Kris Krüg's CMVan keynote." />
     <meta property="og:url" content="https://www.punkrockai.com/" />
     <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <meta name="twitter:card" content="summary_large_image" />
     <script type="application/ld+json">
       {

--- a/site/library.html
+++ b/site/library.html
@@ -15,6 +15,7 @@
     <meta property="og:description" content="Sixty-plus documents. One search box. The whole talk is in there." />
     <meta property="og:url" content="https://www.punkrockai.com/library" />
     <meta property="og:image" content="https://www.punkrockai.com/public/slides/taste-full.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/taste-full.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/lineage.html
+++ b/site/lineage.html
@@ -21,6 +21,7 @@
     <link rel="stylesheet" href="/css/widgets/lineage.css" />
     <link rel="stylesheet" href="/css/zine-overhaul.css" />
     <meta property="og:image" content="https://punkrockai.com/public/slides/weirdos-lineage-full.webp" />
+    <meta name="twitter:image" content="https://punkrockai.com/public/slides/weirdos-lineage-full.webp" />
     <style>:root { --hero-photo: url('/public/photos/rick/050.webp'); }</style>
   </head>
   <body class="shell">

--- a/site/photos/michelle-diamond.html
+++ b/site/photos/michelle-diamond.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/css/widgets/photos.css" />
     <link rel="stylesheet" href="/css/zine-overhaul.css" />
     <meta property="og:image" content="https://punkrockai.com/public/photos/michelle-diamond/275.webp" />
+    <meta name="twitter:image" content="https://punkrockai.com/public/photos/michelle-diamond/275.webp" />
   </head>
   <body class="shell">
     <header class="site-header" data-include="header"></header>

--- a/site/photos/rick.html
+++ b/site/photos/rick.html
@@ -16,6 +16,7 @@
     <meta property="og:description" content="200 frames from the room where Punk Rock AI landed live." />
     <meta property="og:url" content="https://www.punkrockai.com/photos/rick" />
     <meta property="og:image" content="https://www.punkrockai.com/public/photos/rick/150.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/photos/rick/150.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/posse.html
+++ b/site/posse.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/css/widgets/posse.css" />
     <link rel="stylesheet" href="/css/zine-overhaul.css" />
     <meta property="og:image" content="https://punkrockai.com/public/slides/posse-full.webp" />
+    <meta name="twitter:image" content="https://punkrockai.com/public/slides/posse-full.webp" />
     <style>:root { --hero-photo: url('/public/photos/rick/100.webp'); }</style>
   </head>
   <body class="shell">

--- a/site/recap.html
+++ b/site/recap.html
@@ -23,6 +23,7 @@
     <link rel="stylesheet" href="/css/widgets/punk-stack-map.css" />
     <link rel="stylesheet" href="/css/zine-overhaul.css" />
     <meta property="og:image" content="https://punkrockai.com/public/photos/michelle-diamond/135.webp" />
+    <meta name="twitter:image" content="https://punkrockai.com/public/photos/michelle-diamond/135.webp" />
     <link rel="alternate" type="application/rss+xml" title="Punk Rock AI — field notes" href="/feed.xml" />
   </head>
   <body class="shell recap">

--- a/site/release-day.html
+++ b/site/release-day.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/css/widgets/release-day.css" />
     <link rel="stylesheet" href="/css/zine-overhaul.css" />
     <meta property="og:image" content="https://punkrockai.com/public/slides/release-day-full.webp" />
+    <meta name="twitter:image" content="https://punkrockai.com/public/slides/release-day-full.webp" />
     <style>:root { --hero-photo: url('/public/photos/michelle-diamond/109.webp'); }</style>
   </head>
   <body class="shell">

--- a/site/signal.html
+++ b/site/signal.html
@@ -15,6 +15,8 @@
     <meta property="og:description" content="One slide or quote from the talk, surfaced for today." />
     <meta property="og:url" content="https://www.punkrockai.com/signal" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/talk.html
+++ b/site/talk.html
@@ -23,6 +23,7 @@
     <link rel="stylesheet" href="/css/widgets/talk-waveform.css" />
     <link rel="stylesheet" href="/css/zine-overhaul.css" />
     <meta property="og:image" content="https://punkrockai.com/public/photos/michelle-diamond/109.webp" />
+    <meta name="twitter:image" content="https://punkrockai.com/public/photos/michelle-diamond/109.webp" />
   </head>
   <body class="shell">
     <header class="site-header" data-include="header"></header>

--- a/site/widgets/action.html
+++ b/site/widgets/action.html
@@ -10,6 +10,8 @@
     />
     <meta name="theme-color" content="#0a0a0a" />
     <link rel="canonical" href="https://www.punkrockai.com/widgets/action" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/bias-bingo.html
+++ b/site/widgets/bias-bingo.html
@@ -10,6 +10,8 @@
     />
     <meta name="theme-color" content="#0a0a0a" />
     <link rel="canonical" href="https://www.punkrockai.com/widgets/bias-bingo" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/both-hands-gallery.html
+++ b/site/widgets/both-hands-gallery.html
@@ -13,6 +13,8 @@
     <meta property="og:title" content="Both Hands Gallery — Punk Rock AI" />
     <meta property="og:description" content="A public wall of opt-in Both Hands canvases. Critique in one hand, capability in the other." />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/both-hands-gallery" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/both-hands.html
+++ b/site/widgets/both-hands.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="/css/widgets/both-hands.css" />
     <link rel="stylesheet" href="/css/zine-overhaul.css" />
     <meta property="og:image" content="https://punkrockai.com/public/photos/michelle-diamond/109.webp" />
+    <meta name="twitter:image" content="https://punkrockai.com/public/photos/michelle-diamond/109.webp" />
   </head>
   <body class="shell">
     <header class="site-header" data-include="header"></header>

--- a/site/widgets/chainsaws.html
+++ b/site/widgets/chainsaws.html
@@ -15,6 +15,8 @@
     <meta property="og:description" content="Every &lsquo;neutral&rsquo; tool was a corporate spectacle until somebody used it wrong on purpose. Six beats from Gutenberg to AI." />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/chainsaws" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/conductor-ratio.html
+++ b/site/widgets/conductor-ratio.html
@@ -14,6 +14,8 @@
     <meta property="og:title" content="Conductor Craft Ratio — Punk Rock AI" />
     <meta property="og:description" content="Move between 90, 50, and 10 percent machine throughput and see what changes in craft, cost, and loss." />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/conductor-ratio" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/conductor.html
+++ b/site/widgets/conductor.html
@@ -16,6 +16,7 @@
     <meta property="og:description" content="Visualize directing N AI agents in parallel. Frame Painter, Motion Director, Voice Actor, Scribe, Compositor, Polisher. The taste stays with you." />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/conductor" />
     <meta property="og:image" content="https://www.punkrockai.com/public/slides/taste-full.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/taste-full.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/crit.html
+++ b/site/widgets/crit.html
@@ -12,6 +12,8 @@
     <link rel="canonical" href="https://www.punkrockai.com/widgets/crit" />
     <meta property="og:title" content="Crit office — Punk Rock AI" />
     <meta property="og:description" content="Structured critique through five Punk Rock AI lenses." />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/cut-up.html
+++ b/site/widgets/cut-up.html
@@ -10,6 +10,8 @@
     />
     <meta name="theme-color" content="#0a0a0a" />
     <link rel="canonical" href="https://www.punkrockai.com/widgets/cut-up" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/cutting-room-buckets.html
+++ b/site/widgets/cutting-room-buckets.html
@@ -16,6 +16,7 @@
     <meta property="og:description" content="Sort the real keynote cutting-room floor into keep, cut, and save-for-later piles." />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/cutting-room-buckets" />
     <meta property="og:image" content="https://www.punkrockai.com/public/slides/taste-drip.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/taste-drip.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/cutting-room.html
+++ b/site/widgets/cutting-room.html
@@ -13,6 +13,8 @@
     <meta property="og:title" content="Cutting Room Floor — Punk Rock AI" />
     <meta property="og:description" content="What got cut from the talk and why." />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/cutting-room" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/detournement.html
+++ b/site/widgets/detournement.html
@@ -13,6 +13,8 @@
     <meta property="og:title" content="D&eacute;tournement maker — Punk Rock AI" />
     <meta property="og:description" content="Take the tools of the spectacle and turn them against the spectacle. Annotate any image, export a zine." />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/detournement" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/in-there.html
+++ b/site/widgets/in-there.html
@@ -13,6 +13,8 @@
     <meta property="og:title" content="Am I In There? — Punk Rock AI" />
     <meta property="og:description" content="If you put it on the public web before 2024, the odds are: yes." />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/in-there" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/junior-pipeline.html
+++ b/site/widgets/junior-pipeline.html
@@ -15,6 +15,8 @@
     <meta property="og:description" content="The bottom three rungs of the creative career ladder are getting eaten. Where do the next masters come from?" />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/junior-pipeline" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/manifesto.html
+++ b/site/widgets/manifesto.html
@@ -10,6 +10,8 @@
     />
     <meta name="theme-color" content="#0a0a0a" />
     <link rel="canonical" href="https://www.punkrockai.com/widgets/manifesto" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/mastery-gym.html
+++ b/site/widgets/mastery-gym.html
@@ -13,6 +13,8 @@
     <meta property="og:title" content="Mastery Gym &mdash; Punk Rock AI" />
     <meta property="og:description" content="One cycle a day. Try. Feedback. Iterate. Build the taste muscle." />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/mastery-gym" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/name-what-you-see.html
+++ b/site/widgets/name-what-you-see.html
@@ -12,6 +12,8 @@
     <link rel="canonical" href="https://www.punkrockai.com/widgets/name-what-you-see" />
     <meta property="og:title" content="Name What You See — Punk Rock AI" />
     <meta property="og:description" content="Stop saying bias. Name what you're seeing." />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/pattern-finder.html
+++ b/site/widgets/pattern-finder.html
@@ -12,6 +12,8 @@
     <link rel="canonical" href="https://www.punkrockai.com/widgets/pattern-finder" />
     <meta property="og:title" content="Pattern Finder — Punk Rock AI" />
     <meta property="og:description" content="The mirror named the pattern I'd been making for fifteen years." />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/pattern-graph.html
+++ b/site/widgets/pattern-graph.html
@@ -13,6 +13,8 @@
     <meta property="og:title" content="Pattern cluster graph — Punk Rock AI" />
     <meta property="og:description" content="Force-directed graph of the lineage. Six moves, six eras, one through-line." />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/pattern-graph" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/posse-builder.html
+++ b/site/widgets/posse-builder.html
@@ -13,6 +13,8 @@
     <meta property="og:title" content="Posse builder — Punk Rock AI" />
     <meta property="og:description" content="A force-directed graph of your posse. You in the centre. Edges coloured by relationship." />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/posse-builder" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/receipt-print.html
+++ b/site/widgets/receipt-print.html
@@ -10,6 +10,8 @@
     />
     <meta name="theme-color" content="#0a0a0a" />
     <link rel="canonical" href="https://www.punkrockai.com/widgets/receipt-print" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/receipt-tells.html
+++ b/site/widgets/receipt-tells.html
@@ -19,6 +19,7 @@
     />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/receipt-tells" />
     <meta property="og:image" content="https://www.punkrockai.com/public/slides/feed-machine-stamp.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/feed-machine-stamp.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/receipt.html
+++ b/site/widgets/receipt.html
@@ -13,6 +13,8 @@
     <meta property="og:title" content="Open Source Receipt — Punk Rock AI" />
     <meta property="og:description" content="A heuristic, not the truth. Tally your open-source footprint and feel the shape of the question." />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/receipt" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/releases-wall.html
+++ b/site/widgets/releases-wall.html
@@ -12,6 +12,8 @@
     <link rel="canonical" href="https://www.punkrockai.com/widgets/releases-wall" />
     <meta property="og:title" content="Releases Wall — Punk Rock AI" />
     <meta property="og:description" content="What people shipped on Release Day." />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/selector.html
+++ b/site/widgets/selector.html
@@ -10,6 +10,8 @@
     />
     <meta name="theme-color" content="#0a0a0a" />
     <link rel="canonical" href="https://www.punkrockai.com/widgets/selector" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/sig.html
+++ b/site/widgets/sig.html
@@ -13,6 +13,8 @@
     <meta property="og:title" content="Email signature generator — Punk Rock AI" />
     <meta property="og:description" content="Carry the talk into every email. Pick a quote. Copy. Paste." />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/sig" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/taste-audit.html
+++ b/site/widgets/taste-audit.html
@@ -12,6 +12,8 @@
     <link rel="canonical" href="https://www.punkrockai.com/widgets/taste-audit" />
     <meta property="og:title" content="Taste Audit — Punk Rock AI" />
     <meta property="og:description" content="What's on your cutting room floor?" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/three-documents.html
+++ b/site/widgets/three-documents.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="/css/widgets/three-documents.css" />
     <link rel="stylesheet" href="/css/zine-overhaul.css" />
     <meta property="og:image" content="https://punkrockai.com/public/slides/three-docs-full.webp" />
+    <meta name="twitter:image" content="https://punkrockai.com/public/slides/three-docs-full.webp" />
   </head>
   <body class="shell">
     <header class="site-header" data-include="header"></header>

--- a/site/widgets/tool-not-neutral-matrix.html
+++ b/site/widgets/tool-not-neutral-matrix.html
@@ -14,6 +14,7 @@
     <meta property="og:description" content="Hover or tap the matrix to see real cases behind design choices." />
     <meta property="og:url" content="https://www.punkrockai.com/widgets/tool-not-neutral-matrix" />
     <meta property="og:image" content="https://punkrockai.com/public/slides/tool-neutral-full.webp" />
+    <meta name="twitter:image" content="https://punkrockai.com/public/slides/tool-neutral-full.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/tool-not-neutral.html
+++ b/site/widgets/tool-not-neutral.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="/css/widgets/tool-not-neutral.css" />
     <link rel="stylesheet" href="/css/zine-overhaul.css" />
     <meta property="og:image" content="https://punkrockai.com/public/slides/tool-neutral-full.webp" />
+    <meta name="twitter:image" content="https://punkrockai.com/public/slides/tool-neutral-full.webp" />
   </head>
   <body class="shell">
     <header class="site-header" data-include="header"></header>

--- a/site/widgets/voice-clone-booth.html
+++ b/site/widgets/voice-clone-booth.html
@@ -10,6 +10,8 @@
     />
     <meta name="theme-color" content="#0a0a0a" />
     <link rel="canonical" href="https://www.punkrockai.com/widgets/voice-clone-booth" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/widgets/word-ban.html
+++ b/site/widgets/word-ban.html
@@ -10,6 +10,8 @@
     />
     <meta name="theme-color" content="#0a0a0a" />
     <link rel="canonical" href="https://www.punkrockai.com/widgets/word-ban" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/site/workshop.html
+++ b/site/workshop.html
@@ -13,6 +13,8 @@
     <meta property="og:title" content="Workshop kit — Punk Rock AI" />
     <meta property="og:description" content="Four printable templates. Print to PDF, hand them out, run the talk's frameworks with your team." />
     <meta property="og:url" content="https://www.punkrockai.com/workshop" />
+    <meta property="og:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
+    <meta name="twitter:image" content="https://www.punkrockai.com/public/slides/neither-are-we.webp" />
     <link rel="stylesheet" href="/css/theme.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/punk-graphics.css" />

--- a/tests/index-hygiene.test.mjs
+++ b/tests/index-hygiene.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const execFileAsync = promisify(execFile);
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const CHECKER = path.join(ROOT, "scripts/check-index-hygiene.mjs");
+const CANONICAL_ORIGIN = "https://www.punkrockai.com";
+const FALLBACK_IMAGE = `${CANONICAL_ORIGIN}/public/slides/neither-are-we.webp`;
+
+test("accepts fallback and existing page-specific images on the canonical site", async () => {
+  const result = await runChecker({
+    "/": { ogImage: FALLBACK_IMAGE, twitterImage: FALLBACK_IMAGE },
+    "/feature": {
+      ogImage: "https://punkrockai.com/public/slides/page-specific.webp",
+      twitterImage: "https://punkrockai.com/public/slides/page-specific.webp",
+    },
+  });
+
+  assert.equal(result.code, 0, result.output);
+  assert.match(result.output, /social preview image issues: 0/);
+});
+
+test("rejects a missing Open Graph image", async () => {
+  const result = await runChecker({
+    "/": { twitterImage: FALLBACK_IMAGE },
+  });
+
+  assert.equal(result.code, 1, result.output);
+  assert.match(result.output, /og:image is missing/);
+});
+
+test("rejects relative social image URLs", async () => {
+  const result = await runChecker({
+    "/": {
+      ogImage: "/public/slides/neither-are-we.webp",
+      twitterImage: "/public/slides/neither-are-we.webp",
+    },
+  });
+
+  assert.equal(result.code, 1, result.output);
+  assert.match(result.output, /must be an absolute URL/);
+});
+
+test("rejects social images on a foreign host", async () => {
+  const image = "https://images.example.com/social.webp";
+  const result = await runChecker({
+    "/": { ogImage: image, twitterImage: image },
+  });
+
+  assert.equal(result.code, 1, result.output);
+  assert.match(result.output, /must use the punkrockai\.com canonical site host \(www optional\)/);
+});
+
+test("rejects Twitter images that do not match Open Graph", async () => {
+  const result = await runChecker({
+    "/": {
+      ogImage: FALLBACK_IMAGE,
+      twitterImage: `${CANONICAL_ORIGIN}/public/slides/page-specific.webp`,
+    },
+  });
+
+  assert.equal(result.code, 1, result.output);
+  assert.match(result.output, /twitter:image .* should match og:image/);
+});
+
+async function runChecker(pages) {
+  const fixtureRoot = await mkdtemp(path.join(tmpdir(), "punk-rock-ai-index-hygiene-"));
+  const siteDir = path.join(fixtureRoot, "site");
+  await mkdir(siteDir);
+
+  try {
+    const sitemapUrls = [];
+    for (const [route, metadata] of Object.entries(pages)) {
+      const canonical = `${CANONICAL_ORIGIN}${route}`;
+      sitemapUrls.push(canonical);
+      const file = route === "/" ? path.join(siteDir, "index.html") : path.join(siteDir, `${route.slice(1)}.html`);
+      await mkdir(path.dirname(file), { recursive: true });
+      await writeFile(file, renderHtml(canonical, metadata));
+    }
+
+    await writeFile(
+      path.join(siteDir, "sitemap.xml"),
+      `<urlset>${sitemapUrls.map((url) => `<url><loc>${url}</loc></url>`).join("")}</urlset>`
+    );
+
+    try {
+      const { stdout, stderr } = await execFileAsync(
+        process.execPath,
+        [
+          CHECKER,
+          "--site-dir",
+          path.relative(ROOT, siteDir),
+          "--canonical-origin",
+          CANONICAL_ORIGIN,
+        ],
+        { cwd: ROOT, encoding: "utf8" }
+      );
+      return { code: 0, output: `${stdout}${stderr}` };
+    } catch (error) {
+      return {
+        code: typeof error.code === "number" ? error.code : 1,
+        output: `${error.stdout || ""}${error.stderr || ""}`,
+      };
+    }
+  } finally {
+    await rm(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+function renderHtml(canonical, { ogImage, twitterImage }) {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <title>Fixture</title>
+    <meta name="description" content="Fixture page." />
+    <link rel="canonical" href="${canonical}" />
+    <meta property="og:url" content="${canonical}" />
+    ${ogImage ? `<meta property="og:image" content="${ogImage}" />` : ""}
+    ${twitterImage ? `<meta name="twitter:image" content="${twitterImage}" />` : ""}
+  </head>
+  <body><h1>Fixture</h1></body>
+</html>
+`;
+}


### PR DESCRIPTION
## Summary

- add the existing homepage fallback image to the 28 sitemap pages that lacked `og:image`
- add matching `twitter:image` metadata across all 45 sitemap pages while preserving all 17 existing page-specific Open Graph values
- extend the index-hygiene checker with sitemap-backed social-image validation and five focused regression cases

## Why

The production crawl found all 45 sitemap URLs indexable, but 28 pages had no social-preview image. Because this is a static site with page-owned `<head>` markup, the smallest coherent fix touches each sitemap HTML page directly.

The checker treats `punkrockai.com` and `www.punkrockai.com` as the same canonical site host family so the existing page-specific values remain byte-for-byte unchanged. Relative URLs, non-canonical protocols or ports, foreign hosts, missing tags, and mismatched Twitter images fail.

## Acceptance Self-Check

- [x] 45/45 sitemap pages have one absolute same-site `og:image`
- [x] 17/17 existing page-specific `og:image` values are preserved
- [x] the existing `https://www.punkrockai.com/public/slides/neither-are-we.webp` fallback is added only to the 28 prior gaps
- [x] 45/45 `twitter:image` values match their Open Graph image
- [x] the fallback exists locally and returned `200 image/webp` in local HTTP smoke
- [x] titles, descriptions, canonicals, H1s, routes, sitemap membership, page copy, and interactive behavior are unchanged

## Verification

- [x] `npm run seo:index-hygiene`
- [x] `npm run check`
- [x] focused checker tests: 5 passed
- [x] local HTTP smoke: 45/45 sitemap pages returned `200 text/html`; all 13 unique referenced images returned `200 image/*`
- [x] fallback smoke: `200 image/webp`, 75,474 bytes
- [x] metadata-only invariant: 17 preserved, 28 fallbacks added, 45 matching Twitter images, 73 HTML additions, 0 HTML deletions
- [x] `git diff --check`

## Scope

The diff is 48 files and 285 insertions / 1 deletion: 45 static sitemap HTML files plus the existing checker, one focused test file, and the package test script. The issue explicitly requires full sitemap coverage. No deployment or Search Console, GA4, or DNS changes were performed.

Closes #171