### PR TITLE
perf: stabilize Punk Rock AI homepage rendering

### DIFF
--- a/site/css/widgets/daily-refrain.css
+++ b/site/css/widgets/daily-refrain.css
@@ -10,7 +10,8 @@
   padding: var(--space-3) var(--space-4);
   background: var(--bg-elevated);
   border-bottom: 1px solid var(--accent);
-  font-family: var(--font-mono);
+  font-family: ui-monospace, "SF Mono", "SFMono-Regular", Menlo, Consolas,
+    "Liberation Mono", "Courier New", monospace;
   font-size: var(--fs-sm);
   color: var(--fg-soft);
   text-align: center;
@@ -25,7 +26,7 @@
 }
 
 .daily-refrain__tag {
-  font-family: var(--font-mono);
+  font-family: inherit;
   font-size: var(--fs-xs);
   letter-spacing: 0.22em;
   text-transform: uppercase;
@@ -37,7 +38,7 @@
   color: var(--fg);
   text-decoration: none;
   border-bottom: 1px solid transparent;
-  font-family: var(--font-display);
+  font-family: "Times New Roman", "Hoefler Text", Georgia, ui-serif, serif;
   font-size: var(--fs-md);
   line-height: 1.35;
   transition: border-color 120ms var(--ease-snap), color 120ms var(--ease-snap);
@@ -63,9 +64,37 @@
 
 @media (max-width: 560px) {
   .daily-refrain {
+    --refrain-min-h: 7.75rem;
     padding-block: var(--space-2);
+  }
+  .daily-refrain__inner {
+    display: grid;
+    grid-template-rows: 1.25rem 2.5rem 2.5rem;
+    align-items: stretch;
+    align-content: center;
+    gap: 0.25rem;
+    width: 100%;
+    min-height: 6.75rem;
+  }
+  .daily-refrain__tag,
+  .daily-refrain__link,
+  .daily-refrain__cite {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
   }
   .daily-refrain__link {
     font-size: var(--fs-sm);
+  }
+}
+
+@media (max-width: 340px) {
+  .daily-refrain {
+    --refrain-min-h: 9rem;
+  }
+  .daily-refrain__inner {
+    grid-template-rows: 1.25rem 3.75rem 2.5rem;
+    min-height: 8rem;
   }
 }

--- a/site/css/zine-overhaul.css
+++ b/site/css/zine-overhaul.css
@@ -256,6 +256,12 @@
   z-index: 1;
 }
 
