### PR TITLE
fix(seo): correct Both Hands Full entity link

### DIFF
--- a/scripts/eval.mjs
+++ b/scripts/eval.mjs
@@ -158,6 +158,7 @@ function checkHomepageSeoGeoMetadata() {
   const file = "site/index.html";
   const source = readFileSync(abs(file), "utf8");
   const canonicalUrl = "https://www.punkrockai.com/";
+  const bothHandsFullUrl = "https://www.bothhandsfull.com/";
 
   if (!source.includes(`<link rel="canonical" href="${canonicalUrl}" />`)) {
     failures.push(`${file}: homepage canonical must be ${canonicalUrl}`);
@@ -197,7 +198,7 @@ function checkHomepageSeoGeoMetadata() {
       if (person?.name !== "Kris Krüg") {
         failures.push(`${file}: Person JSON-LD must name Kris Krüg`);
       }
-      if (!person?.sameAs?.includes("https://bothhandsfull.ai/")) {
+      if (!person?.sameAs?.includes(bothHandsFullUrl)) {
         failures.push(`${file}: Person JSON-LD must connect Both Hands Full`);
       }
       if (work?.url !== canonicalUrl || work?.creator?.["@id"] !== person?.["@id"]) {
@@ -211,6 +212,9 @@ function checkHomepageSeoGeoMetadata() {
       failures.push(`${file}: visible homepage copy must include ${text}`);
     }
   }
+  if (!source.includes(`href="${bothHandsFullUrl}"`)) {
+    failures.push(`${file}: visible Both Hands Full link must use ${bothHandsFullUrl}`);
+  }
 
   const llmsFile = "site/llms.txt";
   if (existsSync(abs(llmsFile))) {
@@ -219,6 +223,9 @@ function checkHomepageSeoGeoMetadata() {
       if (!llms.includes(text)) {
         failures.push(`${llmsFile}: llms.txt must include ${text}`);
       }
+    }
+    if (!llms.includes(bothHandsFullUrl)) {
+      failures.push(`${llmsFile}: Both Hands Full link must use ${bothHandsFullUrl}`);
     }
   }
 }

--- a/site/index.html
+++ b/site/index.html
@@ -43,7 +43,7 @@
             "name": "Kris Krüg",
             "url": "https://kriskrug.co/",
             "sameAs": [
-              "https://bothhandsfull.ai/",
+              "https://www.bothhandsfull.com/",
               "https://bc-ai.ca/",
               "https://www.punkrockai.com/"
             ],
@@ -292,7 +292,7 @@
           <p>
             Punk Rock AI is Kris Kr&uuml;g&rsquo;s CreativeMornings Vancouver keynote
             portal and a public workshop layer from the
-            <a href="https://bothhandsfull.ai/">Both Hands Full</a> practice:
+            <a href="https://www.bothhandsfull.com/">Both Hands Full</a> practice:
             critique in one hand, capability in the other. The site gathers the
             talk, recap, photos, field course, and widgets so people can cite
             the work and use it without flattening AI into hype or panic.

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -4,7 +4,7 @@ Punk Rock AI is Kris Krug's CreativeMornings Vancouver keynote portal about hold
 
 Canonical site: https://www.punkrockai.com/
 Creator: Kris Krug
-Related practice: Both Hands Full, https://bothhandsfull.ai/
+Related practice: Both Hands Full, https://www.bothhandsfull.com/
 
 Primary pages:
 - Homepage: https://www.punkrockai.com/


### PR DESCRIPTION
## Summary

- Replace the retired `bothhandsfull.ai` relationship URL with the canonical `https://www.bothhandsfull.com/` homepage in visible copy, JSON-LD, and `llms.txt`.
- Add eval assertions so the stale relationship cannot return unnoticed.
- Refs #159 without closing the broader structured-data validation issue.

## Verification

- [x] `npm run eval` (all checks passed)
- [x] `npm run test:index-hygiene` (6/6 passed)
- [x] `git diff --check`
- [x] Public `.com` homepage resolves and identifies itself canonically; the retired `.ai` hostname does not resolve.

## Acceptance self-check

- [x] The visible relationship points to the canonical entity homepage.
- [x] Person `sameAs` points to the same canonical homepage.
- [x] `llms.txt` carries the canonical relationship.
- [x] Eval coverage rejects the retired hostname.

## Agentic Delivery
- [x] Linked with `Closes #...` only when every acceptance criterion is met
- [x] Acceptance self-check included when opened by an agent
- [x] Diff is within 20 files / 500 changed lines, or human approval is documented

Rollback: revert commit `680feb8ff889`.
