### PR TITLE
perf: make Punk Rock AI mobile hero immediately paintable

### DIFF
--- a/site/css/zine-overhaul.css
+++ b/site/css/zine-overhaul.css
@@ -453,3 +453,19 @@
 .hero--photo:hover .hero__photo-layer {
   filter: brightness(1.0) saturate(1.0);
 }
+
+@media (max-width: 720px) {
+  .hero__photo-layer,
+  .hero__slide-layer,
+  .hero__date,
+  .hero__title span:nth-child(1),
+  .hero__title span:nth-child(2),
+  .hero__title span:nth-child(3),
+  .hero__title em,
+  .hero__lede,
+  .hero__cta,
+  .btn.punk-shadow-pink {
+    animation: none;
+    will-change: auto;
+  }
+}

--- a/tests/index-hygiene.test.mjs
+++ b/tests/index-hygiene.test.mjs
@@ -93,6 +93,10 @@ test("keeps the homepage critical rendering path stable", () => {
   assert.deepEqual(extractHrefs(inlineHeader), extractHrefs(headerPartial));
   assert.match(refrainCss, /--refrain-min-h:\s*7\.75rem/);
   assert.match(zineCss, /\.punk-section,[\s\S]*content-visibility:\s*auto/);
+  assert.match(
+    zineCss,
+    /@media \(max-width: 720px\)[\s\S]*\.hero__photo-layer,[\s\S]*animation:\s*none/
+  );
 });
 
 function extractHrefs(source) {


### PR DESCRIPTION
## Summary

- disable autonomous hero entrance, ambient, and glow animations at mobile widths
- preserve the full desktop animation system
- extend the critical-rendering regression policy

## Why

Production follow-through on #174 confirmed the intended wins:
- CLS became 0 in all three Lighthouse runs
- initial transfer fell from about 4.26MB to 1.43MB
- initial requests fell from 52 to 39

The same benchmark also exposed a mobile paint delay. Lighthouse simulated LCP increased from a 5.160s baseline median to 6.912s even though real observed LCP remained approximately 2.28s. A throttled PerformanceObserver trace showed the animated title becoming the final LCP candidate at 3.256s.

## Candidate evidence

Under the same throttled mobile profile:
- current production final LCP candidate: 3.256s
- candidate final LCP candidate: 0.624s
- candidate autonomous hero animations: 0
- desktop hero animations retained: 10
- mobile and desktop visual review passed
- no horizontal overflow

## Verification

- npm run check
- all project evals passed
- 154-file documentation link audit passed
- 6 index-hygiene tests passed
- 14 agentic tests passed
- Python compile check passed
- npm audit: 0 vulnerabilities
- Lighthouse accessibility 100 and SEO 100

No content, layout, canonical, analytics, sitemap, routing, or desktop motion behavior changed.