+.punk-section,
+.release-cta {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 1800px;
+}
+
 /* ── 6. Section header — pink dominance + slide crop art ─────────────── */
 
 .punk-section-header {

--- a/site/index.html
+++ b/site/index.html
@@ -11,6 +11,13 @@
     <meta name="theme-color" content="#0a0a0a" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="canonical" href="https://www.punkrockai.com/" />
+    <link
+      rel="preload"
+      as="image"
+      href="/public/photos/michelle-diamond/195.webp"
+      type="image/webp"
+      fetchpriority="high"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Punk Rock AI — Both hands full." />
     <meta property="og:description" content="Critique in one hand, capability in the other. The interactive portal for Kris Krüg's CMVan keynote." />
@@ -119,7 +126,83 @@
     </style>
   </head>
   <body class="shell">
-    <header class="site-header" data-include="header"></header>
+    <header class="site-header">
+      <div class="site-header__inner wrap">
+        <a class="site-header__brand" href="/">Punk Rock AI</a>
+        <nav class="site-nav" aria-label="Primary">
+          <a href="/talk" class="site-nav__primary" data-route="/talk">Talk</a>
+          <a href="/field-course" class="site-nav__primary" data-route="/field-course">Course</a>
+          <a href="/recap" class="site-nav__primary" data-route="/recap">Recap</a>
+          <a href="/merch" class="site-nav__primary" data-route="/merch">Merch</a>
+
+          <details class="site-nav__group" data-nav-group="make">
+            <summary>Make<span class="site-nav__caret" aria-hidden="true">&#9662;</span></summary>
+            <div class="site-nav__menu" role="menu">
+              <a href="/widgets/three-documents" data-route="/widgets/three-documents">Three Documents</a>
+              <a href="/widgets/both-hands" data-route="/widgets/both-hands">Both Hands</a>
+              <a href="/widgets/cut-up" data-route="/widgets/cut-up">Cut-up</a>
+              <a href="/widgets/selector" data-route="/widgets/selector">Selector</a>
+              <a href="/widgets/conductor" data-route="/widgets/conductor">Conductor</a>
+              <a href="/widgets/conductor-ratio" data-route="/widgets/conductor-ratio">Craft Ratio</a>
+              <a href="/widgets/voice-clone-booth" data-route="/widgets/voice-clone-booth">Voice Booth</a>
+              <a href="/widgets/manifesto" data-route="/widgets/manifesto">Manifesto</a>
+              <a href="/widgets/sig" data-route="/widgets/sig">Email Sig</a>
+              <a href="/widgets/receipt-print" data-route="/widgets/receipt-print">Receipt Printer</a>
+              <a href="/widgets/detournement" data-route="/widgets/detournement">D&eacute;tournement</a>
+            </div>
+          </details>
+
+          <details class="site-nav__group" data-nav-group="name">
+            <summary>Name<span class="site-nav__caret" aria-hidden="true">&#9662;</span></summary>
+            <div class="site-nav__menu" role="menu">
+              <a href="/widgets/bias-bingo" data-route="/widgets/bias-bingo">Bias Bingo</a>
+              <a href="/widgets/name-what-you-see" data-route="/widgets/name-what-you-see">Name What You See</a>
+              <a href="/widgets/word-ban" data-route="/widgets/word-ban">Word-ban</a>
+              <a href="/widgets/tool-not-neutral" data-route="/widgets/tool-not-neutral">Tool Is Never Neutral</a>
+              <a href="/widgets/tool-not-neutral-matrix" data-route="/widgets/tool-not-neutral-matrix">Tool Matrix</a>
+              <a href="/widgets/in-there" data-route="/widgets/in-there">Am I in There?</a>
+              <a href="/widgets/receipt-tells" data-route="/widgets/receipt-tells">Training Receipt</a>
+              <a href="/widgets/taste-audit" data-route="/widgets/taste-audit">Taste Audit</a>
+              <a href="/widgets/cutting-room" data-route="/widgets/cutting-room">Cutting Room</a>
+              <a href="/widgets/pattern-finder" data-route="/widgets/pattern-finder">Pattern Finder</a>
+              <a href="/widgets/pattern-graph" data-route="/widgets/pattern-graph">Pattern Graph</a>
+              <a href="/widgets/junior-pipeline" data-route="/widgets/junior-pipeline">Junior Pipeline</a>
+              <a href="/widgets/chainsaws" data-route="/widgets/chainsaws">Chainsaws</a>
+              <a href="/widgets/mastery-gym" data-route="/widgets/mastery-gym">Mastery Gym</a>
+              <a href="/widgets/receipt" data-route="/widgets/receipt">Open Source Receipt</a>
+            </div>
+          </details>
+
+          <details class="site-nav__group" data-nav-group="connect">
+            <summary>Connect<span class="site-nav__caret" aria-hidden="true">&#9662;</span></summary>
+            <div class="site-nav__menu" role="menu">
+              <a href="/posse" data-route="/posse">Posse</a>
+              <a href="/widgets/posse-builder" data-route="/widgets/posse-builder">Posse Builder</a>
+              <a href="/widgets/both-hands-gallery" data-route="/widgets/both-hands-gallery">Both Hands Gallery</a>
+              <a href="/widgets/releases-wall" data-route="/widgets/releases-wall">Releases Wall</a>
+              <a href="/widgets/crit" data-route="/widgets/crit">Crit Office</a>
+              <a href="/lineage" data-route="/lineage">Lineage</a>
+              <a href="/library" data-route="/library">Library</a>
+              <a href="/decisions" data-route="/decisions">Decisions</a>
+              <a href="/photos/michelle-diamond" data-route="/photos/michelle-diamond">CMVan Photos</a>
+            </div>
+          </details>
+
+          <details class="site-nav__group" data-nav-group="ship">
+            <summary>Ship<span class="site-nav__caret" aria-hidden="true">&#9662;</span></summary>
+            <div class="site-nav__menu" role="menu">
+              <a href="/release-day" data-route="/release-day">Release Day</a>
+              <a href="/widgets/action" data-route="/widgets/action">Action Chooser</a>
+              <a href="/workshop" data-route="/workshop">Workshop Kit</a>
+              <a href="/signal" data-route="/signal">Signal</a>
+              <a href="/feed.xml">RSS Feed</a>
+            </div>
+          </details>
+
+          <a href="/release-day" class="site-nav__cta" data-route="/release-day">May 29 &nearr;</a>
+        </nav>
+      </div>
+    </header>
 
     <main>
       <aside class="daily-refrain" id="daily-refrain" aria-label="Daily refrain" data-state="loading">

--- a/tests/index-hygiene.test.mjs
+++ b/tests/index-hygiene.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -68,6 +69,35 @@ test("rejects Twitter images that do not match Open Graph", async () => {
   assert.equal(result.code, 1, result.output);
   assert.match(result.output, /twitter:image .* should match og:image/);
 });
+
+test("keeps the homepage critical rendering path stable", () => {
+  const home = readFileSync(path.join(ROOT, "site/index.html"), "utf8");
+  const headerPartial = readFileSync(
+    path.join(ROOT, "site/partials/header.html"),
+    "utf8"
+  );
+  const refrainCss = readFileSync(
+    path.join(ROOT, "site/css/widgets/daily-refrain.css"),
+    "utf8"
+  );
+  const zineCss = readFileSync(path.join(ROOT, "site/css/zine-overhaul.css"), "utf8");
+
+  assert.match(
+    home,
+    /rel="preload"[\s\S]*href="\/public\/photos\/michelle-diamond\/195\.webp"[\s\S]*fetchpriority="high"/
+  );
+  assert.match(home, /<header class="site-header">[\s\S]*<nav class="site-nav"/);
+  assert.doesNotMatch(home, /<header[^>]+data-include="header"/);
+  const inlineHeader = home.match(/<header class="site-header">([\s\S]*?)<\/header>/)?.[1];
+  assert.ok(inlineHeader);
+  assert.deepEqual(extractHrefs(inlineHeader), extractHrefs(headerPartial));
+  assert.match(refrainCss, /--refrain-min-h:\s*7\.75rem/);
+  assert.match(zineCss, /\.punk-section,[\s\S]*content-visibility:\s*auto/);
+});
+
+function extractHrefs(source) {
+  return [...source.matchAll(/href="([^"]+)"/g)].map((match) => match[1]);
+}
 
 async function runChecker(pages) {
   const fixtureRoot = await mkdtemp(path.join(tmpdir(), "punk-rock-ai-index-hygiene-"));


### PR DESCRIPTION
## Summary

- pre-render the homepage header so the primary navigation no longer expands from 82px to 272px after a network fetch
- reserve a measured layout for every daily-refrain quote at 320px and wider
- preload the hero photo with high priority
- defer the four large below-fold section backgrounds until their sections approach the viewport
- guard the critical rendering policy and keep all 46 inline header links synchronized with the shared partial

## Production baseline

Three mobile Lighthouse 13.4.0 runs on https://www.punkrockai.com/:
- Performance: 77 / 72 / 70, median 72
- LCP: 5.160s / 3.236s / 5.291s, median 5.160s
- CLS: 0 / 0.481 / 0
- Initial transfer: about 4.26MB
- Initial requests: 52 / 52 / 57

A throttled trace reproduced two independent shifts: the fetched header moved main content 190px, then the fetched refrain moved the hero another 20px.

## Candidate evidence

Local browser verification:
- CLS: 0
- Initial transfer: 1.43MB
- Initial requests: 39
- no overflow at 320px, 412px, or 1440px
- all 19 rotating quotes fit without clipping
- deferred slide backgrounds remain absent above the fold and load when scrolled into view
- mobile and desktop visual review passed

The Vercel preview remains the LCP decision gate because the generic local HTTP/1 server produces an invalid simulated LCP estimate for this many-resource static page.

## Verification

- npm run check
- all project evals passed
- 154 maintained and archived documentation files passed link audit
- 6 index-hygiene tests passed
- 14 agentic tests passed
- Python compile check passed
- npm audit: 0 vulnerabilities
- local Lighthouse accessibility 100 and SEO 100

No content, canonical, structured-data, analytics, sitemap, or routing behavior changed.